### PR TITLE
US1515333: change version of iOS used for running virtual tests as version is now unsupported

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,7 +49,7 @@ workflows:
     - virtual-device-testing-for-ios:
         inputs:
         - test_devices: |-
-            iphone8,12.4,en,portrait
+            iphone8,16.3,en,portrait
         - test_timeout: 13500
     - script:
         title: "Add version number to env variables"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,8 +49,8 @@ workflows:
     - virtual-device-testing-for-ios:
         inputs:
         - test_devices: |-
-            iphone8,16.3,en,portrait
-        - test_timeout: 13500
+            iphone8,15.7,en,portrait
+        - test_timeout: 2700
     - script:
         title: "Add version number to env variables"
         inputs:


### PR DESCRIPTION
Change iOS version used for unit tests to keep in line with more recent versions of iOS