### PR TITLE
Us1700895 add new component and support for validation feature

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
@@ -23,7 +23,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uOE-eK-LJK" userLabel="Pan" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="81" width="327" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan"/>
+                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Olc-Mj-W5U"/>
                                 </constraints>
@@ -31,6 +33,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ts8-Kj-GhN" userLabel="Expiry date" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="145" width="64" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="64" id="1K6-wM-DAF"/>
                                     <constraint firstAttribute="height" constant="44" id="Ute-5x-z9t"/>
@@ -39,6 +44,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4Q-yr-qYy" userLabel="Cvc" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="103" y="145" width="62" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="expiryDate" label="Expiry Date">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                             </view>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="V3W-HP-wPE">
                                 <rect key="frame" x="294" y="221" width="51" height="31"/>
@@ -190,7 +198,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cXc-DJ-Q7s" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="81" width="327" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan"/>
+                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iUX-jl-sEW">
                                 <rect key="frame" x="283" y="84" width="57" height="38"/>
@@ -276,7 +286,9 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rhF-MI-5Qs" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="81" width="97" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc"/>
+                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="97" id="gId-03-C4E"/>
                                 </constraints>

--- a/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0kh-GD-3gP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0kh-GD-3gP">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,6 +20,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uOE-eK-LJK" userLabel="Pan" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
+                                <rect key="frame" x="16" y="81" width="327" height="44"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="Olc-Mj-W5U"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ts8-Kj-GhN" userLabel="Expiry date" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
+                                <rect key="frame" x="16" y="145" width="64" height="44"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="64" id="1K6-wM-DAF"/>
+                                    <constraint firstAttribute="height" constant="44" id="Ute-5x-z9t"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4Q-yr-qYy" userLabel="Cvc" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
+                                <rect key="frame" x="103" y="145" width="62" height="44"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="V3W-HP-wPE">
                                 <rect key="frame" x="294" y="221" width="51" height="31"/>
                                 <accessibility key="accessibilityConfiguration" identifier="paymentsCvcSessionToggle"/>
@@ -34,42 +54,14 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PSJ-iT-v62">
-                                <rect key="frame" x="294" y="282" width="49" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PSJ-iT-v62">
+                                <rect key="frame" x="16" y="282" width="49" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="submit"/>
                                 <state key="normal" title="Submit"/>
                                 <connections>
                                     <action selector="submit:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ex7-Xf-fix"/>
                                 </connections>
                             </button>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8AE-e7-b1R">
-                                <rect key="frame" x="103" y="145" width="62" height="44"/>
-                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="cvc"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="62" id="T9O-hC-CAg"/>
-                                </constraints>
-                                <color key="textColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Mya-3f-hK8">
-                                <rect key="frame" x="16" y="81" width="327" height="44"/>
-                                <accessibility key="accessibilityConfiguration" identifier="pan" label="pan"/>
-                                <color key="textColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a8i-GI-0zO">
-                                <rect key="frame" x="16" y="145" width="64" height="44"/>
-                                <accessibility key="accessibilityConfiguration" identifier="expiryDate" label="Expiry Date"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="64" id="6EM-ft-nNk"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="qzS-NE-0Wd"/>
-                                    <constraint firstAttribute="height" constant="44" id="znX-4L-e4b"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            </textField>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4gy-2k-boW">
                                 <rect key="frame" x="283" y="84" width="57" height="38"/>
                                 <accessibility key="accessibilityConfiguration" identifier="cardBrandImage" label="card brand image"/>
@@ -85,8 +77,8 @@
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="NXi-qk-FE5">
-                                <rect key="frame" x="266" y="287" width="20" height="20"/>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="NXi-qk-FE5">
+                                <rect key="frame" x="-12" y="287" width="20" height="20"/>
                             </activityIndicatorView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="panIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MXa-G9-0FX">
                                 <rect key="frame" x="16" y="0.0" width="119" height="21"/>
@@ -96,24 +88,22 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="expiryDateIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMM-PP-5OM">
-                                <rect key="frame" x="16" y="20" width="173" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="expiryDateIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMM-PP-5OM">
+                                <rect key="frame" x="16" y="20" width="172" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="expiryDateIsValidLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="cvcIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NxL-IN-v4K">
-                                <rect key="frame" x="16" y="41" width="118" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="cvcIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NxL-IN-v4K">
+                                <rect key="frame" x="16" y="41" width="117" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="cvcIsValidLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FGh-S7-760">
-                                <rect key="frame" x="16" y="343" width="185" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FGh-S7-760">
+                                <rect key="frame" x="16" y="332" width="185" height="30"/>
                                 <accessibility key="accessibilityConfiguration" label="setPanCaretPositionButton"/>
                                 <state key="normal" title="setPanCaretPositionButton"/>
                                 <connections>
@@ -137,44 +127,43 @@
                         </subviews>
                         <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="baseline" secondItem="a8i-GI-0zO" secondAttribute="baseline" id="1fh-PR-Gif"/>
                             <constraint firstItem="NXi-qk-FE5" firstAttribute="top" secondItem="UzK-5d-eEZ" secondAttribute="bottom" constant="21" id="3R3-7x-qZ8"/>
                             <constraint firstItem="FGh-S7-760" firstAttribute="top" secondItem="PSJ-iT-v62" secondAttribute="bottom" constant="20" id="3eT-E1-LWY"/>
-                            <constraint firstItem="Mya-3f-hK8" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="4Wo-Jr-MTY"/>
-                            <constraint firstItem="a8i-GI-0zO" firstAttribute="top" secondItem="Mya-3f-hK8" secondAttribute="bottom" constant="20" id="65D-Ef-7g9"/>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="firstBaseline" secondItem="a8i-GI-0zO" secondAttribute="baseline" id="6Mp-Cb-ydu"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="top" secondItem="A4Q-yr-qYy" secondAttribute="top" id="5Cc-Zm-iER"/>
+                            <constraint firstItem="uOE-eK-LJK" firstAttribute="trailing" secondItem="V3W-HP-wPE" secondAttribute="trailing" id="7Uy-EY-dpW"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="leading" secondItem="gxk-b1-dMa" secondAttribute="leading" id="D1W-nh-hHQ"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="leading" secondItem="NxL-IN-v4K" secondAttribute="leading" id="Ddn-oh-qOo"/>
                             <constraint firstItem="PSJ-iT-v62" firstAttribute="leading" secondItem="NXi-qk-FE5" secondAttribute="trailing" constant="8" id="Ec7-e5-MQQ"/>
-                            <constraint firstItem="gxk-b1-dMa" firstAttribute="leading" secondItem="a8i-GI-0zO" secondAttribute="leading" id="HGC-2s-NEA"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="top" secondItem="uOE-eK-LJK" secondAttribute="bottom" constant="20" id="ExN-ri-CWS"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="bottom" secondItem="A4Q-yr-qYy" secondAttribute="bottom" id="HeA-VK-iPK"/>
                             <constraint firstItem="4gy-2k-boW" firstAttribute="top" secondItem="hy8-fq-jdj" secondAttribute="bottom" constant="84" id="J9X-kf-fAJ"/>
-                            <constraint firstItem="Mya-3f-hK8" firstAttribute="top" secondItem="hy8-fq-jdj" secondAttribute="bottom" constant="81" id="N9a-eQ-gxn"/>
+                            <constraint firstItem="uOE-eK-LJK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="JNk-u6-HOu"/>
+                            <constraint firstItem="A4Q-yr-qYy" firstAttribute="leading" secondItem="ts8-Kj-GhN" secondAttribute="trailing" constant="23" id="Nhx-HB-abn"/>
                             <constraint firstItem="FGh-S7-760" firstAttribute="leading" secondItem="PSJ-iT-v62" secondAttribute="leading" id="Nwd-J1-PvZ"/>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="top" secondItem="a8i-GI-0zO" secondAttribute="top" id="Obz-wv-4Uc"/>
-                            <constraint firstItem="Mya-3f-hK8" firstAttribute="leading" secondItem="a8i-GI-0zO" secondAttribute="leading" id="PHs-7U-Qyf"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="leading" secondItem="uOE-eK-LJK" secondAttribute="leading" id="Tct-QG-Q6u"/>
                             <constraint firstItem="NXi-qk-FE5" firstAttribute="centerY" secondItem="PSJ-iT-v62" secondAttribute="centerY" id="Wb7-Z0-DXa"/>
-                            <constraint firstItem="Mya-3f-hK8" firstAttribute="trailing" secondItem="V3W-HP-wPE" secondAttribute="trailing" id="XQ4-Wj-5tw"/>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="bottom" secondItem="a8i-GI-0zO" secondAttribute="bottom" id="YAA-AS-D9n"/>
                             <constraint firstItem="gxk-b1-dMa" firstAttribute="centerY" secondItem="V3W-HP-wPE" secondAttribute="centerY" id="YOD-hy-WxO"/>
                             <constraint firstItem="gxk-b1-dMa" firstAttribute="leading" secondItem="UzK-5d-eEZ" secondAttribute="leading" id="aIa-0m-NUn"/>
                             <constraint firstAttribute="trailingMargin" secondItem="4gy-2k-boW" secondAttribute="trailing" constant="19" id="bQl-87-Tli"/>
                             <constraint firstItem="UzK-5d-eEZ" firstAttribute="top" secondItem="gxk-b1-dMa" secondAttribute="bottom" constant="8" id="chq-il-XVd"/>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="leading" secondItem="a8i-GI-0zO" secondAttribute="trailing" constant="23" id="d4P-3N-Epg"/>
-                            <constraint firstItem="V3W-HP-wPE" firstAttribute="top" secondItem="Mya-3f-hK8" secondAttribute="bottom" constant="96" id="g9c-2p-ZIo"/>
-                            <constraint firstItem="V3W-HP-wPE" firstAttribute="leading" secondItem="PSJ-iT-v62" secondAttribute="leading" id="lY1-Hn-FII"/>
-                            <constraint firstItem="8AE-e7-b1R" firstAttribute="baseline" secondItem="a8i-GI-0zO" secondAttribute="firstBaseline" id="ln5-sL-V1h"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Mya-3f-hK8" secondAttribute="trailing" constant="16" id="yeE-Ox-lHE"/>
-                            <constraint firstItem="Mya-3f-hK8" firstAttribute="centerY" secondItem="4gy-2k-boW" secondAttribute="centerY" id="zTy-uV-Q3K"/>
+                            <constraint firstItem="uOE-eK-LJK" firstAttribute="centerY" secondItem="4gy-2k-boW" secondAttribute="centerY" id="gav-x2-6nM"/>
+                            <constraint firstItem="ts8-Kj-GhN" firstAttribute="leading" secondItem="FMM-PP-5OM" secondAttribute="leading" id="ixK-6Z-DA2"/>
+                            <constraint firstAttribute="trailing" secondItem="A4Q-yr-qYy" secondAttribute="trailing" constant="210" id="jnm-R8-NOg"/>
+                            <constraint firstItem="uOE-eK-LJK" firstAttribute="top" secondItem="hy8-fq-jdj" secondAttribute="bottom" constant="81" id="js5-A8-eow"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="uOE-eK-LJK" secondAttribute="trailing" constant="16" id="noD-9L-4qa"/>
+                            <constraint firstItem="gxk-b1-dMa" firstAttribute="top" secondItem="ts8-Kj-GhN" secondAttribute="bottom" constant="38" id="wQt-85-33g"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Card Flow" image="creditcard" catalog="system" id="m9y-Ux-VVN"/>
                     <connections>
                         <outlet property="cvcIsValidLabel" destination="NxL-IN-v4K" id="3xq-OV-BPX"/>
-                        <outlet property="cvcTextField" destination="8AE-e7-b1R" id="Dyk-Q4-XIZ"/>
+                        <outlet property="cvcTextField" destination="A4Q-yr-qYy" id="pGg-lZ-5MU"/>
                         <outlet property="expiryDateIsValidLabel" destination="FMM-PP-5OM" id="EKv-Pa-JkQ"/>
-                        <outlet property="expiryDateTextField" destination="a8i-GI-0zO" id="ctL-po-sv5"/>
+                        <outlet property="expiryDateTextField" destination="ts8-Kj-GhN" id="g2q-k2-Uxk"/>
                         <outlet property="getPanCaretPositionTextField" destination="uCP-BC-ifY" id="tZd-4h-DAb"/>
                         <outlet property="imageView" destination="4gy-2k-boW" id="RJe-7W-H1o"/>
                         <outlet property="panIsValidLabel" destination="MXa-G9-0FX" id="vI4-fM-Idp"/>
-                        <outlet property="panTextField" destination="Mya-3f-hK8" id="CtN-ZL-0db"/>
+                        <outlet property="panTextField" destination="uOE-eK-LJK" id="ElA-Kn-zDb"/>
                         <outlet property="paymentsCvcSessionToggle" destination="V3W-HP-wPE" id="EPo-AH-AJP"/>
                         <outlet property="setPanCaretPositionButton" destination="FGh-S7-760" id="lNp-HZ-ymz"/>
                         <outlet property="setPanCaretPositionTextField" destination="gdc-Jc-Nb3" id="JQh-qT-u79"/>
@@ -198,13 +187,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DT4-6e-hWq">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cXc-DJ-Q7s" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="81" width="327" height="44"/>
-                                <accessibility key="accessibilityConfiguration" identifier="pan" label="pan"/>
-                                <color key="textColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            </textField>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="pan" label="Pan"/>
+                            </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iUX-jl-sEW">
                                 <rect key="frame" x="283" y="84" width="57" height="38"/>
                                 <accessibility key="accessibilityConfiguration" identifier="cardBrandImage" label="card brand image"/>
@@ -213,8 +200,8 @@
                                     <constraint firstAttribute="height" constant="38" id="abL-ww-6yu"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Supported Card Brands: Visa, Mastercard &amp; Amex" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dTi-zG-nFA">
-                                <rect key="frame" x="56" y="135" width="262" height="14"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Supported Card Brands: Visa, Mastercard &amp; Amex" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dTi-zG-nFA">
+                                <rect key="frame" x="20" y="135" width="261.5" height="14"/>
                                 <accessibility key="accessibilityConfiguration" identifier="restrictedCardBrandsLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <nil key="textColor"/>
@@ -231,22 +218,22 @@
                         </subviews>
                         <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="cXc-DJ-Q7s" firstAttribute="centerY" secondItem="iUX-jl-sEW" secondAttribute="centerY" id="2E3-Zy-H8a"/>
                             <constraint firstAttribute="trailingMargin" secondItem="iUX-jl-sEW" secondAttribute="trailing" constant="19" id="6Xp-p5-ilF"/>
+                            <constraint firstItem="dTi-zG-nFA" firstAttribute="top" secondItem="cXc-DJ-Q7s" secondAttribute="bottom" constant="10" id="IKl-TO-cu3"/>
+                            <constraint firstItem="cXc-DJ-Q7s" firstAttribute="top" secondItem="SLT-ku-F2z" secondAttribute="bottom" constant="81" id="JfK-5R-HwU"/>
                             <constraint firstItem="iUX-jl-sEW" firstAttribute="top" secondItem="SLT-ku-F2z" secondAttribute="bottom" constant="84" id="NV3-UH-05j"/>
