### PR TITLE
US1791485: Refactor dynamic font implementation to rectify regression

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -16,7 +16,7 @@ public final class AccessCheckoutUITextField: UIView {
         keyboardType: .asciiCapableNumberPad,
         keyboardAppearance: .default,
         horizontalPadding: 6,
-        font: .preferredFont(forTextStyle: .caption1)
+        font: .preferredFont(forTextStyle: .body)
     )
     
     internal lazy var uiTextField = buildTextField()
@@ -31,10 +31,10 @@ public final class AccessCheckoutUITextField: UIView {
         // UITextField defaults
         uiTextField.keyboardType = AccessCheckoutUITextField.defaults.keyboardType
         
-        uiTextField.frame = bounds.insetBy(dx: AccessCheckoutUITextField.defaults.horizontalPadding, dy: 0)
+        uiTextField.frame = bounds.insetBy(dx: AccessCheckoutUITextField.defaults.horizontalPadding, dy: -AccessCheckoutUITextField.defaults.font.pointSize)
         uiTextField.autoresizingMask = [
-            UIView.AutoresizingMask.flexibleWidth,
-            UIView.AutoresizingMask.flexibleHeight
+            .flexibleWidth,
+            .flexibleHeight,
         ]
         
         addSubview(uiTextField)
@@ -65,6 +65,12 @@ public final class AccessCheckoutUITextField: UIView {
     override public func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         self.setStyles()
+    }
+    
+    override public func layoutSublayers(of layer: CALayer) {
+        super.layoutSublayers(of: layer)
+        layer.bounds = layer.visibleRect.insetBy(dx: layer.contentsRect.width, dy: -layer.contentsRect.height)
+        layer.masksToBounds = true
     }
     
     private func setStyles() {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -69,7 +69,7 @@ public final class AccessCheckoutUITextField: UIView {
     
     override public func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
-        layer.bounds = layer.visibleRect.insetBy(dx: layer.contentsRect.width, dy: -layer.contentsRect.height)
+        layer.bounds = layer.visibleRect.insetBy(dx: (0), dy: -layer.contentsRect.height)
         layer.masksToBounds = true
     }
     

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -69,7 +69,7 @@ public final class AccessCheckoutUITextField: UIView {
     
     override public func layoutSublayers(of layer: CALayer) {
         super.layoutSublayers(of: layer)
-        layer.bounds = layer.visibleRect.insetBy(dx: (0), dy: -layer.contentsRect.height)
+        layer.bounds = layer.visibleRect.insetBy(dx: 0, dy: -layer.contentsRect.height)
         layer.masksToBounds = true
     }
     


### PR DESCRIPTION

## What
Use system font body instead of caption and resize border according to font size
## Why
Regression was introduced when dynamic font was implemented so this change should rectify that issue and keep dynamic font implemented

**Current commit on Master:**
<img width="554" alt="Screenshot 2025-03-06 at 15 38 09" src="https://github.com/user-attachments/assets/5d2973ff-37bd-43b5-b17b-0d1cf1c82f8c" />

**Change:**
<img width="521" alt="Screenshot 2025-03-06 at 15 40 00" src="https://github.com/user-attachments/assets/61432213-482c-4824-a11e-57742ccb01f1" />