### PR TITLE
US2020332: change demo app to use try.access.worldpay.com instead of NPE

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
@@ -671,7 +671,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8BA50193BD557BCBB2DE4933 /* Pods-AccessCheckoutDemo.debug.xcconfig */;
 			buildSettings = {
-				ACCESS_BASE_URL = "https://npe.access.worldpay.com";
+				ACCESS_BASE_URL = "https://try.access.worldpay.com";
+				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -695,7 +696,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6E7FDDA3E36720BDB3959BF7 /* Pods-AccessCheckoutDemo.release.xcconfig */;
 			buildSettings = {
-				ACCESS_BASE_URL = "https://npe.access.worldpay.com";
+				ACCESS_BASE_URL = "https://try.access.worldpay.com";
+				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/AccessCheckoutDemo/AccessCheckoutDemo/Configuration.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Configuration.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 struct Configuration {
-    static let checkoutId = CI.checkoutId != "" && CI.checkoutId != "$(CHECKOUT_ID)" ? CI.checkoutId : "identity"
+    static let checkoutId = CI.checkoutId != "" && CI.checkoutId != "$(CHECKOUT_ID)" ? CI.checkoutId : Bundle.main.infoDictionary?["AccessCheckoutId"] as! String
 
     static var accessBaseUrl: String = ""
 

--- a/AccessCheckoutDemo/AccessCheckoutDemo/Info.plist
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AccessCheckoutId</key>
+	<string>$(ACCESS_CHECKOUT_ID)</string>
 	<key>AccessBaseURL</key>
 	<string>$(ACCESS_BASE_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/AccessCheckoutDemo/README.md
+++ b/AccessCheckoutDemo/README.md
@@ -1,8 +1,28 @@
 # Access Checkout Demo for iOS
 
-## A sample App to demonstrate an Access Checkout SDK integration
+A sample App to demonstrate an Access Checkout SDK integration
 
-The Access Checkout SDK dependency is managed via Cocoapods, run `pod install` before building the example App.
+## Running the Access Checkout Demo App
+
+1. Install dependencies
+    ```
+    # Install Cocoapods dependencies for the SDK first
+    cd <access-checkout-ios-root>/AccessCheckoutSDK
+    pod install
+    
+    # Install Cocoapods dependencies for the demo app
+    cd <access-checkout-ios-root>/AccessCheckoutDemo
+    pod install
+    ```
+2. Open project `AccessCheckoutDemo` in XCode
+    1. Click on `File > Open`
+    2. Select the `<access-checkout-ios-root>/AccessCheckoutSDKDemo/AccessCheckoutDemo.xcworkspace` directory and click `Open`
+
+3. In the Project Navigator in XCode, click on the `AccessCheckoutDemo` app
+4. In the app properties, select the `AccessCheckoutDemo` target under `Targets`
+5. Scroll down to the `User-Defined` properties
+6. Replace the `ACCESS_CHECKOUT_ID` value by the `Checkout ID` that was provided to you when you were on-boarded on Access Worldpay
+7. To run the demo app, click the `Play` button in the top-left corner of the screen to open the demo app in the simulated device of your choice.
 
 ## How to integrate the SDK in an iOS app
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,25 @@ See instructions in the `AccessCheckoutSDK/scripts/mocks-build-phase.sh` script
 
 ### Running the Demo App
 
-1. Install dependencies for the demo app
-    ```
-    cd <access-checkout-ios-root>/AccessCheckoutDemo
-    pod install
-    ```
-2. Open project in XCode
-    1. Click on 'File > Open'
-    2. Select the '<access-checkout-ios-root>/AccessCheckoutSDKDemo/' directory and click 'Open'
+1. Install dependencies
+   ```
+   # Install Cocoapods dependencies for the SDK first
+   cd <access-checkout-ios-root>/AccessCheckoutSDK
+   pod install
+   
+   # Install Cocoapods dependencies for the demo app
+   cd <access-checkout-ios-root>/AccessCheckoutDemo
+   pod install
+   ```
+2. Open project `AccessCheckoutDemo` in XCode
+    1. Click on `File > Open`
+    2. Select the `<access-checkout-ios-root>/AccessCheckoutSDKDemo/AccessCheckoutDemo.xcworkspace` directory and click `Open`
     
-3. Run the demo app
-    1. Click the `Play` button on the top-left corner of the screen to open the demo app in the simulated device of your choice.
+3. In the Project Navigator in XCode, click on the `AccessCheckoutDemo` app
+4. In the app properties, select the `AccessCheckoutDemo` target under `Targets`
+5. Scroll down to the `User-Defined` properties
+6. Replace the `ACCESS_CHECKOUT_ID` value by the `Checkout ID` that was provided to you when you were on-boarded on Access Worldpay
+7. To run the demo app, click the `Play` button in the top-left corner of the screen to open the demo app in the simulated device of your choice.
 
 ## Security
 


### PR DESCRIPTION
## What
- change demo app to use https://try.access.worldpay.com instead of NPE environment
- add in Demo app a property that contains the Checkout ID. It's initialised with `<replace-with-your-checkoutid>` and instructions have been added to Demo app to explain what it should be replaced with and how to replace it