-                            <constraint firstItem="DT4-6e-hWq" firstAttribute="centerY" secondItem="iUX-jl-sEW" secondAttribute="centerY" id="OmC-1X-wmX"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="DT4-6e-hWq" secondAttribute="trailing" constant="16" id="Thb-hN-Sgd"/>
-                            <constraint firstItem="dTi-zG-nFA" firstAttribute="centerX" secondItem="Zvz-kn-Pea" secondAttribute="centerX" id="UL5-Ex-MmA"/>
-                            <constraint firstItem="DT4-6e-hWq" firstAttribute="top" secondItem="SLT-ku-F2z" secondAttribute="bottom" constant="81" id="l1Q-8I-sar"/>
-                            <constraint firstItem="dTi-zG-nFA" firstAttribute="top" secondItem="DT4-6e-hWq" secondAttribute="bottom" constant="10" id="ndM-4W-0zD"/>
-                            <constraint firstItem="DT4-6e-hWq" firstAttribute="leading" secondItem="Zvz-kn-Pea" secondAttribute="leadingMargin" id="ufL-Hu-yUV"/>
-                            <constraint firstItem="dTi-zG-nFA" firstAttribute="leading" secondItem="Zvz-kn-Pea" secondAttribute="leadingMargin" constant="40" id="zx8-Mh-4X2"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="cXc-DJ-Q7s" secondAttribute="trailing" constant="16" id="cRA-jE-7WA"/>
+                            <constraint firstItem="iUX-jl-sEW" firstAttribute="leading" secondItem="Zvz-kn-Pea" secondAttribute="trailing" constant="-92" id="nKU-GJ-Rvf"/>
+                            <constraint firstItem="cXc-DJ-Q7s" firstAttribute="leading" secondItem="Zvz-kn-Pea" secondAttribute="leadingMargin" id="pxW-8y-8a7"/>
+                            <constraint firstItem="dTi-zG-nFA" firstAttribute="leading" secondItem="Zvz-kn-Pea" secondAttribute="leadingMargin" constant="4" id="zx8-Mh-4X2"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Restricted Card Flow" image="creditcard" catalog="system" id="1Zs-RC-hnU"/>
                     <connections>
                         <outlet property="imageView" destination="iUX-jl-sEW" id="9lP-kL-PiX"/>
                         <outlet property="panIsValidLabel" destination="DcK-R3-jK5" id="3be-3n-4XV"/>
-                        <outlet property="panTextField" destination="DT4-6e-hWq" id="95m-NU-26K"/>
+                        <outlet property="panTextField" destination="cXc-DJ-Q7s" id="VN1-U0-875"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dfJ-C5-324" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -265,15 +252,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5NE-TN-m7a">
-                                <rect key="frame" x="16" y="81" width="97" height="44"/>
-                                <accessibility key="accessibilityConfiguration" hint="123" identifier="cvc" label="cvc"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="97" id="1CT-72-q9H"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xFk-y0-dUk" userLabel="Submit Button">
                                 <rect key="frame" x="291" y="88" width="49" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="submit">
@@ -295,22 +273,30 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rhF-MI-5Qs" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
+                                <rect key="frame" x="16" y="81" width="97" height="44"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="97" id="gId-03-C4E"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="xFk-y0-dUk" firstAttribute="top" secondItem="og0-0P-fDP" secondAttribute="bottom" constant="88" id="11c-aF-4Tw"/>
-                            <constraint firstItem="5NE-TN-m7a" firstAttribute="centerY" secondItem="tjE-oa-gkj" secondAttribute="centerY" id="9qW-eq-9U7"/>
+                            <constraint firstItem="rhF-MI-5Qs" firstAttribute="top" secondItem="og0-0P-fDP" secondAttribute="bottom" constant="81" id="1D2-5j-3Fz"/>
+                            <constraint firstItem="rhF-MI-5Qs" firstAttribute="leading" secondItem="y9R-az-JC0" secondAttribute="leadingMargin" id="6A4-u4-x9e"/>
                             <constraint firstItem="xFk-y0-dUk" firstAttribute="leading" secondItem="tjE-oa-gkj" secondAttribute="trailing" constant="4" id="Ha2-JX-7UP"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xFk-y0-dUk" secondAttribute="trailing" constant="19" id="cOE-Ap-r6F"/>
-                            <constraint firstItem="5NE-TN-m7a" firstAttribute="leading" secondItem="y9R-az-JC0" secondAttribute="leadingMargin" id="hPa-Go-lQS"/>
                             <constraint firstItem="tjE-oa-gkj" firstAttribute="centerY" secondItem="xFk-y0-dUk" secondAttribute="centerY" id="iQK-kr-5dS"/>
-                            <constraint firstItem="5NE-TN-m7a" firstAttribute="top" secondItem="og0-0P-fDP" secondAttribute="bottom" constant="81" id="jg7-zw-0Ve"/>
+                            <constraint firstItem="rhF-MI-5Qs" firstAttribute="centerY" secondItem="tjE-oa-gkj" secondAttribute="centerY" id="sEV-tb-E0U"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="CVC Flow" image="macwindow" catalog="system" id="YRb-wv-5YY"/>
                     <connections>
                         <outlet property="cvcIsValidLabel" destination="rhE-RM-1YK" id="8VX-Tu-dTh"/>
-                        <outlet property="cvcTextField" destination="5NE-TN-m7a" id="urH-5K-lPD"/>
+                        <outlet property="cvcTextField" destination="rhF-MI-5Qs" id="KuL-TK-MNQ"/>
                         <outlet property="spinner" destination="tjE-oa-gkj" id="Uk1-0u-3Vf"/>
                         <outlet property="submitButton" destination="xFk-y0-dUk" id="Dty-Nd-Jvt"/>
                     </connections>

--- a/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Base.lproj/Main.storyboard
@@ -33,7 +33,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ts8-Kj-GhN" userLabel="Expiry date" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="16" y="145" width="64" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc">
+                                <accessibility key="accessibilityConfiguration" identifier="expiryDate" label="Expiry date">
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
                                 <constraints>
@@ -44,7 +44,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A4Q-yr-qYy" userLabel="Cvc" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK">
                                 <rect key="frame" x="103" y="145" width="62" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <accessibility key="accessibilityConfiguration" identifier="expiryDate" label="Expiry Date">
+                                <accessibility key="accessibilityConfiguration" identifier="cvc" label="Cvc">
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
                             </view>
