### PR TITLE
US1752077: fix for a failing unit test and remove virtual devices tests from primary flow

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
@@ -154,13 +154,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		1BD0EE9E22CBB59400147A71 /* Stubs */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Stubs;
-			sourceTree = "<group>";
-		};
 		512907EF2AEC0432008A7357 /* stubs */ = {
 			isa = PBXGroup;
 			children = (
@@ -224,7 +217,6 @@
 		C9AFE3F822B799AC00943B3E /* AccessCheckoutDemo */ = {
 			isa = PBXGroup;
 			children = (
-				1BD0EE9E22CBB59400147A71 /* Stubs */,
 				E7A09297243CB24100BCABC8 /* AlertView.swift */,
 				C9AFE46C22B7C5A600943B3E /* AppDelegate.swift */,
 				C9AFE46D22B7C5A600943B3E /* CardFlowViewController.swift */,

--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/xcshareddata/xcschemes/AccessCheckoutDemo.xcscheme
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/xcshareddata/xcschemes/AccessCheckoutDemo.xcscheme
@@ -75,7 +75,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-enableStubs true"
+            argument = "-enableStubs false"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -101,7 +101,7 @@
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/AccessCheckoutDemo/AccessCheckoutDemo/AppDelegate.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/AppDelegate.swift
@@ -3,16 +3,20 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    let stubServicesBaseUrl = "http://localhost:8123"
+    
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Configuration.accessBaseUrl = Bundle.main.infoDictionary?["AccessBaseURL"] as! String
+
         if let enableStubsArgumentValue = UserDefaults.standard.string(forKey: "enableStubs") {
             if (enableStubsArgumentValue as NSString).boolValue {
-                Configuration.accessBaseUrl = "http://localhost:8123"
+                Configuration.accessBaseUrl = stubServicesBaseUrl
             }
         }
 
+        NSLog("Application will use base URL \(Configuration.accessBaseUrl)")
         return true
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
@@ -138,7 +138,7 @@ class AccessCheckoutClientTests: XCTestCase {
             expectationToFulfill.fulfill()
         }
         
-        wait(for: [expectationToFulfill], timeout: 5)
+        wait(for: [expectationToFulfill], timeout: 10)
     }
     
     func testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndBothServicesRespondWithAnError() throws {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,11 +8,11 @@ workflows:
     - build-router-start:
         inputs:
           - workflows: |-
-              spm-support
+              ui-tests-ios-13
               sdk-ui-tests-ios-13
+              spm-support
               sdk-ui-tests-ios-14
               sdk-ui-tests-ios-15
-              ui-tests-ios-13
               ui-tests-ios-14
               ui-tests-ios-15
           - access_token: "$BITRISE_PERSONAL_ACCESS_TOKEN_PARALLEL_BUILDS"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,11 +49,6 @@ workflows:
         inputs:
         - scheme: "$DEMO_SCHEME"
         - project_path: "$DEMO_PROJECT_PATH"
-    - virtual-device-testing-for-ios:
-        inputs:
-        - test_devices: |-
-            iphone8,15.7,en,portrait
-        - test_timeout: 2700
     - script:
         title: "Add version number to env variables"
         inputs:


### PR DESCRIPTION
## What
- fix unit test failing due to insufficient timeout
- remove virtual device test step from primary flow because the same tests (demo ui tests) already run against the same version of iOS in one of the children builds
- optimise order of children builds triggered by primary flow to save a few minutes