### PR TITLE
US1762588: add support for horizontalPadding in AccessCheckoutUITextField

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -125,6 +125,19 @@ public final class AccessCheckoutUITextField: UIView {
         get { nil }
     }
     
+    /* Padding properties */
+    
+    /**
+     A value that represents the padding between the border and the text
+     */
+    @IBInspectable
+    public var horizontalPadding: CGFloat = defaults.horizontalPadding {
+        didSet {
+            self.uiTextField.frame = bounds.insetBy(dx: horizontalPadding, dy: 0)
+            self.setNeedsLayout()
+        }
+    }
+    
     /* Border properties */
     
     /**

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -163,6 +163,18 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual("something", textField.uiTextField.accessibilityLanguage)
     }
     
+    // MARK: Padding properties tests
+    
+    // horizontalPadding
+    func testHorizontalPaddingModifiesTheUITextFieldFrame() {
+        let textField = AccessCheckoutUITextField(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
+        // Asserts padding is default padding to start with
+        XCTAssertEqual(AccessCheckoutUITextField.defaults.horizontalPadding, textField.uiTextField.frame.minX)
+        
+        textField.horizontalPadding = 20
+        XCTAssertEqual(20, textField.uiTextField.frame.minX)
+    }
+    
     // MARK: Border properties tests
     
     // cornerRadius


### PR DESCRIPTION
This is to solve an issue with AccessCheckoutUITextField in React Native

- the AccessCheckoutUITextField does not display correctly in React Native when its internal UITextField.frame CGRect is inset by a value > 0
- to solve the issue, a horizontalPadding property has been added and this property is designed to affect the position and size of the internal UITextField frame. In return, this property can be used by the React Native native component to reset the padding to 0, ensuring the AccessCheckoutUITextField.uiTextField.frame does not have an inset