@@ -96,15 +96,17 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="expiryDateIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMM-PP-5OM">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="expiryDateIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FMM-PP-5OM">
                                 <rect key="frame" x="16" y="20" width="172" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" identifier="expiryDateIsValidLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="cvcIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NxL-IN-v4K">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="cvcIsValidLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NxL-IN-v4K">
                                 <rect key="frame" x="16" y="41" width="117" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" identifier="cvcIsValidLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -2,9 +2,9 @@ import AccessCheckoutSDK
 import UIKit
 
 class CardFlowViewController: UIViewController {
-    @IBOutlet weak var panTextField: UITextField!
-    @IBOutlet weak var expiryDateTextField: UITextField!
-    @IBOutlet weak var cvcTextField: UITextField!
+    @IBOutlet weak var panTextField: AccessCheckoutUITextField!
+    @IBOutlet weak var expiryDateTextField: AccessCheckoutUITextField!
+    @IBOutlet weak var cvcTextField: AccessCheckoutUITextField!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var submitButton: UIButton!
     @IBOutlet weak var spinner: UIActivityIndicatorView!
@@ -21,9 +21,9 @@ class CardFlowViewController: UIViewController {
     private let unknownBrandImage = UIImage(named: "card_unknown")
 
     @IBAction func submit(_ sender: Any) {
-        submitCard(pan: panTextField.text ?? "",
-                   expiryDate: expiryDateTextField.text ?? "",
-                   cvc: (cvcTextField.text ?? "") as String)
+//        submitCard(pan: panTextField.text ?? "",
+//                   expiryDate: expiryDateTextField.text ?? "",
+//                   cvc: (cvcTextField.text ?? "") as String)
     }
 
     @IBAction func getPanCaret(_ sender: Any) {
@@ -57,66 +57,69 @@ class CardFlowViewController: UIViewController {
         panTextField.selectedTextRange = panTextField.textRange(from: caretPositionFrom, to: caretPositionTo)
     }
 
-    private func submitCard(pan: String, expiryDate: String, cvc: String) {
+    private func submitCard(pan: AccessCheckoutUITextField, expiryDate: AccessCheckoutUITextField, cvc: AccessCheckoutUITextField) {
         spinner.startAnimating()
 
         let sessionTypes: Set<SessionType> = paymentsCvcSessionToggle.isOn ? [SessionType.card, SessionType.cvc] : [SessionType.card]
 
-        let cardDetails = try! CardDetailsBuilder().pan(pan)
-            .expiryDate(expiryDate)
-            .cvc(cvc)
-            .build()
-
-        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
-            .merchantId(Configuration.merchantId)
-            .build()
-
-        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: sessionTypes) { result in
-            DispatchQueue.main.async {
-                self.spinner.stopAnimating()
-
-                switch result {
-                case .success(let sessions):
-                    var titleToDisplay: String, messageToDisplay: String
-
-                    if sessionTypes.count > 1 {
-                        titleToDisplay = "Verified Tokens & Payments CVC Sessions"
-                        messageToDisplay = """
-                        \(sessions[SessionType.card]!)
-                        \(sessions[SessionType.cvc]!)
-                        """
-                    } else {
-                        titleToDisplay = "Verified Tokens Session"
-                        messageToDisplay = "\(sessions[SessionType.card]!)"
-                    }
-
-                    AlertView.display(using: self, title: titleToDisplay, message: messageToDisplay, closeHandler: {
-                        self.resetCard(preserveContent: false, validationErrors: nil)
-                    })
-                case .failure(let error):
-                    let title = error.localizedDescription
-                    var accessCheckoutClientValidationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?
-                    if error.message.contains("bodyDoesNotMatchSchema") {
-                        accessCheckoutClientValidationErrors = error.validationErrors
-                    }
-
-                    AlertView.display(using: self, title: title, message: nil, closeHandler: {
-                        self.resetCard(preserveContent: true, validationErrors: accessCheckoutClientValidationErrors)
-                    })
-                }
-            }
-        }
+//        let cardDetails = try! CardDetailsBuilder().pan(pan)
+//            .expiryDate(expiryDate)
+//            .cvc(cvc)
+//            .build()
+//
+//        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
+//            .merchantId(Configuration.merchantId)
+//            .build()
+//
+//        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: sessionTypes) { result in
+//            DispatchQueue.main.async {
+//                self.spinner.stopAnimating()
+//
+//                switch result {
+//                case .success(let sessions):
+//                    var titleToDisplay: String, messageToDisplay: String
+//
+//                    if sessionTypes.count > 1 {
+//                        titleToDisplay = "Verified Tokens & Payments CVC Sessions"
+//                        messageToDisplay = """
+//                        \(sessions[SessionType.card]!)
+//                        \(sessions[SessionType.cvc]!)
+//                        """
+//                    } else {
+//                        titleToDisplay = "Verified Tokens Session"
+//                        messageToDisplay = "\(sessions[SessionType.card]!)"
+//                    }
+//
+//                    AlertView.display(using: self, title: titleToDisplay, message: messageToDisplay, closeHandler: {
+//                        self.resetCard(preserveContent: false, validationErrors: nil)
+//                    })
+//                case .failure(let error):
+//                    let title = error.localizedDescription
+//                    var accessCheckoutClientValidationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?
+//                    if error.message.contains("bodyDoesNotMatchSchema") {
+//                        accessCheckoutClientValidationErrors = error.validationErrors
+//                    }
+//
+//                    AlertView.display(using: self, title: title, message: nil, closeHandler: {
+//                        self.resetCard(preserveContent: true, validationErrors: accessCheckoutClientValidationErrors)
+//                    })
+//                }
+//            }
+//        }
     }
 
     private func resetCard(preserveContent: Bool, validationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?) {
         if !preserveContent {
-            panTextField.text = ""
+//            panTextField.text = ""
+            panTextField.clear()
             panTextField.sendActions(for: .editingChanged)
-
-            expiryDateTextField.text = ""
+            
+//            expiryDateTextField.text = ""
+            expiryDateTextField.clear()
             expiryDateTextField.sendActions(for: .editingChanged)
 
-            cvcTextField.text = ""
+//            cvcTextField.text = ""
+            cvcTextField.clear()
             cvcTextField.sendActions(for: .editingChanged)
         }
 

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -2,28 +2,28 @@ import AccessCheckoutSDK
 import UIKit
 
 class CardFlowViewController: UIViewController {
-    @IBOutlet weak var panTextField: AccessCheckoutUITextField!
-    @IBOutlet weak var expiryDateTextField: AccessCheckoutUITextField!
-    @IBOutlet weak var cvcTextField: AccessCheckoutUITextField!
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var submitButton: UIButton!
-    @IBOutlet weak var spinner: UIActivityIndicatorView!
-    @IBOutlet weak var paymentsCvcSessionToggle: UISwitch!
+    @IBOutlet var panTextField: AccessCheckoutUITextField!
+    @IBOutlet var expiryDateTextField: AccessCheckoutUITextField!
+    @IBOutlet var cvcTextField: AccessCheckoutUITextField!
+    @IBOutlet var imageView: UIImageView!
+    @IBOutlet var submitButton: UIButton!
+    @IBOutlet var spinner: UIActivityIndicatorView!
+    @IBOutlet var paymentsCvcSessionToggle: UISwitch!
 
-    @IBOutlet weak var panIsValidLabel: UILabel!
-    @IBOutlet weak var expiryDateIsValidLabel: UILabel!
-    @IBOutlet weak var cvcIsValidLabel: UILabel!
+    @IBOutlet var panIsValidLabel: UILabel!
+    @IBOutlet var expiryDateIsValidLabel: UILabel!
+    @IBOutlet var cvcIsValidLabel: UILabel!
 
-    @IBOutlet weak var getPanCaretPositionTextField: UITextField!
-    @IBOutlet weak var setPanCaretPositionButton: UIButton!
-    @IBOutlet weak var setPanCaretPositionTextField: UITextField!
+    @IBOutlet var getPanCaretPositionTextField: UITextField!
+    @IBOutlet var setPanCaretPositionButton: UIButton!
+    @IBOutlet var setPanCaretPositionTextField: UITextField!
 
     private let unknownBrandImage = UIImage(named: "card_unknown")
 
     @IBAction func submit(_ sender: Any) {
-//        submitCard(pan: panTextField.text ?? "",
-//                   expiryDate: expiryDateTextField.text ?? "",
-//                   cvc: (cvcTextField.text ?? "") as String)
+        submitCard(panUITextField: panTextField,
+                   expiryDateUITextField: expiryDateTextField,
+                   cvcUITextField: cvcTextField)
     }
 
     @IBAction func getPanCaret(_ sender: Any) {
@@ -57,68 +57,68 @@ class CardFlowViewController: UIViewController {
         panTextField.selectedTextRange = panTextField.textRange(from: caretPositionFrom, to: caretPositionTo)
     }
 
-    private func submitCard(pan: AccessCheckoutUITextField, expiryDate: AccessCheckoutUITextField, cvc: AccessCheckoutUITextField) {
+    private func submitCard(panUITextField: AccessCheckoutUITextField,
+                            expiryDateUITextField: AccessCheckoutUITextField,
+                            cvcUITextField: AccessCheckoutUITextField)
+    {
         spinner.startAnimating()
 
         let sessionTypes: Set<SessionType> = paymentsCvcSessionToggle.isOn ? [SessionType.card, SessionType.cvc] : [SessionType.card]
 
-//        let cardDetails = try! CardDetailsBuilder().pan(pan)
-//            .expiryDate(expiryDate)
-//            .cvc(cvc)
-//            .build()
-//
-//        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
-//            .merchantId(Configuration.merchantId)
-//            .build()
-//
-//        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: sessionTypes) { result in
-//            DispatchQueue.main.async {
-//                self.spinner.stopAnimating()
-//
-//                switch result {
-//                case .success(let sessions):
-//                    var titleToDisplay: String, messageToDisplay: String
-//
-//                    if sessionTypes.count > 1 {
-//                        titleToDisplay = "Verified Tokens & Payments CVC Sessions"
-//                        messageToDisplay = """
-//                        \(sessions[SessionType.card]!)
-//                        \(sessions[SessionType.cvc]!)
-//                        """
-//                    } else {
-//                        titleToDisplay = "Verified Tokens Session"
-//                        messageToDisplay = "\(sessions[SessionType.card]!)"
-//                    }
-//
-//                    AlertView.display(using: self, title: titleToDisplay, message: messageToDisplay, closeHandler: {
-//                        self.resetCard(preserveContent: false, validationErrors: nil)
-//                    })
-//                case .failure(let error):
-//                    let title = error.localizedDescription
-//                    var accessCheckoutClientValidationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?
-//                    if error.message.contains("bodyDoesNotMatchSchema") {
-//                        accessCheckoutClientValidationErrors = error.validationErrors
-//                    }
-//
-//                    AlertView.display(using: self, title: title, message: nil, closeHandler: {
-//                        self.resetCard(preserveContent: true, validationErrors: accessCheckoutClientValidationErrors)
-//                    })
-//                }
-//            }
-//        }
+        let cardDetails = try! CardDetailsBuilder().pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+            .build()
+
+        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
+            .merchantId(Configuration.merchantId)
+            .build()
+
+        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: sessionTypes) { result in
+            DispatchQueue.main.async {
+                self.spinner.stopAnimating()
+
+                switch result {
+                case .success(let sessions):
+                    var titleToDisplay: String, messageToDisplay: String
+
+                    if sessionTypes.count > 1 {
+                        titleToDisplay = "Verified Tokens & Payments CVC Sessions"
+                        messageToDisplay = """
+                        \(sessions[SessionType.card]!)
+                        \(sessions[SessionType.cvc]!)
+                        """
+                    } else {
+                        titleToDisplay = "Verified Tokens Session"
+                        messageToDisplay = "\(sessions[SessionType.card]!)"
+                    }
+
+                    AlertView.display(using: self, title: titleToDisplay, message: messageToDisplay, closeHandler: {
+                        self.resetCard(preserveContent: false, validationErrors: nil)
+                    })
+                case .failure(let error):
+                    let title = error.localizedDescription
+                    var accessCheckoutClientValidationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?
+                    if error.message.contains("bodyDoesNotMatchSchema") {
+                        accessCheckoutClientValidationErrors = error.validationErrors
+                    }
+
+                    AlertView.display(using: self, title: title, message: nil, closeHandler: {
+                        self.resetCard(preserveContent: true, validationErrors: accessCheckoutClientValidationErrors)
+                    })
+                }
+            }
+        }
     }
 
     private func resetCard(preserveContent: Bool, validationErrors: [AccessCheckoutError.AccessCheckoutValidationError]?) {
         if !preserveContent {
-//            panTextField.text = ""
             panTextField.clear()
             panTextField.sendActions(for: .editingChanged)
-            
-//            expiryDateTextField.text = ""
+
             expiryDateTextField.clear()
             expiryDateTextField.sendActions(for: .editingChanged)
 
-//            cvcTextField.text = ""
             cvcTextField.clear()
             cvcTextField.sendActions(for: .editingChanged)
         }
@@ -177,10 +177,10 @@ class CardFlowViewController: UIViewController {
         cvcIsValidLabel.font = UIFont.systemFont(ofSize: 0)
 
         setPanCaretPositionButton.titleLabel?.font = UIFont.systemFont(ofSize: 0)
-        
+
         setPanCaretPositionTextField.borderStyle = .none
         setPanCaretPositionTextField.font = UIFont.systemFont(ofSize: 0)
-        
+
         getPanCaretPositionTextField.borderStyle = .none
         getPanCaretPositionTextField.font = UIFont.systemFont(ofSize: 0)
         // Controls used as helpers for the automated tests - End of section
@@ -233,7 +233,8 @@ class CardFlowViewController: UIViewController {
 extension CardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandChanged(cardBrand: CardBrand?) {
         if let imageUrl = cardBrand?.images.filter({ $0.type == "image/png" }).first?.url,
-            let url = URL(string: imageUrl) {
+           let url = URL(string: imageUrl)
+        {
             updateCardBrandImage(url: url)
         } else {
             imageView.image = unknownBrandImage

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
@@ -2,41 +2,39 @@ import AccessCheckoutSDK
 import UIKit
 
 class CvcFlowViewController: UIViewController {
-    @IBOutlet weak var cvcTextField: AccessCheckoutUITextField!
-    @IBOutlet weak var submitButton: UIButton!
-    @IBOutlet weak var spinner: UIActivityIndicatorView!
-    @IBOutlet weak var cvcIsValidLabel: UILabel!
+    @IBOutlet var cvcTextField: AccessCheckoutUITextField!
+    @IBOutlet var submitButton: UIButton!
+    @IBOutlet var spinner: UIActivityIndicatorView!
+    @IBOutlet var cvcIsValidLabel: UILabel!
     
     @IBAction func submitTouchUpInsideHandler(_ sender: Any) {
-//        let cvc = cvcTextField.text
-//
-//        spinner.startAnimating()
-//
-//        let cardDetails = try! CardDetailsBuilder()
-//            .cvc(cvc ?? "")
-//            .build()
-//
-//        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
-//            .merchantId(Configuration.merchantId)
-//            .build()
-//
-//        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: [SessionType.cvc]) { result in
-//            DispatchQueue.main.async {
-//                self.spinner.stopAnimating()
-//
-//                switch result {
-//                    case .success(let sessions):
-//                        AlertView.display(using: self, title: "Payments CVC Session", message: sessions[SessionType.cvc], closeHandler: {
-//                            self.cvcTextField.text = ""
-//                            self.cvcTextField.sendActions(for: .editingChanged)
-//                    })
-//                    case .failure(let error):
-//                        self.highlightCvcField(error: error)
-//
-//                        AlertView.display(using: self, title: "Error", message: error.localizedDescription)
-//                }
-//            }
-//        }
+        spinner.startAnimating()
+
+        let cardDetails = try! CardDetailsBuilder()
+            .cvc(cvcTextField)
+            .build()
+
+        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
+            .merchantId(Configuration.merchantId)
+            .build()
+
+        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: [SessionType.cvc]) { result in
+            DispatchQueue.main.async {
+                self.spinner.stopAnimating()
+
+                switch result {
+                    case .success(let sessions):
+                        AlertView.display(using: self, title: "Payments CVC Session", message: sessions[SessionType.cvc], closeHandler: {
+                            self.cvcTextField.clear()
+                            self.cvcTextField.sendActions(for: .editingChanged)
+                        })
+                    case .failure(let error):
+                        self.highlightCvcField(error: error)
+
+                        AlertView.display(using: self, title: "Error", message: error.localizedDescription)
+                }
+            }
+        }
     }
     
     override func viewDidLoad() {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
@@ -2,41 +2,41 @@ import AccessCheckoutSDK
 import UIKit
 
 class CvcFlowViewController: UIViewController {
-    @IBOutlet weak var cvcTextField: UITextField!
+    @IBOutlet weak var cvcTextField: AccessCheckoutUITextField!
     @IBOutlet weak var submitButton: UIButton!
     @IBOutlet weak var spinner: UIActivityIndicatorView!
     @IBOutlet weak var cvcIsValidLabel: UILabel!
     
     @IBAction func submitTouchUpInsideHandler(_ sender: Any) {
-        let cvc = cvcTextField.text
-        
-        spinner.startAnimating()
-        
-        let cardDetails = try! CardDetailsBuilder()
-            .cvc(cvc ?? "")
-            .build()
-        
-        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
-            .merchantId(Configuration.merchantId)
-            .build()
-        
-        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: [SessionType.cvc]) { result in
-            DispatchQueue.main.async {
-                self.spinner.stopAnimating()
-                
-                switch result {
-                    case .success(let sessions):
-                        AlertView.display(using: self, title: "Payments CVC Session", message: sessions[SessionType.cvc], closeHandler: {
-                            self.cvcTextField.text = ""
-                            self.cvcTextField.sendActions(for: .editingChanged)
-                    })
-                    case .failure(let error):
-                        self.highlightCvcField(error: error)
-                        
-                        AlertView.display(using: self, title: "Error", message: error.localizedDescription)
-                }
-            }
-        }
+//        let cvc = cvcTextField.text
+//
+//        spinner.startAnimating()
+//
+//        let cardDetails = try! CardDetailsBuilder()
+//            .cvc(cvc ?? "")
+//            .build()
+//
+//        let accessCheckoutClient = try? AccessCheckoutClientBuilder().accessBaseUrl(Configuration.accessBaseUrl)
+//            .merchantId(Configuration.merchantId)
+//            .build()
+//
+//        try? accessCheckoutClient?.generateSessions(cardDetails: cardDetails, sessionTypes: [SessionType.cvc]) { result in
+//            DispatchQueue.main.async {
+//                self.spinner.stopAnimating()
+//
+//                switch result {
+//                    case .success(let sessions):
+//                        AlertView.display(using: self, title: "Payments CVC Session", message: sessions[SessionType.cvc], closeHandler: {
+//                            self.cvcTextField.text = ""
+//                            self.cvcTextField.sendActions(for: .editingChanged)
+//                    })
+//                    case .failure(let error):
+//                        self.highlightCvcField(error: error)
+//
+//                        AlertView.display(using: self, title: "Error", message: error.localizedDescription)
+//                }
+//            }
+//        }
     }
     
     override func viewDidLoad() {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
@@ -2,7 +2,7 @@ import AccessCheckoutSDK
 import UIKit
 
 class RestrictedCardFlowViewController: UIViewController {
-    @IBOutlet weak var panTextField: UITextField!
+    @IBOutlet weak var panTextField: AccessCheckoutUITextField!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var panIsValidLabel: UILabel!
     
@@ -20,8 +20,8 @@ class RestrictedCardFlowViewController: UIViewController {
         panIsValidLabel.font = UIFont.systemFont(ofSize: 0)
         
         let validationConfig = try! CardValidationConfig.builder().pan(panTextField)
-            .expiryDate(UITextField())
-            .cvc(UITextField())
+            .expiryDate(AccessCheckoutUITextField(frame: CGRect()))
+            .cvc(AccessCheckoutUITextField(frame: CGRect()))
             .accessBaseUrl(Configuration.accessBaseUrl)
             .validationDelegate(self)
             .acceptedCardBrands(["visa", "mastercard", "AMEX"])

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -14,10 +14,13 @@
 		1BCBFECF22B8F40300A65FAA /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 1BCBFECB22B8F40300A65FAA /* LICENSE */; };
 		5138297026863877001E61B5 /* PanViewPresenterCardSpacingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5138296F26863877001E61B5 /* PanViewPresenterCardSpacingTests.swift */; };
 		5166BC8726833E3C00648CE8 /* CardValidationConfigConstructorLegacyViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5166BC8626833E3C00648CE8 /* CardValidationConfigConstructorLegacyViewTests.swift */; };
-		5166BC9526833FCA00648CE8 /* CardValidationConfigConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorTests.swift */; };
+		5166BC9526833FCA00648CE8 /* CardValidationConfigConstructorLegacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorLegacyTests.swift */; };
 		5173EF252970367300770177 /* WpSdkHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EF242970367300770177 /* WpSdkHeaderTests.swift */; };
+		5182FA752AC485C500976088 /* AccessCheckoutUITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */; };
+		5182FA772AC4861700976088 /* AccessCheckoutUITextField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5182FA762AC4861700976088 /* AccessCheckoutUITextField.xib */; };
 		51D610D125CD750A00B1B685 /* CardValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */; };
 		51D610D325CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */; };
+		51F1E92A2AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F1E9292AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift */; };
 		51F7EEEC25C88E41002FE45F /* AcceptanceTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */; };
 		683DFBB48F1684E7AFD56E13 /* PaymentsCvcSessionURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DFFF3DC25699A1CE15270 /* PaymentsCvcSessionURLRequestFactory.swift */; };
 		75E83DCA95B5103C9D6B49BA /* Pods_AccessCheckoutSDKPactTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */; };
@@ -220,10 +223,13 @@
 		1BCBFECB22B8F40300A65FAA /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		5138296F26863877001E61B5 /* PanViewPresenterCardSpacingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanViewPresenterCardSpacingTests.swift; sourceTree = "<group>"; };
 		5166BC8626833E3C00648CE8 /* CardValidationConfigConstructorLegacyViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigConstructorLegacyViewTests.swift; sourceTree = "<group>"; };
-		5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigConstructorTests.swift; sourceTree = "<group>"; };
+		5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorLegacyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigConstructorLegacyTests.swift; sourceTree = "<group>"; };
 		5173EF242970367300770177 /* WpSdkHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WpSdkHeaderTests.swift; sourceTree = "<group>"; };
+		5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCheckoutUITextField.swift; sourceTree = "<group>"; };
+		5182FA762AC4861700976088 /* AccessCheckoutUITextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccessCheckoutUITextField.xib; sourceTree = "<group>"; };
 		51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CvcOnlyValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
+		51F1E9292AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigConstructorTests.swift; sourceTree = "<group>"; };
 		51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceTestSuite.swift; sourceTree = "<group>"; };
 		5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDKPactTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63E9AC2FDE45ABB3E75E6DFE /* Pods-AccessCheckoutSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDK.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDK/Pods-AccessCheckoutSDK.release.xcconfig"; sourceTree = "<group>"; };
@@ -591,7 +597,8 @@
 				E75C5E69248E7020003A1BDE /* AccessCheckoutCardValidationDelegate_EditText_Tests.swift */,
 				E75C5E6D248E7171003A1BDE /* AccessCheckoutCardValidationDelegate_FocusOut_Tests.swift */,
 				51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */,
-				5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorTests.swift */,
+				51F1E9292AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift */,
+				5166BC9426833FCA00648CE8 /* CardValidationConfigConstructorLegacyTests.swift */,
 				5166BC8626833E3C00648CE8 /* CardValidationConfigConstructorLegacyViewTests.swift */,
 			);
 			path = card;
@@ -966,6 +973,8 @@
 		E79EAC5724587DC200A8DDA6 /* components */ = {
 			isa = PBXGroup;
 			children = (
+				5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */,
+				5182FA762AC4861700976088 /* AccessCheckoutUITextField.xib */,
 				E7821A9424586BF4003F7231 /* AccessCheckoutTextView.swift */,
 				C9AFE44F22B7AA4700943B3E /* CvcView.swift */,
 				C9AFE44922B7AA4700943B3E /* CvcView.xib */,
@@ -1196,6 +1205,7 @@
 				C9AFE46922B7AA4800943B3E /* mastercard.png in Resources */,
 				1BCBFECE22B8F40300A65FAA /* CHANGELOG.md in Resources */,
 				C9AFE45C22B7AA4800943B3E /* CvcView.xib in Resources */,
+				5182FA772AC4861700976088 /* AccessCheckoutUITextField.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1361,6 +1371,7 @@
 				E7821A9524586BF4003F7231 /* AccessCheckoutTextView.swift in Sources */,
 				E719B08A24643C350037DED4 /* VerifiedTokensApiDiscovery.swift in Sources */,
 				E745CC1824856AD8000390CA /* ValidationRule.swift in Sources */,
+				5182FA752AC485C500976088 /* AccessCheckoutUITextField.swift in Sources */,
 				E749024D247FEEB600889AAA /* TextChangeHandler.swift in Sources */,
 				E72C3EF124893C0100284A31 /* CardBrandsConfigurationProvider.swift in Sources */,
 				E7821A87245869DB003F7231 /* ApiHeaders.swift in Sources */,
@@ -1438,6 +1449,7 @@
 				E719B0AE2464A4B90037DED4 /* SessionsApiClientTests.swift in Sources */,
 				E72C3EDE248669EF00284A31 /* MockPanValidationStateHandler.swift in Sources */,
 				D7D6D5F3248154B900D57D7A /* PanValidationFlowTests.swift in Sources */,
+				51F1E92A2AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift in Sources */,
 				E7D19F74246328EA001EA13A /* SingleLinkDiscoveryTests.swift in Sources */,
 				E75C5E67248E6F7F003A1BDE /* MockAccessCheckoutCardValidationDelegate.swift in Sources */,
 				D7D6D5D2247EBA0600D57D7A /* ExpiryDateValidatorTests.swift in Sources */,
@@ -1502,7 +1514,7 @@
 				E7D19F8124640008001EA13A /* StubUtils.swift in Sources */,
 				5173EF252970367300770177 /* WpSdkHeaderTests.swift in Sources */,
 				E782A6DC24A106EF005904B5 /* LegacyViewTestSuite.swift in Sources */,
-				5166BC9526833FCA00648CE8 /* CardValidationConfigConstructorTests.swift in Sources */,
+				5166BC9526833FCA00648CE8 /* CardValidationConfigConstructorLegacyTests.swift in Sources */,
 				E77B8BA9245C552200564C19 /* VerifiedTokensRetrieveSessionHandlerTests.swift in Sources */,
 				D7851B212487B21600461377 /* CvcValidationFlowTests.swift in Sources */,
 				5138297026863877001E61B5 /* PanViewPresenterCardSpacingTests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5182FA772AC4861700976088 /* AccessCheckoutUITextField.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5182FA762AC4861700976088 /* AccessCheckoutUITextField.xib */; };
 		51D610D125CD750A00B1B685 /* CardValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */; };
 		51D610D325CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */; };
