### PR TITLE
US1776564: change AccessCheckoutUITextField.accessibilityIdentifier so it sets id on itself plus another id using a naming convention on the child UITextField

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
@@ -6,7 +6,7 @@ class CardFlowViewPageObject {
     private let app: XCUIApplication
 
     var panField: XCUIElement {
-        return app.textFields["pan"]
+        return app.otherElements["pan"].textFields.firstMatch
     }
 
     var panText: String? {
@@ -18,11 +18,11 @@ class CardFlowViewPageObject {
     }
 
     var expiryDateField: XCUIElement {
-        return app.textFields["expiryDate"]
+        return app.otherElements["expiryDate"].textFields.firstMatch
     }
 
     var cvcField: XCUIElement {
-        return app.textFields["cvc"]
+        return app.otherElements["cvc"].textFields.firstMatch
     }
 
     var cvcText: String? {

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CvcFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CvcFlowViewPageObject.swift
@@ -5,7 +5,7 @@ class CvcFlowViewPageObject {
     private let app: XCUIApplication
 
     var cvcField: XCUIElement {
-        return app.textFields["cvc"]
+        return app.otherElements["cvc"].textFields.firstMatch
     }
 
     var cvcText: String? {

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/RestrictedCardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/RestrictedCardFlowViewPageObject.swift
@@ -4,7 +4,7 @@ class RestrictedCardFlowViewPageObject {
     private let app: XCUIApplication
     
     var panField: XCUIElement {
-        return app.textFields["pan"]
+        return app.otherElements["pan"].textFields.firstMatch
     }
     
     var panText: String? {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -61,8 +61,12 @@ public final class AccessCheckoutUITextField: UIView {
 
     /* Accessibility properties */
     override public var isAccessibilityElement: Bool {
-        set { self.uiTextField.isAccessibilityElement = newValue }
-        get { false }
+        set {
+            self.uiTextField.isAccessibilityElement = newValue
+        }
+        get {
+            false
+        }
     }
     
     override public var accessibilityHint: String? {
@@ -71,8 +75,13 @@ public final class AccessCheckoutUITextField: UIView {
     }
     
     override public var accessibilityIdentifier: String? {
-        set { self.uiTextField.accessibilityIdentifier = newValue }
-        get { nil }
+        set {
+            super.accessibilityIdentifier = newValue
+            self.uiTextField.accessibilityIdentifier = newValue != nil ? "\(newValue!)-UITextField" : nil
+        }
+        get {
+            super.accessibilityIdentifier
+        }
     }
     
     override public var accessibilityLabel: String? {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 
 class PanBasePageObject {
@@ -23,7 +22,7 @@ class PanBasePageObject {
     }
 
     var panField: XCUIElement {
-        return app.textFields[panFieldIdentifier]
+        return app.otherElements[panFieldIdentifier].textFields.firstMatch
     }
 
     var panCaretPositionTextField: XCUIElement {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -44,7 +44,7 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
     // MARK: Accessibility properties tests
 
     // isAccessibilityElement
-    func testIsAccessibilityElementGetterAlwaysReturnsTrue() {
+    func testIsAccessibilityElementGetterAlwaysReturnsFalse() {
         let textField = createTextField()
         XCTAssertFalse(textField.isAccessibilityElement)
         
@@ -78,20 +78,21 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
     }
     
     // accessibilityIdentifier
-    func testAccessibilityIdentifierGetterAlwaysReturnsNil() {
+    func testAccessibilityIdentifierGetterReturnsId() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityIdentifier)
-         
-        textField.accessibilityHint = "something"
-        XCTAssertNil(textField.accessibilityIdentifier)
-    }
-     
-    func testAccessibilityIdentifierSetterSetsUITextFieldProperty() {
-        let textField = createTextField()
-        XCTAssertNil(textField.uiTextField.accessibilityIdentifier)
          
         textField.accessibilityIdentifier = "something"
-        XCTAssertEqual("something", textField.uiTextField.accessibilityIdentifier)
+        XCTAssertEqual("something", textField.accessibilityIdentifier)
+    }
+    
+    func testAccessibilityIdentifierSetterSetsIdAndUITextFieldIdUsingANamingConvention() {
+        let textField = createTextField()
+        XCTAssertNil(textField.accessibilityIdentifier)
+         
+        textField.accessibilityIdentifier = "something"
+        XCTAssertEqual("something", textField.accessibilityIdentifier)
+        XCTAssertEqual("something-UITextField", textField.uiTextField.accessibilityIdentifier)
     }
     
     // accessibilityLabel


### PR DESCRIPTION
## What
- `AccessCheckoutUITextField.accessibilityIdentifier` setter is changed to set ID on AccessCheckoutUITextField + set a different ID on the child UITextField using a naming convention
- `AccessCheckoutUITextField.accessibilityIdentifier`getter is changed to return AccessCheckoutUITextField ID, instead of child UITextField ID before

## Why
- This has been done to align the iOS and Android SDKs implementation so that merchants have a consistent experience when writing automated UI tests for their apps