### PR TITLE
US1822605: Add and expose AccessCheckoutUITextField enabled property

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -148,6 +148,12 @@ public final class AccessCheckoutUITextField: UIView {
     public var keyboardAppearance: UIKeyboardAppearance = .default {
         didSet { self.uiTextField.keyboardAppearance = self.keyboardAppearance }
     }
+
+    /* Enabled properties */
+    @IBInspectable
+    public var enabled: Bool = true {
+        didSet { self.uiTextField.isEnabled = self.enabled }
+    }
     
     // MARK: Public methods
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -403,6 +403,21 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(expected, textField.uiTextField.keyboardAppearance)
     }
     
+    // MARK: enabled properties
+    
+    func testEnabledIsTrueByDefault() {
+        let textField = createTextField()
+        
+        XCTAssertTrue(textField.enabled)
+    }
+    
+    func testEnabledSetterSetsEnabledProperty() {
+        let textField = createTextField()
+        
+        textField.enabled = false
+        XCTAssertFalse(textField.enabled)
+    }
+    
     // MARK: methods properties
     
     func testClearClearsUITextFieldText_andDispatchesAnEditingChangedEvent() {


### PR DESCRIPTION
## What
- Expose enabled property in AccessCheckoutUITextField
- Allows the prevention of interaction with AccessCheckoutUITextField

## How
- Add enabled property to AccessCheckoutUITextField

## Why
- This change is to be able support the React Native SDK functionality using native components