+		51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E831E12ACDB49900A8FC22 /* UIUtils.swift */; };
 		51F1E92A2AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F1E9292AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift */; };
 		51F7EEEC25C88E41002FE45F /* AcceptanceTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */; };
 		683DFBB48F1684E7AFD56E13 /* PaymentsCvcSessionURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DFFF3DC25699A1CE15270 /* PaymentsCvcSessionURLRequestFactory.swift */; };
@@ -229,6 +230,7 @@
 		5182FA762AC4861700976088 /* AccessCheckoutUITextField.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccessCheckoutUITextField.xib; sourceTree = "<group>"; };
 		51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CvcOnlyValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
+		51E831E12ACDB49900A8FC22 /* UIUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
 		51F1E9292AC5D11C00AB6F84 /* CardValidationConfigConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigConstructorTests.swift; sourceTree = "<group>"; };
 		51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceTestSuite.swift; sourceTree = "<group>"; };
 		5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDKPactTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -998,6 +1000,7 @@
 				D74028322592136700104B32 /* PresenterTestSuite.swift */,
 				E7D19F8024640008001EA13A /* StubUtils.swift */,
 				E70305A024924AAA00802AF1 /* TestFixtures.swift */,
+				51E831E12ACDB49900A8FC22 /* UIUtils.swift */,
 			);
 			path = testUtils;
 			sourceTree = "<group>";
@@ -1504,6 +1507,7 @@
 				E719B084246417110037DED4 /* SingleLinkDiscoveryMock.swift in Sources */,
 				E719B08824642EF80037DED4 /* CuckooExtension.swift in Sources */,
 				E719B0AA2464A3B30037DED4 /* VerifiedTokensApiClientMock.swift in Sources */,
