### PR TITLE
US786385: fix for an issue which causes ReactNative to fail to retrie…

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/PanViewPresenter.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/PanViewPresenter.swift
@@ -124,6 +124,7 @@ extension PanViewPresenter: UITextFieldDelegate {
             }
 
             setCaretPosition(textField, newCaretPosition)
+            textField.sendActions(for: UIControl.Event.editingChanged)
             onEditEnd()
         } else {
             setCaretPosition(textField, range.location)


### PR DESCRIPTION
…ve the value of the PAN field despite the field having a PAN entered by the user

- this issue was due to the fact that the Access Checkout iOS SDK did not raise an .editingChanged event when it reformatted the text in the PAN field