### PR TITLE
US515575: Update devices used to run tests for iOS 11 & iOS 12

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -71,8 +71,8 @@ workflows:
     - virtual-device-testing-for-ios:
         inputs:
         - test_devices: |-
-            iphonex,11.4,en,portrait
-            iphonexs,12.0,en,portrait
+            iphone8,11.4,en,portrait
+            iphone8,12.4,en,portrait
     - script:
         inputs:
         - content: |-


### PR DESCRIPTION
This is necessary because Firebase deprecates devices+iOS combinations from time to time
- see here for deprecated devices (displayed for a month before removing devices): https://firebase.google.com/docs/test-lab/ios/available-testing-devices
- see here for available devices (is not necessarily up to date as BitRise team struggles to keep it up to date): https://github.com/bitrise-steplib/steps-virtual-device-testing-for-ios/blob/master/step.yml