+				51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */,
 				D74028332592136700104B32 /* PresenterTestSuite.swift in Sources */,
 				E719B09E246481DA0037DED4 /* VerifiedTokensSessionURLRequestFactoryMock.swift in Sources */,
 				E745CC2424857616000390CA /* CardBrandDtoTransformerTests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/AccessCheckoutIllegalArgumentError.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/AccessCheckoutIllegalArgumentError.swift
@@ -35,4 +35,8 @@ public struct AccessCheckoutIllegalArgumentError: Error, Equatable {
     static func missingValidationDelegate() -> AccessCheckoutIllegalArgumentError {
         return AccessCheckoutIllegalArgumentError(message: "Expected validation delegate to be provided but was not")
     }
+    
+    static func cannotBuildEmptyCardDetails() -> AccessCheckoutIllegalArgumentError {
+        return AccessCheckoutIllegalArgumentError(message: "Cannot build an instance of CardDetails when pan, expiryDate and cvc are all nil")
+    }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/AccessCheckoutIllegalArgumentError.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/AccessCheckoutIllegalArgumentError.swift
@@ -35,8 +35,4 @@ public struct AccessCheckoutIllegalArgumentError: Error, Equatable {
     static func missingValidationDelegate() -> AccessCheckoutIllegalArgumentError {
         return AccessCheckoutIllegalArgumentError(message: "Expected validation delegate to be provided but was not")
     }
-    
-    static func cannotBuildEmptyCardDetails() -> AccessCheckoutIllegalArgumentError {
-        return AccessCheckoutIllegalArgumentError(message: "Cannot build an instance of CardDetails when pan, expiryDate and cvc are all nil")
-    }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/session/CardDetails.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/session/CardDetails.swift
@@ -1,8 +1,7 @@
 // TODO: fix comments in this code
 
 /**
- This protocol is a representation of card information that can be constructed with a `CardDetailsBuilder`
- 
+ This class is a representation of card information. It cannot be constructed as such, only subclasses conforming to its internal interface can be constructed with a `CardDetailsBuilder`.
  - `pan`: an optional `String` containing the PAN as a numeric string with no spaces
  - `expiryMonth`: an optional `UInt` containing the month part of an expiry date
  - `expiryYear`: an optional `UInt` containing the year part of an expiry date in a 4 digits format
@@ -14,11 +13,11 @@ public class CardDetails {
     internal var expiryYear: UInt? { return nil }
     internal var cvc: String? { return nil }
     
-    internal init() {}
+    fileprivate init() {}
 }
 
 /**
- This struct is a representation of card information that can be constructed with a `CardDetailsBuilder` using plain `String` objects for the pan, expiry date and cvc
+ This class is a representation of card information that can be constructed with a `CardDetailsBuilder` using plain `String` objects for the PAN and cvc, and plain `UInt` for the expiry month and year
  
  - `pan`: an optional `String` containing the PAN
  - `expiryMonth`: an optional `UInt` containing the month part of an expiry date
@@ -75,8 +74,7 @@ internal class CardDetailsFromValues: CardDetails {
 }
 
 /**
- This struct is a representation of card information that can be constructed with a `CardDetailsBuilder` using instances of `AccessCheckoutUITextField` for the pan, expiry date and cvc
- 
+ This class is a representation of card information that can be constructed with a `CardDetailsBuilder` using instances of `AccessCheckoutUITextField` for the PAN, expiry date and cvc
  - `pan`: an optional `AccessCheckoutUITextField` containing the PAN text
  - `expiryDate`: an optional `AccessCheckoutUITextField` containing the expiry date text
  - `cvc`: an optional `AccessCheckoutUITextField` containing the cvc text
@@ -118,7 +116,11 @@ internal class CardDetailsFromUIComponents: CardDetails {
     }
 }
 
-/// This build helps building the `CardDetails` instance
+/**
+ This builder is designed to create instances of classes that represent the details of a payment card (PAN, expiry date, cvc, all optional).
+ Classes of the instances created conform to the internal interface exposed by the `CardDetails` class.
+ It is designed to allow merchants to choose to either pass card details directly (higher PCI data footprint), or pass instances of `AccessCheckoutUITextField` which the SDK uses to extract card details (lower PCI data footprint).
+ */
 public final class CardDetailsBuilder {
     private var pan: String?
     private var cvc: String?
@@ -145,7 +147,7 @@ public final class CardDetailsBuilder {
     /**
      Sets the expiry month and year for the card
      
-     - Parameter expiryDate: `String` that represents the expiry date
+     - Parameter expiryDate: `String` that represents the expiry date in mm/yy format
      
      - Returns: the `CardDetailsBuilder` instance in order to chain further operations
      */
@@ -203,9 +205,9 @@ public final class CardDetailsBuilder {
     }
     
     /**
-     Builds the `CardDetails` instance
+     Builds an instance of a class that conform to the internal contract of `CardDetails`
      
-     - Returns: `CardDetails` instance with the given details
+     - Returns: an instance of a class conforming to the internal contract of `CardDetails` and containig card details
      
      - Throws: `AccessCheckoutIllegalArgumentError` in case where the expiry date is provided in an invalid format
      */

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/session/CardDetails.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/session/CardDetails.swift
@@ -1,8 +1,5 @@
 // TODO: fix comments in this code
 
-
-
-
 /**
  This protocol is a representation of card information that can be constructed with a `CardDetailsBuilder`
  
@@ -232,8 +229,7 @@ public final class CardDetailsBuilder {
                 cvcUITextField: cvcUITextField
             )
         }
-        
-        throw AccessCheckoutIllegalArgumentError.cannotBuildEmptyCardDetails()
+        return CardDetailsFromValues(pan: nil, expiryMonth: nil, expiryYear: nil, cvc: nil)
     }
 }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
@@ -45,7 +45,11 @@ public struct AccessCheckoutValidationInitialiser {
         let expiryDatePresenter = expiryDateViewPresenter(validationStateHandler)
         let cvcPresenter = CvcViewPresenter(cvcValidationFlow, cvcValidator)
         
-        if config.textFieldMode {
+        if config.accessCheckoutUITextFieldMode {
+            setTextFieldDelegate(textField: config.panUITextField!.uiTextField, delegate: panPresenter)
+            setTextFieldDelegate(textField: config.expiryDateUITextField!.uiTextField, delegate: expiryDatePresenter)
+            setTextFieldDelegate(textField: config.cvcUITextField!.uiTextField, delegate: cvcPresenter)
+        } else if config.textFieldMode {
             setTextFieldDelegate(textField: config.panTextField!, delegate: panPresenter)
             setTextFieldDelegate(textField: config.expiryDateTextField!, delegate: expiryDatePresenter)
             setTextFieldDelegate(textField: config.cvcTextField!, delegate: cvcPresenter)
@@ -62,7 +66,9 @@ public struct AccessCheckoutValidationInitialiser {
         let cvcValidationFlow = CvcValidationFlow(cvcValidator, validationStateHandler)
         let cvcPresenter = CvcViewPresenter(cvcValidationFlow, cvcValidator)
         
-        if config.textFieldMode {
+        if config.accessCheckoutUITextFieldMode {
+            setTextFieldDelegate(textField: config.cvcUITextField!.uiTextField, delegate: cvcPresenter)
+        } else if config.textFieldMode {
             setTextFieldDelegate(textField: config.cvcTextField!, delegate: cvcPresenter)
         } else {
             config.cvcView!.presenter = cvcPresenter

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
@@ -46,9 +46,9 @@ public struct AccessCheckoutValidationInitialiser {
         let cvcPresenter = CvcViewPresenter(cvcValidationFlow, cvcValidator)
         
         if config.accessCheckoutUITextFieldMode {
-            setTextFieldDelegate(textField: config.panUITextField!.uiTextField, delegate: panPresenter)
-            setTextFieldDelegate(textField: config.expiryDateUITextField!.uiTextField, delegate: expiryDatePresenter)
-            setTextFieldDelegate(textField: config.cvcUITextField!.uiTextField, delegate: cvcPresenter)
+            setTextFieldDelegate(textField: config.pan!.uiTextField, delegate: panPresenter)
+            setTextFieldDelegate(textField: config.expiryDate!.uiTextField, delegate: expiryDatePresenter)
+            setTextFieldDelegate(textField: config.cvc!.uiTextField, delegate: cvcPresenter)
         } else if config.textFieldMode {
             setTextFieldDelegate(textField: config.panTextField!, delegate: panPresenter)
             setTextFieldDelegate(textField: config.expiryDateTextField!, delegate: expiryDatePresenter)
@@ -67,7 +67,7 @@ public struct AccessCheckoutValidationInitialiser {
         let cvcPresenter = CvcViewPresenter(cvcValidationFlow, cvcValidator)
         
         if config.accessCheckoutUITextFieldMode {
-            setTextFieldDelegate(textField: config.cvcUITextField!.uiTextField, delegate: cvcPresenter)
+            setTextFieldDelegate(textField: config.cvc!.uiTextField, delegate: cvcPresenter)
         } else if config.textFieldMode {
             setTextFieldDelegate(textField: config.cvcTextField!, delegate: cvcPresenter)
         } else {
@@ -78,7 +78,8 @@ public struct AccessCheckoutValidationInitialiser {
     private func panViewPresenter(_ configurationProvider: CardBrandsConfigurationProvider,
                                   _ cvcValidationFlow: CvcValidationFlow,
                                   _ validationStateHandler: PanValidationStateHandler,
-                                  _ panFormattingEnabled: Bool) -> PanViewPresenter {
+                                  _ panFormattingEnabled: Bool) -> PanViewPresenter
+    {
         let panValidator = PanValidator(configurationProvider)
         let panValidationFlow = PanValidationFlow(panValidator, validationStateHandler, cvcValidationFlow)
         return PanViewPresenter(panValidationFlow, panValidator, panFormattingEnabled: panFormattingEnabled)

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
@@ -5,20 +5,22 @@ import UIKit
  
  Use this configuration to register the relevant fields and listener.
  
- - panTextField: `UITextField` that represents the pan ui element
- - expiryDateTextField: `UITextField` that represents the expiry date ui element
- - cvcTextField: `UITextField` that represents the cvc ui element
+ - panTextField: `AccessCheckoutUITextField` that represents the pan ui element
+ - expiryDateTextField: `AccessCheckoutUITextField` that represents the expiry date ui element
+ - cvcTextField: `AccessCheckoutUITextField` that represents the cvc ui element
  - accessBaseUrl: `String` that represents the base url to use when calling Worldpay services
  - validationDelegate: `AccessCheckoutCardValidationDelegate` that represents the validation delegate that should be notified on validation changes
  - acceptedCardBrands: `Array` of `String` that represents the list of card brands to accept for validation. Any unrecognised card brand will be accepted at all times.
  - panFormattingEnabled: `Bool` that represents whether the PAN field will be formatted.
  
- Deprecated - using the Views below to initialise the validation is deprecated and will not be supported on future major versions of the SDK. `UITextField`s should be used as above.
- 
+ Deprecated - using the Views below to initialise the validation is deprecated and will not be supported on future major versions of the SDK. `AccessCheckoutUITextField`s should be used instead
  - panView: `PanView` that represents the pan ui element
  - expiryDateView: `ExpiryDateView` that represents the expiry date ui element
  - cvcView: `CvcView` that represents the cvc ui element
  
+ Deprecated - using `UITextField` instances to capture card information is deprecated and will not be supported on future major versions of the SDK. `AccessCheckoutUITextField`s should be used instead
+ 
+ - SeeAlso: AccessCheckoutUITextField
  - SeeAlso: PanView
  - SeeAlso: ExpiryDateView
  - SeeAlso: CvcView
@@ -29,9 +31,9 @@ public struct CardValidationConfig: ValidationConfig {
     let expiryDateTextField: UITextField?
     let cvcTextField: UITextField?
     
-    let panUITextField:AccessCheckoutUITextField?
-    let expiryDateUITextField:AccessCheckoutUITextField?
-    let cvcUITextField:AccessCheckoutUITextField?
+    let pan: AccessCheckoutUITextField?
+    let expiryDate: AccessCheckoutUITextField?
+    let cvc: AccessCheckoutUITextField?
     
     let panView: PanView?
     let expiryDateView: ExpiryDateView?
@@ -72,7 +74,8 @@ public struct CardValidationConfig: ValidationConfig {
                 accessBaseUrl: String,
                 validationDelegate: AccessCheckoutCardValidationDelegate,
                 acceptedCardBrands: [String] = [],
-                panFormattingEnabled: Bool = false) {
+                panFormattingEnabled: Bool = false)
+    {
         self.panTextField = panTextField
         self.expiryDateTextField = expiryDateTextField
         self.cvcTextField = cvcTextField
@@ -83,9 +86,9 @@ public struct CardValidationConfig: ValidationConfig {
         self.expiryDateView = nil
         self.cvcView = nil
         
-        self.panUITextField = nil
-        self.expiryDateUITextField = nil
-        self.cvcUITextField = nil
+        self.pan = nil
+        self.expiryDate = nil
+        self.cvc = nil
         
         self.textFieldMode = true
         self.accessCheckoutUITextFieldMode = false
@@ -112,7 +115,8 @@ public struct CardValidationConfig: ValidationConfig {
                 accessBaseUrl: String,
                 validationDelegate: AccessCheckoutCardValidationDelegate,
                 acceptedCardBrands: [String] = [],
-                panFormattingEnabled: Bool = false) {
+                panFormattingEnabled: Bool = false)
+    {
         self.panView = panView
         self.expiryDateView = expiryDateView
         self.cvcView = cvcView
@@ -123,9 +127,9 @@ public struct CardValidationConfig: ValidationConfig {
         self.expiryDateTextField = nil
         self.cvcTextField = nil
         
-        self.panUITextField = nil
-        self.expiryDateUITextField = nil
-        self.cvcUITextField = nil
+        self.pan = nil
+        self.expiryDate = nil
+        self.cvc = nil
         
         self.textFieldMode = false
         self.accessCheckoutUITextFieldMode = false
@@ -144,16 +148,17 @@ public struct CardValidationConfig: ValidationConfig {
      - Parameter acceptedCardBrands: `Array` of `String` that represents the list of card brands to accept for validation. Any unrecognised card brand will be accepted at all times.
      - Parameter panFormattingEnabled: `Bool` that represents whether the PAN field will be formatted.
      */
-    public init(panUITextField: AccessCheckoutUITextField,
-                expiryDateUITextField: AccessCheckoutUITextField,
-                cvcUITextField: AccessCheckoutUITextField,
-                accessBaseUrl: String,
-                validationDelegate: AccessCheckoutCardValidationDelegate,
-                acceptedCardBrands: [String] = [],
-                panFormattingEnabled: Bool = false) {
-        self.panUITextField = panUITextField
-        self.expiryDateUITextField = expiryDateUITextField
-        self.cvcUITextField = cvcUITextField
+    internal init(pan: AccessCheckoutUITextField,
+                  expiryDate: AccessCheckoutUITextField,
+                  cvc: AccessCheckoutUITextField,
+                  accessBaseUrl: String,
+                  validationDelegate: AccessCheckoutCardValidationDelegate,
+                  acceptedCardBrands: [String] = [],
+                  panFormattingEnabled: Bool = false)
+    {
+        self.pan = pan
+        self.expiryDate = expiryDate
+        self.cvc = cvc
 
         self.accessBaseUrl = accessBaseUrl
         self.validationDelegate = validationDelegate
@@ -194,34 +199,40 @@ public class CardValidationConfigBuilder {
     fileprivate init() {}
     
     /**
-     - Parameter pan: UITextField that represents the pan ui element
-     - Returns: the same instance of the builder
-     */
-    public func panLegacy(_ pan: UITextField) -> CardValidationConfigBuilder {
-        self.panLegacy = pan
+     Deprecated
+      - Parameter pan: UITextField that represents the pan ui element
+      - Returns: the same instance of the builder
+      */
+    @available(*, deprecated, message: "This method is deprecated and will not be supported on future major versions of the SDK. `pan(AccessCheckoutUITextField)` should be used instead.")
+    public func pan(_ pan: UITextField) -> CardValidationConfigBuilder {
+        panLegacy = pan
         return self
     }
     
     /**
-     - Parameter expiryDate: `UITextField` that represents the expiry date ui element
-     - Returns: the same instance of the builder
-     */
-    public func expiryDateLegacy(_ expiryDate: UITextField) -> CardValidationConfigBuilder {
-        self.expiryDateLegacy = expiryDate
+     Deprecated
+      - Parameter expiryDate: `UITextField` that represents the expiry date ui element
+      - Returns: the same instance of the builder
+      */
+    @available(*, deprecated, message: "This method is deprecated and will not be supported on future major versions of the SDK. `expiryDate(AccessCheckoutUITextField)` should be used instead.")
+    public func expiryDate(_ expiryDate: UITextField) -> CardValidationConfigBuilder {
+        expiryDateLegacy = expiryDate
         return self
     }
     
     /**
-     - Parameter cvc: `UITextField` that represents the cvc ui element
-     - Returns: the same instance of the builder
-     */
-    public func cvcLegacy(_ cvc: UITextField) -> CardValidationConfigBuilder {
-        self.cvcLegacy = cvc
+     Deprecated
+      - Parameter cvc: `UITextField` that represents the cvc ui element
+      - Returns: the same instance of the builder
+      */
+    @available(*, deprecated, message: "This method is deprecated and will not be supported on future major versions of the SDK. `cvc(AccessCheckoutUITextField)` should be used instead.")
+    public func cvc(_ cvc: UITextField) -> CardValidationConfigBuilder {
+        cvcLegacy = cvc
         return self
     }
     
     /**
-     - Parameter pan: AccessCheckoutUITextField that represents the pan ui element
+     - Parameter pan: `AccessCheckoutUITextField` that represents the pan ui element
      - Returns: the same instance of the builder
      */
     public func pan(_ pan: AccessCheckoutUITextField) -> CardValidationConfigBuilder {
@@ -290,13 +301,13 @@ public class CardValidationConfigBuilder {
      - Throws: an `AccessCheckoutIllegalArgumentError` if either the pan, expiryDate, cvc, accessBaseUrl or validationDelegate have not been specified
      */
     public func build() throws -> CardValidationConfig {
-        guard let pan = pan else {
+        if pan == nil && panLegacy == nil {
             throw AccessCheckoutIllegalArgumentError.missingPan()
         }
-        guard let expiryDate = expiryDate else {
+        if expiryDate == nil && expiryDateLegacy == nil {
             throw AccessCheckoutIllegalArgumentError.missingExpiryDate()
         }
-        guard let cvc = cvc else {
+        if cvc == nil && cvcLegacy == nil {
             throw AccessCheckoutIllegalArgumentError.missingCvc()
         }
         guard let accessBaseUrl = accessBaseUrl else {
@@ -306,9 +317,18 @@ public class CardValidationConfigBuilder {
             throw AccessCheckoutIllegalArgumentError.missingValidationDelegate()
         }
         
-        return CardValidationConfig(panUITextField: pan,
-                                    expiryDateUITextField: expiryDate,
-                                    cvcUITextField: cvc,
+        if let pan = pan, let expiryDate = expiryDate, let cvc = cvc {
+            return CardValidationConfig(pan: pan,
+                                        expiryDate: expiryDate,
+                                        cvc: cvc,
+                                        accessBaseUrl: accessBaseUrl,
+                                        validationDelegate: validationDelegate,
+                                        acceptedCardBrands: acceptedCardBrands,
+                                        panFormattingEnabled: panFormattingEnabled)
+        }
+        return CardValidationConfig(panTextField: panLegacy!,
+                                    expiryDateTextField: expiryDateLegacy!,
+                                    cvcTextField: cvcLegacy!,
                                     accessBaseUrl: accessBaseUrl,
                                     validationDelegate: validationDelegate,
                                     acceptedCardBrands: acceptedCardBrands,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
@@ -29,6 +29,10 @@ public struct CardValidationConfig: ValidationConfig {
     let expiryDateTextField: UITextField?
     let cvcTextField: UITextField?
     
+    let panUITextField:AccessCheckoutUITextField?
+    let expiryDateUITextField:AccessCheckoutUITextField?
+    let cvcUITextField:AccessCheckoutUITextField?
+    
     let panView: PanView?
     let expiryDateView: ExpiryDateView?
     let cvcView: CvcView?
@@ -37,6 +41,7 @@ public struct CardValidationConfig: ValidationConfig {
     let validationDelegate: AccessCheckoutCardValidationDelegate
     
     let textFieldMode: Bool
+    let accessCheckoutUITextFieldMode: Bool
     let acceptedCardBrands: [String]
     
     let panFormattingEnabled: Bool
@@ -78,7 +83,12 @@ public struct CardValidationConfig: ValidationConfig {
         self.expiryDateView = nil
         self.cvcView = nil
         
+        self.panUITextField = nil
+        self.expiryDateUITextField = nil
+        self.cvcUITextField = nil
+        
         self.textFieldMode = true
+        self.accessCheckoutUITextFieldMode = false
         self.acceptedCardBrands = acceptedCardBrands
         self.panFormattingEnabled = panFormattingEnabled
     }
@@ -113,7 +123,51 @@ public struct CardValidationConfig: ValidationConfig {
         self.expiryDateTextField = nil
         self.cvcTextField = nil
         
+        self.panUITextField = nil
+        self.expiryDateUITextField = nil
+        self.cvcUITextField = nil
+        
         self.textFieldMode = false
+        self.accessCheckoutUITextFieldMode = false
+        self.acceptedCardBrands = acceptedCardBrands
+        self.panFormattingEnabled = panFormattingEnabled
+    }
+    
+    /**
+     Creates an instance of `CardValidationConfig`
+     
+     - Parameter panUITextField: `AccessCheckoutUITextField` that represents the pan ui element
+     - Parameter expiryDateUITextField: `AccessCheckoutUITextField` that represents the expiry date ui element
+     - Parameter cvcUITextField: `AccessCheckoutUITextField` that represents the cvc ui element
+     - Parameter accessBaseUrl: `String` that represents the base url
+     - Parameter validationDelegate: `AccessCheckoutCardValidationDelegate` that represents the validation events listener
+     - Parameter acceptedCardBrands: `Array` of `String` that represents the list of card brands to accept for validation. Any unrecognised card brand will be accepted at all times.
+     - Parameter panFormattingEnabled: `Bool` that represents whether the PAN field will be formatted.
+     */
+    public init(panUITextField: AccessCheckoutUITextField,
+                expiryDateUITextField: AccessCheckoutUITextField,
+                cvcUITextField: AccessCheckoutUITextField,
+                accessBaseUrl: String,
+                validationDelegate: AccessCheckoutCardValidationDelegate,
+                acceptedCardBrands: [String] = [],
+                panFormattingEnabled: Bool = false) {
+        self.panUITextField = panUITextField
+        self.expiryDateUITextField = expiryDateUITextField
+        self.cvcUITextField = cvcUITextField
+
+        self.accessBaseUrl = accessBaseUrl
+        self.validationDelegate = validationDelegate
+        
+        self.panTextField = nil
+        self.expiryDateTextField = nil
+        self.cvcTextField = nil
+        
+        self.panView = nil
+        self.expiryDateView = nil
+        self.cvcView = nil
+        
+        self.textFieldMode = false
+        self.accessCheckoutUITextFieldMode = true
         self.acceptedCardBrands = acceptedCardBrands
         self.panFormattingEnabled = panFormattingEnabled
     }
@@ -124,9 +178,14 @@ public struct CardValidationConfig: ValidationConfig {
  An instance of this builder can be obtained by calling `CardValidationConfig.builder()`
  */
 public class CardValidationConfigBuilder {
-    private var pan: UITextField?
-    private var expiryDate: UITextField?
-    private var cvc: UITextField?
+    private var panLegacy: UITextField?
+    private var expiryDateLegacy: UITextField?
+    private var cvcLegacy: UITextField?
+    
+    private var pan: AccessCheckoutUITextField?
+    private var expiryDate: AccessCheckoutUITextField?
+    private var cvc: AccessCheckoutUITextField?
+    
     private var accessBaseUrl: String?
     private var validationDelegate: AccessCheckoutCardValidationDelegate?
     private var acceptedCardBrands: [String] = []
@@ -138,8 +197,8 @@ public class CardValidationConfigBuilder {
      - Parameter pan: UITextField that represents the pan ui element
      - Returns: the same instance of the builder
      */
-    public func pan(_ pan: UITextField) -> CardValidationConfigBuilder {
-        self.pan = pan
+    public func panLegacy(_ pan: UITextField) -> CardValidationConfigBuilder {
+        self.panLegacy = pan
         return self
     }
     
@@ -147,8 +206,8 @@ public class CardValidationConfigBuilder {
      - Parameter expiryDate: `UITextField` that represents the expiry date ui element
      - Returns: the same instance of the builder
      */
-    public func expiryDate(_ expiryDate: UITextField) -> CardValidationConfigBuilder {
-        self.expiryDate = expiryDate
+    public func expiryDateLegacy(_ expiryDate: UITextField) -> CardValidationConfigBuilder {
+        self.expiryDateLegacy = expiryDate
         return self
     }
     
@@ -156,7 +215,34 @@ public class CardValidationConfigBuilder {
      - Parameter cvc: `UITextField` that represents the cvc ui element
      - Returns: the same instance of the builder
      */
-    public func cvc(_ cvc: UITextField) -> CardValidationConfigBuilder {
+    public func cvcLegacy(_ cvc: UITextField) -> CardValidationConfigBuilder {
+        self.cvcLegacy = cvc
+        return self
+    }
+    
+    /**
+     - Parameter pan: AccessCheckoutUITextField that represents the pan ui element
+     - Returns: the same instance of the builder
+     */
+    public func pan(_ pan: AccessCheckoutUITextField) -> CardValidationConfigBuilder {
+        self.pan = pan
+        return self
+    }
+    
+    /**
+     - Parameter expiryDate: `AccessCheckoutUITextField` that represents the expiry date ui element
+     - Returns: the same instance of the builder
+     */
+    public func expiryDate(_ expiryDate: AccessCheckoutUITextField) -> CardValidationConfigBuilder {
+        self.expiryDate = expiryDate
+        return self
+    }
+    
+    /**
+     - Parameter cvc: `AccessCheckoutUITextField` that represents the cvc ui element
+     - Returns: the same instance of the builder
+     */
+    public func cvc(_ cvc: AccessCheckoutUITextField) -> CardValidationConfigBuilder {
         self.cvc = cvc
         return self
     }
@@ -220,9 +306,9 @@ public class CardValidationConfigBuilder {
             throw AccessCheckoutIllegalArgumentError.missingValidationDelegate()
         }
         
-        return CardValidationConfig(panTextField: pan,
-                                    expiryDateTextField: expiryDate,
-                                    cvcTextField: cvc,
+        return CardValidationConfig(panUITextField: pan,
+                                    expiryDateUITextField: expiryDate,
+                                    cvcUITextField: cvc,
                                     accessBaseUrl: accessBaseUrl,
                                     validationDelegate: validationDelegate,
                                     acceptedCardBrands: acceptedCardBrands,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/cvcOnly/CvcOnlyValidationConfig.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/cvcOnly/CvcOnlyValidationConfig.swift
@@ -15,7 +15,9 @@ import UIKit
 public struct CvcOnlyValidationConfig: ValidationConfig {
     let cvcView: CvcView?
     let cvcTextField: UITextField?
+    let cvcUITextField:AccessCheckoutUITextField?
     
+    let accessCheckoutUITextFieldMode: Bool
     let textFieldMode: Bool
     let validationDelegate: AccessCheckoutCvcOnlyValidationDelegate
 
@@ -39,7 +41,9 @@ public struct CvcOnlyValidationConfig: ValidationConfig {
         self.cvcView = cvcView
         self.validationDelegate = validationDelegate
         self.cvcTextField = nil
+        self.cvcUITextField = nil
         self.textFieldMode = false
+        self.accessCheckoutUITextFieldMode = false
     }
     
     /**
@@ -53,7 +57,25 @@ public struct CvcOnlyValidationConfig: ValidationConfig {
         self.cvcTextField = cvcTextField
         self.validationDelegate = validationDelegate
         self.cvcView = nil
+        self.cvcUITextField = nil
         self.textFieldMode = true
+        self.accessCheckoutUITextFieldMode = false
+    }
+    
+    /**
+    Creates an instance of `CvcOnlyValidationConfig`
+
+    - Parameter cvcView: `AccessCheckoutUITextField` that represents the cvc ui element
+    - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
+    */
+    @available(*, deprecated, message: "This constructor is deprecated and will not be supported on future major versions of the SDK. Instead, use the static `builder()` method to get an instance of a `CvcOnlyValidationConfigBuilder` to create your `CvcOnlyValidationConfig`.")
+    public init(cvcUITextField: AccessCheckoutUITextField, validationDelegate: AccessCheckoutCvcOnlyValidationDelegate) {
+        self.cvcUITextField = cvcUITextField
+        self.validationDelegate = validationDelegate
+        self.cvcView = nil
+        self.cvcTextField = nil
+        self.textFieldMode = false
+        self.accessCheckoutUITextFieldMode = true
     }
 }
 
@@ -62,7 +84,8 @@ public struct CvcOnlyValidationConfig: ValidationConfig {
  An instance of this builder can be obtained by calling `CvcOnlyValidationConfig.builder()`
  */
 public class CvcOnlyValidationConfigBuilder {
-    private var cvc: UITextField?
+    private var cvcLegacy: UITextField?
+    private var cvc: AccessCheckoutUITextField?
     private var validationDelegate: AccessCheckoutCvcOnlyValidationDelegate?
 
     fileprivate init() {}
@@ -71,7 +94,16 @@ public class CvcOnlyValidationConfigBuilder {
      - Parameter cvc: `UITextField` that represents the cvc ui element
      - Returns: the same instance of the builder
      */
-    public func cvc(_ cvc: UITextField) -> CvcOnlyValidationConfigBuilder {
+    public func cvcLegacy(_ cvc: UITextField) -> CvcOnlyValidationConfigBuilder {
+        self.cvcLegacy = cvc
+        return self
+    }
+    
+    /**
+     - Parameter cvc: `AccessCheckoutUITextField` that represents the cvc ui element
+     - Returns: the same instance of the builder
+     */
+    public func cvc(_ cvc: AccessCheckoutUITextField) -> CvcOnlyValidationConfigBuilder {
         self.cvc = cvc
         return self
     }
@@ -98,7 +130,7 @@ public class CvcOnlyValidationConfigBuilder {
             throw AccessCheckoutIllegalArgumentError.missingValidationDelegate()
         }
 
-        return CvcOnlyValidationConfig(cvcTextField: cvc, validationDelegate: validationDelegate)
+        return CvcOnlyValidationConfig(cvcUITextField: cvc, validationDelegate: validationDelegate)
     }
 }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/cvcOnly/CvcOnlyValidationConfig.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/cvcOnly/CvcOnlyValidationConfig.swift
@@ -4,19 +4,24 @@ import UIKit
  An implementation of the [ValidationConfig] that represents the cvc validation configuration.
 
  This configuration should be built to register the relevant fields and the listeners.
- - cvcTextField: `UITextField` that represents the cvc ui element
+ - cvcTextField: `AccessCheckoutUITextField` that represents the cvc ui element
  - accessBaseUrl: `String` that represents the base url to use when calling Worldpay services
  - validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation delegate that should be notified on validation changes
- 
+
  Deprecated - using the `CvcView` below to initialise the validation is deprecated and will not be supported on future major versions of the SDK.  A `UITextField` should be used as above.
  - cvc:  `CvcView` that represents the cvc ui element
- - validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation delegate that should be notified on validation changes
+
+ Deprecated - using `UITextField` instances to capture cvc information is deprecated and will not be supported on future major versions of the SDK. `AccessCheckoutUITextField` should be used instead
+
+ - SeeAlso: AccessCheckoutUITextField
+ - SeeAlso: CvcView
+ - SeeAlso: AccessCheckoutCvcOnlyValidationDelegate
  */
 public struct CvcOnlyValidationConfig: ValidationConfig {
     let cvcView: CvcView?
     let cvcTextField: UITextField?
-    let cvcUITextField:AccessCheckoutUITextField?
-    
+    let cvc: AccessCheckoutUITextField?
+
     let accessCheckoutUITextFieldMode: Bool
     let textFieldMode: Bool
     let validationDelegate: AccessCheckoutCvcOnlyValidationDelegate
@@ -28,49 +33,48 @@ public struct CvcOnlyValidationConfig: ValidationConfig {
     public static func builder() -> CvcOnlyValidationConfigBuilder {
         return CvcOnlyValidationConfigBuilder()
     }
-    
-    /**
-    Deprecated
-    Creates an instance of `CvcOnlyValidationConfig`
 
-    - Parameter cvcView: `CvcView` that represents the cvc ui element
-    - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
-    */
+    /**
+     Deprecated
+     Creates an instance of `CvcOnlyValidationConfig`
+
+     - Parameter cvcView: `CvcView` that represents the cvc ui element
+     - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
+     */
     @available(*, deprecated, message: "Using CvcView to initialize the validation is deprecated and will not be supported on future major versions of the SDK. A `UITextField` should be used instead.")
     public init(cvcView: CvcView, validationDelegate: AccessCheckoutCvcOnlyValidationDelegate) {
         self.cvcView = cvcView
         self.validationDelegate = validationDelegate
         self.cvcTextField = nil
-        self.cvcUITextField = nil
+        self.cvc = nil
         self.textFieldMode = false
         self.accessCheckoutUITextFieldMode = false
     }
-    
-    /**
-    Creates an instance of `CvcOnlyValidationConfig`
 
-    - Parameter cvcView: `UITextField` that represents the cvc ui element
-    - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
-    */
+    /**
+     Creates an instance of `CvcOnlyValidationConfig`
+
+     - Parameter cvcTextField: `UITextField` that represents the cvc ui element
+     - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
+     */
     @available(*, deprecated, message: "This constructor is deprecated and will not be supported on future major versions of the SDK. Instead, use the static `builder()` method to get an instance of a `CvcOnlyValidationConfigBuilder` to create your `CvcOnlyValidationConfig`.")
     public init(cvcTextField: UITextField, validationDelegate: AccessCheckoutCvcOnlyValidationDelegate) {
         self.cvcTextField = cvcTextField
         self.validationDelegate = validationDelegate
         self.cvcView = nil
-        self.cvcUITextField = nil
+        self.cvc = nil
         self.textFieldMode = true
         self.accessCheckoutUITextFieldMode = false
     }
-    
-    /**
-    Creates an instance of `CvcOnlyValidationConfig`
 
-    - Parameter cvcView: `AccessCheckoutUITextField` that represents the cvc ui element
-    - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
-    */
-    @available(*, deprecated, message: "This constructor is deprecated and will not be supported on future major versions of the SDK. Instead, use the static `builder()` method to get an instance of a `CvcOnlyValidationConfigBuilder` to create your `CvcOnlyValidationConfig`.")
-    public init(cvcUITextField: AccessCheckoutUITextField, validationDelegate: AccessCheckoutCvcOnlyValidationDelegate) {
-        self.cvcUITextField = cvcUITextField
+    /**
+     Creates an instance of `CvcOnlyValidationConfig`
+
+     - Parameter cvc: `AccessCheckoutUITextField` that represents the cvc ui element
+     - Parameter validationDelegate: `AccessCheckoutCvcOnlyValidationDelegate` that represents the validation events listener
+     */
+    internal init(cvc: AccessCheckoutUITextField, validationDelegate: AccessCheckoutCvcOnlyValidationDelegate) {
+        self.cvc = cvc
         self.validationDelegate = validationDelegate
         self.cvcView = nil
         self.cvcTextField = nil
@@ -91,14 +95,16 @@ public class CvcOnlyValidationConfigBuilder {
     fileprivate init() {}
 
     /**
-     - Parameter cvc: `UITextField` that represents the cvc ui element
-     - Returns: the same instance of the builder
-     */
-    public func cvcLegacy(_ cvc: UITextField) -> CvcOnlyValidationConfigBuilder {
-        self.cvcLegacy = cvc
+     Deprecated
+      - Parameter cvc: `UITextField` that represents the cvc ui element
+      - Returns: the same instance of the builder
+      */
+    @available(*, deprecated, message: "This method is deprecated and will not be supported on future major versions of the SDK. `cvc(AccessCheckoutUITextField)` should be used instead.")
+    public func cvc(_ cvc: UITextField) -> CvcOnlyValidationConfigBuilder {
+        cvcLegacy = cvc
         return self
     }
-    
+
     /**
      - Parameter cvc: `AccessCheckoutUITextField` that represents the cvc ui element
      - Returns: the same instance of the builder
@@ -123,14 +129,16 @@ public class CvcOnlyValidationConfigBuilder {
      - Throws: an `AccessCheckoutIllegalArgumentError` if either the cvc or validationDelegate have not been specified
      */
     public func build() throws -> CvcOnlyValidationConfig {
-        guard let cvc = cvc else {
+        if cvc == nil && cvcLegacy == nil {
             throw AccessCheckoutIllegalArgumentError.missingCvc()
         }
         guard let validationDelegate = validationDelegate else {
             throw AccessCheckoutIllegalArgumentError.missingValidationDelegate()
         }
 
-        return CvcOnlyValidationConfig(cvcUITextField: cvc, validationDelegate: validationDelegate)
+        if let cvc = cvc {
+            return CvcOnlyValidationConfig(cvc: cvc, validationDelegate: validationDelegate)
+        }
+        return CvcOnlyValidationConfig(cvcTextField: cvcLegacy!, validationDelegate: validationDelegate)
     }
 }
-

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+@IBDesignable public class AccessCheckoutUITextField: UIView {
+    @IBOutlet internal var uiTextField: UITextField! = UITextField()
+
+    internal var text: String? {
+        set { self.uiTextField.text = newValue }
+        get { self.uiTextField.text }
+    }
+    
+    internal var delegate: UITextFieldDelegate? {
+        set { self.uiTextField.delegate = newValue }
+        get { self.uiTextField.delegate }
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
@@ -1,8 +1,34 @@
 import UIKit
 
 @IBDesignable public class AccessCheckoutUITextField: UIView {
-    @IBOutlet internal var uiTextField: UITextField! = UITextField()
+    @IBOutlet internal var uiTextField: UITextField!
 
+    init() {
+        super.init(coder: NSCoder())!
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        initSubViews()
+    }
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        initSubViews()
+    }
+    
+    private func initSubViews() {
+        let bundle = Bundle(for: type(of: self))
+        let nib = UINib(nibName: String(describing: type(of: self)), bundle: bundle)
+        let view = nib.instantiate(withOwner: self, options: nil).first as! UIView
+        view.frame = bounds
+        view.autoresizingMask = [
+            UIView.AutoresizingMask.flexibleWidth,
+            UIView.AutoresizingMask.flexibleHeight
+        ]
+        addSubview(view)
+    }
+    
     internal var text: String? {
         set { self.uiTextField.text = newValue }
         get { self.uiTextField.text }
@@ -11,5 +37,72 @@ import UIKit
     internal var delegate: UITextFieldDelegate? {
         set { self.uiTextField.delegate = newValue }
         get { self.uiTextField.delegate }
+    }
+    
+    public var placeholder: String? {
+        set { self.uiTextField.placeholder = newValue }
+        get { self.uiTextField.placeholder }
+    }
+    
+    public var textColor: UIColor? {
+        set { self.uiTextField.textColor = newValue }
+        get { self.uiTextField.textColor }
+    }
+    
+    public var selectedTextRange: UITextRange? {
+        set { self.uiTextField.selectedTextRange = newValue }
+        get { self.uiTextField.selectedTextRange }
+    }
+    
+    public func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
+        self.uiTextField.addTarget(target, action:action, for: controlEvents)
+    }
+
+    public func clear() {
+        self.uiTextField.text = ""
+    }
+    
+    public func offset(from: UITextPosition, to: UITextPosition) -> Int {
+        return self.uiTextField.offset(from: from, to: to)
+    }
+    
+    /* The end and beginning of the the text document. */
+    @available(iOS 3.2, *)
+    public var beginningOfDocument: UITextPosition {
+        get { self.uiTextField.beginningOfDocument }
+    }
+
+    @available(iOS 3.2, *)
+    public var endOfDocument: UITextPosition {
+        get { self.uiTextField.endOfDocument }
+    }
+    
+    /* Methods for creating ranges and positions. */
+    @available(iOS 3.2, *)
+    public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
+        return self.uiTextField.position(from: position, offset: offset)
+    }
+
+    @available(iOS 3.2, *)
+    public func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
+        return self.uiTextField.position(from: position, in:direction, offset: offset)
+    }
+    
+    @available(iOS 3.2, *)
+    public func textRange(from: UITextPosition, to: UITextPosition) -> UITextRange? {
+        return self.uiTextField.textRange(from: from, to: to)
+    }
+    
+    public func sendAction(_ action: Selector, to target: Any?, for event: UIEvent?) {
+        self.uiTextField.sendAction(action, to: target, for: event)
+    }
+    
+    @available(iOS 14.0, *)
+    public func sendAction(_ action: UIAction) {
+        self.uiTextField.sendAction(action)
+    }
+    
+    public func sendActions(for controlEvents: UIControl.Event) {
+        self.uiTextField.sendActions(for: controlEvents)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
@@ -4,7 +4,8 @@ import UIKit
     @IBOutlet internal var uiTextField: UITextField!
 
     init() {
-        super.init(coder: NSCoder())!
+        super.init(frame: CGRect())
+        initSubViews()
     }
 
     required init?(coder: NSCoder) {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
@@ -3,19 +3,24 @@ import UIKit
 @IBDesignable public class AccessCheckoutUITextField: UIView {
     @IBOutlet internal var uiTextField: UITextField!
 
+    internal init(_ uiTextField: UITextField) {
+        super.init(frame: CGRect())
+        self.uiTextField = uiTextField
+    }
+    
     init() {
         super.init(frame: CGRect())
-        initSubViews()
+        self.initSubViews()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        initSubViews()
+        self.initSubViews()
     }
     
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
-        initSubViews()
+        self.initSubViews()
     }
     
     private func initSubViews() {
@@ -56,7 +61,7 @@ import UIKit
     }
     
     public func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
-        self.uiTextField.addTarget(target, action:action, for: controlEvents)
+        self.uiTextField.addTarget(target, action: action, for: controlEvents)
     }
 
     public func clear() {
@@ -69,14 +74,10 @@ import UIKit
     
     /* The end and beginning of the the text document. */
     @available(iOS 3.2, *)
-    public var beginningOfDocument: UITextPosition {
-        get { self.uiTextField.beginningOfDocument }
-    }
+    public var beginningOfDocument: UITextPosition { self.uiTextField.beginningOfDocument }
 
     @available(iOS 3.2, *)
-    public var endOfDocument: UITextPosition {
-        get { self.uiTextField.endOfDocument }
-    }
+    public var endOfDocument: UITextPosition { self.uiTextField.endOfDocument }
     
     /* Methods for creating ranges and positions. */
     @available(iOS 3.2, *)
@@ -86,7 +87,7 @@ import UIKit
 
     @available(iOS 3.2, *)
     public func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
-        return self.uiTextField.position(from: position, in:direction, offset: offset)
+        return self.uiTextField.position(from: position, in: direction, offset: offset)
     }
     
     @available(iOS 3.2, *)

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.swift
@@ -32,7 +32,27 @@ import UIKit
             UIView.AutoresizingMask.flexibleWidth,
             UIView.AutoresizingMask.flexibleHeight
         ]
+        
         addSubview(view)
+    }
+    
+    override public func becomeFirstResponder() -> Bool {
+        self.uiTextField.becomeFirstResponder()
+    }
+
+    override public var isAccessibilityElement: Bool {
+        set { self.uiTextField.isAccessibilityElement = newValue }
+        get { false }
+    }
+    
+    override public var accessibilityIdentifier: String? {
+        set { self.uiTextField.accessibilityIdentifier = newValue }
+        get { nil }
+    }
+    
+    override public var accessibilityLabel: String? {
+        set { self.uiTextField.accessibilityLabel = newValue }
+        get { nil }
     }
     
     internal var text: String? {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.xib
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK" customModuleProvider="target">
             <connections>
-                <outlet property="uiTextField" destination="WFy-n5-QRw" id="BPv-JU-ysC"/>
+                <outlet property="uiTextField" destination="WFy-n5-QRw" id="N4E-nX-tdR"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.xib
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/components/AccessCheckoutUITextField.xib
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AccessCheckoutUITextField" customModule="AccessCheckoutSDK" customModuleProvider="target">
+            <connections>
+                <outlet property="uiTextField" destination="WFy-n5-QRw" id="BPv-JU-ysC"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="ZCR-IB-OP4">
+            <rect key="frame" x="0.0" y="0.0" width="412" height="133"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WFy-n5-QRw">
+                    <rect key="frame" x="8" y="4" width="396" height="125"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                </textField>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="WFy-n5-QRw" firstAttribute="top" secondItem="ZCR-IB-OP4" secondAttribute="top" constant="4" id="3CE-IV-Kv2"/>
+                <constraint firstItem="WFy-n5-QRw" firstAttribute="leading" secondItem="ZCR-IB-OP4" secondAttribute="leading" constant="8" id="Bnd-De-TvN"/>
+                <constraint firstAttribute="bottom" secondItem="WFy-n5-QRw" secondAttribute="bottom" constant="4" id="YvI-cx-YuA"/>
+                <constraint firstAttribute="trailing" secondItem="WFy-n5-QRw" secondAttribute="trailing" constant="8" id="bhf-gz-rXJ"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="76.811594202898561" y="-207.25446428571428"/>
+        </view>
+    </objects>
+</document>

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
@@ -5,9 +5,9 @@ class CardDetailsBuilderTests: XCTestCase {
     // MARK: tests covering SAQ-A compliant way of instiantiating card details
 
     func testBuildsCardDetailsUsingUITextFields() throws {
-        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
-        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/23"))
-        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
+        let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/23")
+        let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
         
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
@@ -22,10 +22,10 @@ class CardDetailsBuilderTests: XCTestCase {
     }
     
     func testBuildsCardDetailsUsingUITextFieldsWhenPanHasSpaces() throws {
-        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234 1234 1234 1234"))
-        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/23"))
-        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
-        
+        let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234 1234 1234 1234")
+        let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/23")
+        let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
+    
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
             .cvc(cvcUITextField)
@@ -39,9 +39,9 @@ class CardDetailsBuilderTests: XCTestCase {
     }
     
     func testBuildsCardDetailsUsingUITextFieldsWhenExpiryDateHasNoSlash() throws {
-        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
-        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1023"))
-        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
+        let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1023")
+        let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
         
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
@@ -56,7 +56,7 @@ class CardDetailsBuilderTests: XCTestCase {
     }
     
     func testBuildsCardDetailsUsingUITextFieldsWhenPassingOnlyUITextFieldForCvc() throws {
-        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
         let cardDetailsBuilder = CardDetailsBuilder().cvc(cvcUITextField)
         
         let cardDetails = try cardDetailsBuilder.build()
@@ -68,9 +68,9 @@ class CardDetailsBuilderTests: XCTestCase {
     }
     
     func testThrowsErrorWhenUsingUITextFieldsWhenExpiryDateIsInIncorrectFormat() throws {
-        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
-        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/2023"))
-        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
+        let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/2023")
+        let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
         
         let expectedMessage = "Expected expiry date in format MM/YY or MMYY but found 10/2023"
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
@@ -147,17 +147,12 @@ class CardDetailsBuilderTests: XCTestCase {
     
     // MARK: tests covering attempt to build an empty instance of card details
 
-    func testThrowsErrorWhenAttemptingToBuildEmptyCardDetails() throws {
-        let expectedMessage = "Cannot build an instance of CardDetails when pan, expiryDate and cvc are all nil"
-
-        XCTAssertThrowsError(try CardDetailsBuilder().build()) { error in
-            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
-        }
-    }
-    
-    private func createUiTextField(withText text: String) -> UITextField {
-        let uiTextField = UITextField()
-        uiTextField.text = text
-        return uiTextField
+    func testCanBuildEmptyCardDetails() throws {
+        let cardDetails = try CardDetailsBuilder().build()
+        
+        XCTAssertNil(cardDetails.pan)
+        XCTAssertNil(cardDetails.expiryMonth)
+        XCTAssertNil(cardDetails.expiryYear)
+        XCTAssertNil(cardDetails.cvc)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
@@ -2,7 +2,89 @@
 import XCTest
 
 class CardDetailsBuilderTests: XCTestCase {
-    func testBuildsCardDetailsWithPanCvcAndExpiryDateAndFormatsExpiryYearOn4Digits() throws {
+    // MARK: tests covering SAQ-A compliant way of instiantiating card details
+
+    func testBuildsCardDetailsUsingUITextFields() throws {
+        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
+        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/23"))
+        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        
+        let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+        
+        let cardDetails = try cardDetailsBuilder.build()
+        
+        XCTAssertEqual("1234123412341234", cardDetails.pan)
+        XCTAssertEqual(10, cardDetails.expiryMonth)
+        XCTAssertEqual(2023, cardDetails.expiryYear)
+        XCTAssertEqual("123", cardDetails.cvc)
+    }
+    
+    func testBuildsCardDetailsUsingUITextFieldsWhenPanHasSpaces() throws {
+        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234 1234 1234 1234"))
+        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/23"))
+        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        
+        let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+        
+        let cardDetails = try cardDetailsBuilder.build()
+        
+        XCTAssertEqual("1234123412341234", cardDetails.pan)
+        XCTAssertEqual(10, cardDetails.expiryMonth)
+        XCTAssertEqual(2023, cardDetails.expiryYear)
+        XCTAssertEqual("123", cardDetails.cvc)
+    }
+    
+    func testBuildsCardDetailsUsingUITextFieldsWhenExpiryDateHasNoSlash() throws {
+        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
+        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1023"))
+        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        
+        let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+        
+        let cardDetails = try cardDetailsBuilder.build()
+        
+        XCTAssertEqual("1234123412341234", cardDetails.pan)
+        XCTAssertEqual(10, cardDetails.expiryMonth)
+        XCTAssertEqual(2023, cardDetails.expiryYear)
+        XCTAssertEqual("123", cardDetails.cvc)
+    }
+    
+    func testBuildsCardDetailsUsingUITextFieldsWhenPassingOnlyUITextFieldForCvc() throws {
+        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        let cardDetailsBuilder = CardDetailsBuilder().cvc(cvcUITextField)
+        
+        let cardDetails = try cardDetailsBuilder.build()
+        
+        XCTAssertNil(cardDetails.pan)
+        XCTAssertNil(cardDetails.expiryMonth)
+        XCTAssertNil(cardDetails.expiryYear)
+        XCTAssertEqual("123", cardDetails.cvc)
+    }
+    
+    func testThrowsErrorWhenUsingUITextFieldsWhenExpiryDateIsInIncorrectFormat() throws {
+        let panUITextField = AccessCheckoutUITextField(createUiTextField(withText: "1234123412341234"))
+        let expiryDateUITextField = AccessCheckoutUITextField(createUiTextField(withText: "10/2023"))
+        let cvcUITextField = AccessCheckoutUITextField(createUiTextField(withText: "123"))
+        
+        let expectedMessage = "Expected expiry date in format MM/YY or MMYY but found 10/2023"
+        let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+        
+        XCTAssertThrowsError(try cardDetailsBuilder.build()) { error in
+            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
+        }
+    }
+    
+    // MARK: tests covering non SAQ-A compliant way of instiantiating card details
+
+    func testBuildsCardDetailsUsingStringValues() throws {
         let cardDetailsBuilder = CardDetailsBuilder().pan("1234123412341234")
             .expiryDate("10/23")
             .cvc("123")
@@ -15,20 +97,7 @@ class CardDetailsBuilderTests: XCTestCase {
         XCTAssertEqual("123", cardDetails.cvc)
     }
     
-    func testBuildsCardDetailsWithPanCvcAndAlternativeFormatForExpiryDateAndFormatsExpiryYearOn4Digits() throws {
-        let cardDetailsBuilder = CardDetailsBuilder().pan("1234123412341234")
-            .expiryDate("1023")
-            .cvc("123")
-        
-        let cardDetails = try cardDetailsBuilder.build()
-        
-        XCTAssertEqual("1234123412341234", cardDetails.pan)
-        XCTAssertEqual(10, cardDetails.expiryMonth)
-        XCTAssertEqual(2023, cardDetails.expiryYear)
-        XCTAssertEqual("123", cardDetails.cvc)
-    }
-    
-    func testBuildsCardDetailsWithPanWithSpacesCvcAndAlternativeFormatForExpiryDateAndFormatsExpiryYearOn4Digits() throws {
+    func testBuildsCardDetailsUsingStringValuesWhenPanHasSpaces() throws {
         let cardDetailsBuilder = CardDetailsBuilder().pan("1234 1234 1234 1234")
             .expiryDate("1023")
             .cvc("123")
@@ -41,18 +110,20 @@ class CardDetailsBuilderTests: XCTestCase {
         XCTAssertEqual("123", cardDetails.cvc)
     }
     
-    func testThrowsErrorWhenExpiryDateIsInIncorrectFormat() throws {
-        let expectedMessage = "Expected expiry date in format MM/YY or MMYY but found 102023"
+    func testBuildsCardDetailsUsingStringValuesWhenExpiryDateHasNoSlash() throws {
         let cardDetailsBuilder = CardDetailsBuilder().pan("1234123412341234")
-            .expiryDate("102023")
+            .expiryDate("1023")
             .cvc("123")
         
-        XCTAssertThrowsError(try cardDetailsBuilder.build()) { error in
-            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
-        }
+        let cardDetails = try cardDetailsBuilder.build()
+        
+        XCTAssertEqual("1234123412341234", cardDetails.pan)
+        XCTAssertEqual(10, cardDetails.expiryMonth)
+        XCTAssertEqual(2023, cardDetails.expiryYear)
+        XCTAssertEqual("123", cardDetails.cvc)
     }
     
-    func testBuildsCardDetailsWithJustACvc() throws {
+    func testBuildsCardDetailsUsingStringValuesWhenPassingOnlyStringValueForCvc() throws {
         let cardDetailsBuilder = CardDetailsBuilder().cvc("123")
         
         let cardDetails = try cardDetailsBuilder.build()
@@ -61,5 +132,32 @@ class CardDetailsBuilderTests: XCTestCase {
         XCTAssertNil(cardDetails.expiryMonth)
         XCTAssertNil(cardDetails.expiryYear)
         XCTAssertEqual("123", cardDetails.cvc)
+    }
+    
+    func testThrowsErrorWhenUsingStringValuesWhenExpiryDateIsInIncorrectFormat() throws {
+        let expectedMessage = "Expected expiry date in format MM/YY or MMYY but found 10/2023"
+        let cardDetailsBuilder = CardDetailsBuilder().pan("1234123412341234")
+            .expiryDate("10/2023")
+            .cvc("123")
+        
+        XCTAssertThrowsError(try cardDetailsBuilder.build()) { error in
+            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
+        }
+    }
+    
+    // MARK: tests covering attempt to build an empty instance of card details
+
+    func testThrowsErrorWhenAttemptingToBuildEmptyCardDetails() throws {
+        let expectedMessage = "Cannot build an instance of CardDetails when pan, expiryDate and cvc are all nil"
+
+        XCTAssertThrowsError(try CardDetailsBuilder().build()) { error in
+            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
+        }
+    }
+    
+    private func createUiTextField(withText text: String) -> UITextField {
+        let uiTextField = UITextField()
+        uiTextField.text = text
+        return uiTextField
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
@@ -102,12 +102,10 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
     }
     
     func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormattingForLegacyUITextField() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
         let config = try! CardValidationConfig.builder()
-            .panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+            .pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(baseUrl)
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
@@ -61,6 +61,10 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
     let cvcTextField = UITextField()
     let expiryDateTextField = UITextField()
     
+    let panUITextField = AccessCheckoutUITextField()
+    let cvcUITextField = AccessCheckoutUITextField()
+    let expiryDateUITextField = AccessCheckoutUITextField()
+    
     func testInitialisationForCardPaymentFlowWithTextFieldsRetrievesConfiguration() {
         let validationConfig = CardValidationConfig(panTextField: panTextField,
                                                     expiryDateTextField: expiryDateTextField,
@@ -97,11 +101,11 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
         XCTAssertTrue(cvcTextField.delegate is CvcViewPresenter)
     }
     
-    func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormatting() {
+    func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormattingForLegacyUITextField() {
         let config = try! CardValidationConfig.builder()
-            .pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+            .panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(baseUrl)
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])
@@ -113,5 +117,23 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
         XCTAssertTrue(panTextField.delegate is PanViewPresenter)
         XCTAssertTrue(expiryDateTextField.delegate is ExpiryDateViewPresenter)
         XCTAssertTrue(cvcTextField.delegate is CvcViewPresenter)
+    }
+    
+    func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormatting() {
+        let config = try! CardValidationConfig.builder()
+            .pan(panUITextField)
+            .expiryDate(expiryDateUITextField)
+            .cvc(cvcUITextField)
+            .accessBaseUrl(baseUrl)
+            .validationDelegate(cardValidationDelegateMock)
+            .acceptedCardBrands(["amex", "visa"])
+            .enablePanFormatting()
+            .build()
+        
+        accessCheckoutValidationInitialiser!.initialise(config)
+        
+        XCTAssertTrue(panUITextField.uiTextField.delegate is PanViewPresenter)
+        XCTAssertTrue(expiryDateUITextField.uiTextField.delegate is ExpiryDateViewPresenter)
+        XCTAssertTrue(cvcUITextField.uiTextField.delegate is CvcViewPresenter)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
@@ -101,7 +101,9 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
         XCTAssertTrue(cvcTextField.delegate is CvcViewPresenter)
     }
     
-    func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormattingForLegacyUITextField() {
+    func testInitialisationWithBuilderForCardPaymentFlowSetsCorrectConfigAndCanEnableFormattingForLegacyUITextField() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! CardValidationConfig.builder()
             .panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
@@ -10,7 +10,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     private let validationDelegate = MockAccessCheckoutCardValidationDelegate()
     private let acceptedCardBrands = ["visa", "amex"]
 
-    func testConfigWithHasFormattingNotEnabledByDefault() {
+    func testConfigWithHasFormattingNotEnabledByDefault() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
@@ -21,7 +23,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
         XCTAssertFalse(config.panFormattingEnabled)
     }
 
-    func testCanCreateConfigWithPanFormattingEnabled() {
+    func testCanCreateConfigWithPanFormattingEnabled() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
@@ -33,7 +37,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
         XCTAssertTrue(config.panFormattingEnabled)
     }
 
-    func testCanCreateConfigWithoutAcceptedCardBrands() {
+    func testCanCreateConfigWithoutAcceptedCardBrands() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
@@ -49,7 +55,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
         XCTAssertEqual([], config.acceptedCardBrands)
     }
 
-    func testCanCreateConfigWithAcceptedCardBrands() {
+    func testCanCreateConfigWithAcceptedCardBrands() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
@@ -67,6 +75,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenPanIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
@@ -80,6 +90,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenExpiryDateIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.panLegacy(panTextField)
             .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
@@ -93,6 +105,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .accessBaseUrl(accessBaseUrl)
@@ -106,6 +120,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenAccessBaseUrlIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)
@@ -119,6 +135,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.panLegacy(panTextField)
             .expiryDateLegacy(expiryDateTextField)
             .cvcLegacy(cvcTextField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
@@ -11,11 +11,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     private let acceptedCardBrands = ["visa", "amex"]
 
     func testConfigWithHasFormattingNotEnabledByDefault() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        let config = try! builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        let config = try! builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .build()
@@ -24,11 +22,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithPanFormattingEnabled() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        let config = try! builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        let config = try! builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .enablePanFormatting()
@@ -38,11 +34,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithoutAcceptedCardBrands() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        let config = try! builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        let config = try! builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .build()
@@ -56,11 +50,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithAcceptedCardBrands() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        let config = try! builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        let config = try! builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -75,10 +67,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenPanIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        _ = builder.expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -90,10 +80,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenExpiryDateIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.panLegacy(panTextField)
-            .cvcLegacy(cvcTextField)
+        _ = builder.pan(panTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -105,10 +93,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
+        _ = builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -120,11 +106,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenAccessBaseUrlIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        _ = builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
         let expectedMessage = "Expected base url to be provided but was not"
@@ -135,11 +119,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.panLegacy(panTextField)
-            .expiryDateLegacy(expiryDateTextField)
-            .cvcLegacy(cvcTextField)
+        _ = builder.pan(panTextField)
+            .expiryDate(expiryDateTextField)
+            .cvc(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .acceptedCardBrands(acceptedCardBrands)
         let expectedMessage = "Expected validation delegate to be provided but was not"

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
@@ -11,9 +11,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     private let acceptedCardBrands = ["visa", "amex"]
 
     func testConfigWithHasFormattingNotEnabledByDefault() {
-        let config = try! builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        let config = try! builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .build()
@@ -22,9 +22,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithPanFormattingEnabled() {
-        let config = try! builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        let config = try! builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .enablePanFormatting()
@@ -34,9 +34,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithoutAcceptedCardBrands() {
-        let config = try! builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        let config = try! builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .build()
@@ -50,9 +50,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithAcceptedCardBrands() {
-        let config = try! builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        let config = try! builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -67,8 +67,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenPanIsNotSpecified() throws {
-        _ = builder.expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        _ = builder.expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -80,8 +80,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenExpiryDateIsNotSpecified() throws {
-        _ = builder.pan(panTextField)
-            .cvc(cvcTextField)
+        _ = builder.panLegacy(panTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -93,8 +93,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
-        _ = builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
+        _ = builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
@@ -106,9 +106,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenAccessBaseUrlIsNotSpecified() throws {
-        _ = builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        _ = builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
         let expectedMessage = "Expected base url to be provided but was not"
@@ -119,9 +119,9 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
-        _ = builder.pan(panTextField)
-            .expiryDate(expiryDateTextField)
-            .cvc(cvcTextField)
+        _ = builder.panLegacy(panTextField)
+            .expiryDateLegacy(expiryDateTextField)
+            .cvcLegacy(cvcTextField)
             .accessBaseUrl(accessBaseUrl)
             .acceptedCardBrands(acceptedCardBrands)
         let expectedMessage = "Expected validation delegate to be provided but was not"

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigConstructorLegacyTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigConstructorLegacyTests.swift
@@ -1,30 +1,29 @@
 @testable import AccessCheckoutSDK
 import XCTest
 
-class CardValidationConfigConstructorTests: XCTestCase {
+class CardValidationConfigConstructorLegacyTests: XCTestCase {
     private let builder = CardValidationConfig.builder()
-    private let panUITextField = AccessCheckoutUITextField()
-    private let expiryDateUITextField = AccessCheckoutUITextField()
-    private let cvcUITextField = AccessCheckoutUITextField()
+    private let panTextField = UITextField()
+    private let expiryDateTextField = UITextField()
+    private let cvcTextField = UITextField()
     private let accessBaseUrl = "some-url"
     private let validationDelegate = MockAccessCheckoutCardValidationDelegate()
     private let acceptedCardBrands = ["visa", "amex"]
 
     func testShouldSetTextFieldModeToTrueIfInitWithUITextFields() {
-        let cardValidationConfig = CardValidationConfig(panUITextField: panUITextField,
-                                                        expiryDateUITextField: expiryDateUITextField,
-                                                        cvcUITextField: cvcUITextField,
+        let cardValidationConfig = CardValidationConfig(panTextField: panTextField,
+                                                        expiryDateTextField: expiryDateTextField,
+                                                        cvcTextField: cvcTextField,
                                                         accessBaseUrl: "some-url",
                                                         validationDelegate: validationDelegate)
 
-        XCTAssertFalse(cardValidationConfig.textFieldMode)
-        XCTAssertTrue(cardValidationConfig.accessCheckoutUITextFieldMode)
+        XCTAssertTrue(cardValidationConfig.textFieldMode)
     }
 
     func testConfigWithHasFormattingNotEnabledByDefault() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(panTextField: panTextField,
+                                          expiryDateTextField: expiryDateTextField,
+                                          cvcTextField: cvcTextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate)
 
@@ -32,9 +31,9 @@ class CardValidationConfigConstructorTests: XCTestCase {
     }
 
     func testCanCreateConfigWithPanFormattingEnabled() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(panTextField: panTextField,
+                                          expiryDateTextField: expiryDateTextField,
+                                          cvcTextField: cvcTextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate,
                                           panFormattingEnabled: true)
@@ -43,31 +42,31 @@ class CardValidationConfigConstructorTests: XCTestCase {
     }
 
     func testCanCreateConfigWithoutAcceptedCardBrands() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(panTextField: panTextField,
+                                          expiryDateTextField: expiryDateTextField,
+                                          cvcTextField: cvcTextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate)
 
-        XCTAssertEqual(panUITextField, config.panUITextField)
-        XCTAssertEqual(expiryDateUITextField, config.expiryDateUITextField)
-        XCTAssertEqual(cvcUITextField, config.cvcUITextField)
+        XCTAssertEqual(panTextField, config.panTextField)
+        XCTAssertEqual(expiryDateTextField, config.expiryDateTextField)
+        XCTAssertEqual(cvcTextField, config.cvcTextField)
         XCTAssertEqual(accessBaseUrl, config.accessBaseUrl)
         XCTAssertTrue(config.validationDelegate is MockAccessCheckoutCardValidationDelegate)
         XCTAssertEqual([], config.acceptedCardBrands)
     }
 
     func testCanCreateConfigWithAcceptedCardBrands() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(panTextField: panTextField,
+                                          expiryDateTextField: expiryDateTextField,
+                                          cvcTextField: cvcTextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate,
                                           acceptedCardBrands: acceptedCardBrands)
 
-        XCTAssertEqual(panUITextField, config.panUITextField)
-        XCTAssertEqual(expiryDateUITextField, config.expiryDateUITextField)
-        XCTAssertEqual(cvcUITextField, config.cvcUITextField)
+        XCTAssertEqual(panTextField, config.panTextField)
+        XCTAssertEqual(expiryDateTextField, config.expiryDateTextField)
+        XCTAssertEqual(cvcTextField, config.cvcTextField)
         XCTAssertEqual(accessBaseUrl, config.accessBaseUrl)
         XCTAssertTrue(config.validationDelegate is MockAccessCheckoutCardValidationDelegate)
         XCTAssertEqual(acceptedCardBrands, config.acceptedCardBrands)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigConstructorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigConstructorTests.swift
@@ -11,9 +11,9 @@ class CardValidationConfigConstructorTests: XCTestCase {
     private let acceptedCardBrands = ["visa", "amex"]
 
     func testShouldSetTextFieldModeToTrueIfInitWithUITextFields() {
-        let cardValidationConfig = CardValidationConfig(panUITextField: panUITextField,
-                                                        expiryDateUITextField: expiryDateUITextField,
-                                                        cvcUITextField: cvcUITextField,
+        let cardValidationConfig = CardValidationConfig(pan: panUITextField,
+                                                        expiryDate: expiryDateUITextField,
+                                                        cvc: cvcUITextField,
                                                         accessBaseUrl: "some-url",
                                                         validationDelegate: validationDelegate)
 
@@ -22,9 +22,9 @@ class CardValidationConfigConstructorTests: XCTestCase {
     }
 
     func testConfigWithHasFormattingNotEnabledByDefault() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(pan: panUITextField,
+                                          expiryDate: expiryDateUITextField,
+                                          cvc: cvcUITextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate)
 
@@ -32,9 +32,9 @@ class CardValidationConfigConstructorTests: XCTestCase {
     }
 
     func testCanCreateConfigWithPanFormattingEnabled() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(pan: panUITextField,
+                                          expiryDate: expiryDateUITextField,
+                                          cvc: cvcUITextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate,
                                           panFormattingEnabled: true)
@@ -43,31 +43,31 @@ class CardValidationConfigConstructorTests: XCTestCase {
     }
 
     func testCanCreateConfigWithoutAcceptedCardBrands() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(pan: panUITextField,
+                                          expiryDate: expiryDateUITextField,
+                                          cvc: cvcUITextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate)
 
-        XCTAssertEqual(panUITextField, config.panUITextField)
-        XCTAssertEqual(expiryDateUITextField, config.expiryDateUITextField)
-        XCTAssertEqual(cvcUITextField, config.cvcUITextField)
+        XCTAssertEqual(panUITextField, config.pan)
+        XCTAssertEqual(expiryDateUITextField, config.expiryDate)
+        XCTAssertEqual(cvcUITextField, config.cvc)
         XCTAssertEqual(accessBaseUrl, config.accessBaseUrl)
         XCTAssertTrue(config.validationDelegate is MockAccessCheckoutCardValidationDelegate)
         XCTAssertEqual([], config.acceptedCardBrands)
     }
 
     func testCanCreateConfigWithAcceptedCardBrands() {
-        let config = CardValidationConfig(panUITextField: panUITextField,
-                                          expiryDateUITextField: expiryDateUITextField,
-                                          cvcUITextField: cvcUITextField,
+        let config = CardValidationConfig(pan: panUITextField,
+                                          expiryDate: expiryDateUITextField,
+                                          cvc: cvcUITextField,
                                           accessBaseUrl: accessBaseUrl,
                                           validationDelegate: validationDelegate,
                                           acceptedCardBrands: acceptedCardBrands)
 
-        XCTAssertEqual(panUITextField, config.panUITextField)
-        XCTAssertEqual(expiryDateUITextField, config.expiryDateUITextField)
-        XCTAssertEqual(cvcUITextField, config.cvcUITextField)
+        XCTAssertEqual(panUITextField, config.pan)
+        XCTAssertEqual(expiryDateUITextField, config.expiryDate)
+        XCTAssertEqual(cvcUITextField, config.cvc)
         XCTAssertEqual(accessBaseUrl, config.accessBaseUrl)
         XCTAssertTrue(config.validationDelegate is MockAccessCheckoutCardValidationDelegate)
         XCTAssertEqual(acceptedCardBrands, config.acceptedCardBrands)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
@@ -6,7 +6,9 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     private let cvcTextField = UITextField()
     private let validationDelegate = MockAccessCheckoutCvcOnlyValidationDelegate()
 
-    func testCanCreateConfig() {
+    func testCanCreateConfig() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         let config = try! CvcOnlyValidationConfig.builder()
             .cvcLegacy(cvcTextField)
             .validationDelegate(validationDelegate)
@@ -17,6 +19,8 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.validationDelegate(validationDelegate)
         let expectedMessage = "Expected cvc to be provided but was not"
 
@@ -26,6 +30,8 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
+        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
+        
         _ = builder.cvcLegacy(cvcTextField)
         let expectedMessage = "Expected validation delegate to be provided but was not"
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
@@ -8,7 +8,7 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
 
     func testCanCreateConfig() {
         let config = try! CvcOnlyValidationConfig.builder()
-            .cvc(cvcTextField)
+            .cvcLegacy(cvcTextField)
             .validationDelegate(validationDelegate)
             .build()
 
@@ -26,7 +26,7 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
-        _ = builder.cvc(cvcTextField)
+        _ = builder.cvcLegacy(cvcTextField)
         let expectedMessage = "Expected validation delegate to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
@@ -7,10 +7,8 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     private let validationDelegate = MockAccessCheckoutCvcOnlyValidationDelegate()
 
     func testCanCreateConfig() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
         let config = try! CvcOnlyValidationConfig.builder()
-            .cvcLegacy(cvcTextField)
+            .cvc(cvcTextField)
             .validationDelegate(validationDelegate)
             .build()
 
@@ -19,8 +17,6 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
         _ = builder.validationDelegate(validationDelegate)
         let expectedMessage = "Expected cvc to be provided but was not"
 
@@ -30,9 +26,7 @@ class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
-        throw XCTSkip("Skipping this test because it is testing soon to be legacy code")
-        
-        _ = builder.cvcLegacy(cvcTextField)
+        _ = builder.cvc(cvcTextField)
         let expectedMessage = "Expected validation delegate to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionHandlerDispatcherTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionHandlerDispatcherTests.swift
@@ -5,7 +5,11 @@ import XCTest
 class RetrieveSessionHandlerDispatcherTests: XCTestCase {
     let merchantId = "123"
     let baseUrl = "some-url"
-    let cardDetails = try! CardDetailsBuilder().build()
+    
+    let cardDetails = try! CardDetailsBuilder()
+        .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
+        .build()
+    
     let paymentsCvcSessionHandler = PaymentsCvcRetrieveSessionHandlerMock()
     let verifiedTokensSessionHandler = VerifiedTokensRetrieveSessionHandlerMock()
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
@@ -3,9 +3,9 @@ import Cuckoo
 import XCTest
 
 class AcceptanceTestSuite: XCTestCase {
-    let panTextField = UITextField()
-    let expiryDateTextField = UITextField()
-    let cvcTextField = UITextField()
+    let panTextField = AccessCheckoutUITextField()
+    let expiryDateTextField = AccessCheckoutUITextField()
+    let cvcTextField = AccessCheckoutUITextField()
     
     func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedCardBrands: [String] = []) -> MockAccessCheckoutCardValidationDelegate {
         return initialiseCardValidation(cardBrands: cardBrands, acceptedBrands: acceptedCardBrands, panTextField, expiryDateTextField, cvcTextField)
@@ -15,7 +15,10 @@ class AcceptanceTestSuite: XCTestCase {
         return initialiseCardValidation(cardBrands: [TestFixtures.visaBrand(), TestFixtures.maestroBrand()], acceptedBrands: [], panTextField, expiryDateTextField, cvcTextField)
     }
     
-    func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedBrands: [String], _ panTextField: UITextField, _ expiryDateTextField: UITextField, _ cvcTextField: UITextField) -> MockAccessCheckoutCardValidationDelegate {
+    func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedBrands: [String],
+                                  _ panTextField: AccessCheckoutUITextField,
+                                  _ expiryDateTextField: AccessCheckoutUITextField,
+                                  _ cvcTextField: AccessCheckoutUITextField) -> MockAccessCheckoutCardValidationDelegate {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
@@ -65,7 +68,7 @@ class AcceptanceTestSuite: XCTestCase {
     
     func editPan(text: String) {
         panTextField.text = text
-        (panTextField.delegate as! Presenter).textFieldEditingChanged(panTextField)
+        (panTextField.delegate as! Presenter).textFieldEditingChanged(panTextField.uiTextField)
     }
     
     func clearPan() {
@@ -73,22 +76,22 @@ class AcceptanceTestSuite: XCTestCase {
     }
     
     func removeFocusFromPan() {
-        (panTextField.delegate!).textFieldDidEndEditing!(panTextField)
+        (panTextField.delegate!).textFieldDidEndEditing!(panTextField.uiTextField)
     }
     
     func canEnterPan(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
         
-        return (panTextField.delegate!).textField!(panTextField, shouldChangeCharactersIn: range, replacementString: text)
+        return (panTextField.delegate!).textField!(panTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
     
     func editExpiryDate(text: String) {
         expiryDateTextField.text = text
-        (expiryDateTextField.delegate as! Presenter).textFieldEditingChanged(expiryDateTextField)
+        (expiryDateTextField.delegate as! Presenter).textFieldEditingChanged(expiryDateTextField.uiTextField)
     }
     
     func removeFocusFromExpiryDate() {
-        (expiryDateTextField.delegate!).textFieldDidEndEditing!(expiryDateTextField)
+        (expiryDateTextField.delegate!).textFieldDidEndEditing!(expiryDateTextField.uiTextField)
     }
     
     func clearExpiryDate() {
@@ -98,12 +101,12 @@ class AcceptanceTestSuite: XCTestCase {
     func canEnterExpiryDate(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
         
-        return (expiryDateTextField.delegate!).textField!(expiryDateTextField, shouldChangeCharactersIn: range, replacementString: text)
+        return (expiryDateTextField.delegate!).textField!(expiryDateTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
     
     func editCvc(text: String) {
         cvcTextField.text = text
-        (cvcTextField.delegate as! Presenter).textFieldEditingChanged(cvcTextField)
+        (cvcTextField.delegate as! Presenter).textFieldEditingChanged(cvcTextField.uiTextField)
     }
     
     func clearCvc() {
@@ -111,13 +114,13 @@ class AcceptanceTestSuite: XCTestCase {
     }
     
     func removeFocusFromCvc() {
-        (cvcTextField.delegate!).textFieldDidEndEditing!(cvcTextField)
+        (cvcTextField.delegate!).textFieldDidEndEditing!(cvcTextField.uiTextField)
     }
     
     func canEnterCvc(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
         
-        return (cvcTextField.delegate!).textField!(cvcTextField, shouldChangeCharactersIn: range, replacementString: text)
+        return (cvcTextField.delegate!).textField!(cvcTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
     
     private func createConfiguration(brands: [CardBrandModel], acceptedBrands: [String]) -> CardBrandsConfiguration {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/UIUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/UIUtils.swift
@@ -1,0 +1,10 @@
+@testable import AccessCheckoutSDK
+import UIKit
+
+struct UIUtils {
+    static func createAccessCheckoutUITextField(withText text: String) -> AccessCheckoutUITextField {
+        let uiTextField = UITextField()
+        uiTextField.text = text
+        return AccessCheckoutUITextField(uiTextField)
+    }
+}


### PR DESCRIPTION
## What
- Add new UI component designed to ensure merchants are not exposed directly to Payment Card Data
- Add support in validation and generation features for this new UI component alongside existing ways of integrating our SDK

## Why
- This change is to allow merchants to integrate our SDK in a PCI SAQ-A compliant way, ensuring that they don't manipulate directly Payment Card Data

## How
- Create a new AccessCheckoutUITextField component with all properties and methods related to text kept internal to the SDK. This component wraps a private UITextField
- Enhance AccessCheckoutValidationInitialiser to support wiring validation with new UI component
- Change CardDetails to be a class with internal properties for the pan, expiry date and cvc, all empty
- the CardDetailsBuilder has been changed to cater for creating sub classes of CardDetails either by passing text values directly, or by passing references of AccessCheckoutUITextField which the builder extracts text from (SAQ-A compliant way)
