### PR TITLE
xib need to be removed from the podspec file

### DIFF
--- a/AccessCheckoutSDK.podspec
+++ b/AccessCheckoutSDK.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.author       = 'Access Worldpay'
 
   spec.source       = { :git => "https://github.com/Worldpay/access-checkout-ios.git", :tag => "v1.2.1" }
-  spec.source_files = 'AccessCheckoutSDK/AccessCheckoutSDK/**/*.{h,swift,xib,strings}'
+  spec.source_files = 'AccessCheckoutSDK/AccessCheckoutSDK/**/*.{h,swift,strings}'
   spec.public_header_files = 'AccessCheckoutSDK/AccessCheckoutSDK/AccessCheckoutSDK.h'
   spec.resources    = 'AccessCheckoutSDK/AccessCheckoutSDK/**/*.{json,png}'
 end


### PR DESCRIPTION
xib need to be removed from the podspec file otherwise we won't be able to use it in our React-native xcode project.