### PR TITLE
US2132087: align behaviour of validation feature for PAN to behaviour implemented in Android SDK

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo/Configuration.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/Configuration.swift
@@ -2,18 +2,33 @@ import Foundation
 import UIKit
 
 struct Configuration {
-    static let checkoutId = CI.checkoutId != "" && CI.checkoutId != "$(CHECKOUT_ID)" ? CI.checkoutId : Bundle.main.infoDictionary?["AccessCheckoutId"] as! String
+    static let checkoutId =
+        CI.checkoutId != "" && CI.checkoutId != "$(CHECKOUT_ID)"
+        ? CI.checkoutId : Bundle.main.infoDictionary?["AccessCheckoutId"] as! String
 
     static var accessBaseUrl: String = ""
 
-    static let accessCardConfigurationUrl: String = "\(urlWitoutTrailingSlash(accessBaseUrl))/access-checkout/cardTypes.json"
+    static let accessCardConfigurationUrl: String =
+        "\(urlWitoutTrailingSlash(accessBaseUrl))/access-checkout/cardTypes.json"
 
-    static let backgroundColor: UIColor = .init(red: 0.960784, green: 0.960784, blue: 0.960784, alpha: 1)
+    static let backgroundColor: UIColor = .init(
+        red: 0.960784,
+        green: 0.960784,
+        blue: 0.960784,
+        alpha: 1
+    )
+    static let validCardDetailsColor: UIColor = .init(
+        red: 0.44313,
+        green: 0.59607,
+        blue: 0.17254,
+        alpha: 1
+    )
+    static let invalidCardDetailsColor: UIColor = .red
 
     private static func urlWitoutTrailingSlash(_ url: String) -> String {
         return url.last == "/" ? String(url.dropLast()) : url
     }
-    
+
     static func resetAccessBaseUrl() {
         if CI.accessBaseUrl != "" && CI.accessBaseUrl != "$(ACCESS_BASE_URL)" {
             accessBaseUrl = CI.accessBaseUrl

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -50,6 +50,7 @@ class CardFlowCardValidationTests: XCTestCase {
 
     func testPartialPanIsInvalid() {
         view!.typeTextIntoPan("4")
+        view!.expiryDateField.tap() // we move the focus to another field so that the validation triggers
 
         XCTAssertTrue(view!.imageIs("visa"))
         XCTAssertEqual(view!.panIsValidLabel.label, "invalid")

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
@@ -1,48 +1,55 @@
 class CardValidationStateHandler {
     private(set) var merchantDelegate: AccessCheckoutCardValidationDelegate
+
+    private var notifyMerchantOfPanValidationChangeIsPending = false
+    private var merchantNeverNotifiedOfPanValidationChange = true
+
     private(set) var panIsValid = false
     private(set) var cardBrand: CardBrandModel?
     private(set) var expiryDateIsValid = false
     private(set) var cvcIsValid = false
     private let cardBrandModelTransformer: CardBrandModelTransformer
-    
-    private(set) var alreadyNotifiedMerchantOfPanValidationState = false
+
     private(set) var alreadyNotifiedMerchantOfExpiryDateValidationState = false
     private(set) var alreadyNotifiedMerchantOfCvcValidationState = false
-    
+
     init(_ merchantDelegate: AccessCheckoutCardValidationDelegate) {
         self.merchantDelegate = merchantDelegate
         self.cardBrandModelTransformer = CardBrandModelTransformer()
     }
-    
+
     /**
      Convenience constructors used by unit tests
      */
-    init(merchantDelegate: AccessCheckoutCardValidationDelegate, panValidationState: Bool, cardBrand: CardBrandModel?) {
+    init(
+        merchantDelegate: AccessCheckoutCardValidationDelegate,
+        panValidationState: Bool,
+        cardBrand: CardBrandModel?
+    ) {
         self.merchantDelegate = merchantDelegate
         self.panIsValid = panValidationState
         self.cardBrand = cardBrand
         self.cardBrandModelTransformer = CardBrandModelTransformer()
     }
-    
+
     init(merchantDelegate: AccessCheckoutCardValidationDelegate, panValidationState: Bool) {
         self.merchantDelegate = merchantDelegate
         self.panIsValid = panValidationState
         self.cardBrandModelTransformer = CardBrandModelTransformer()
     }
-    
+
     init(merchantDelegate: AccessCheckoutCardValidationDelegate, expiryDateValidationState: Bool) {
         self.merchantDelegate = merchantDelegate
         self.expiryDateIsValid = expiryDateValidationState
         self.cardBrandModelTransformer = CardBrandModelTransformer()
     }
-    
+
     init(merchantDelegate: AccessCheckoutCardValidationDelegate, cvcValidationState: Bool) {
         self.merchantDelegate = merchantDelegate
         self.cvcIsValid = cvcValidationState
         self.cardBrandModelTransformer = CardBrandModelTransformer()
     }
-    
+
     private func allFieldsValid() -> Bool {
         return panIsValid && expiryDateIsValid && cvcIsValid
     }
@@ -52,29 +59,38 @@ extension CardValidationStateHandler: PanValidationStateHandler {
     func handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?) {
         if isValid != panIsValid {
             panIsValid = isValid
+            notifyMerchantOfPanValidationChangeIsPending = true
             notifyMerchantOfPanValidationState()
-            
+
             if allFieldsValid() {
                 merchantDelegate.validationSuccess()
             }
         }
-        
+
         if self.cardBrand?.name != cardBrand?.name {
             self.cardBrand = cardBrand
-            
+
             if let cardBrand = cardBrand {
-                merchantDelegate.cardBrandChanged(cardBrand: cardBrandModelTransformer.transform(cardBrand))
+                merchantDelegate.cardBrandChanged(
+                    cardBrand: cardBrandModelTransformer.transform(cardBrand)
+                )
             } else {
                 merchantDelegate.cardBrandChanged(cardBrand: nil)
             }
         }
     }
-    
+
     func notifyMerchantOfPanValidationState() {
-        merchantDelegate.panValidChanged(isValid: panIsValid)
-        alreadyNotifiedMerchantOfPanValidationState = true
+        if notifyMerchantOfPanValidationChangeIsPending
+            || merchantNeverNotifiedOfPanValidationChange
+        {
+            merchantNeverNotifiedOfPanValidationChange = false
+            notifyMerchantOfPanValidationChangeIsPending = false
+
+            merchantDelegate.panValidChanged(isValid: panIsValid)
+        }
     }
-    
+
     func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool {
         if let currentBrand = self.cardBrand, let newBrand = cardBrand {
             return currentBrand.name != newBrand.name
@@ -84,7 +100,7 @@ extension CardValidationStateHandler: PanValidationStateHandler {
             return false
         }
     }
-    
+
     func getCardBrand() -> CardBrandModel? {
         return self.cardBrand
     }
@@ -95,13 +111,13 @@ extension CardValidationStateHandler: ExpiryDateValidationStateHandler {
         if isValid != expiryDateIsValid {
             expiryDateIsValid = isValid
             notifyMerchantOfExpiryDateValidationState()
-            
+
             if allFieldsValid() {
                 merchantDelegate.validationSuccess()
             }
         }
     }
-    
+
     func notifyMerchantOfExpiryDateValidationState() {
         merchantDelegate.expiryDateValidChanged(isValid: expiryDateIsValid)
         alreadyNotifiedMerchantOfExpiryDateValidationState = true
@@ -113,13 +129,13 @@ extension CardValidationStateHandler: CvcValidationStateHandler {
         if isValid != cvcIsValid {
             cvcIsValid = isValid
             notifyMerchantOfCvcValidationState()
-            
+
             if allFieldsValid() {
                 merchantDelegate.validationSuccess()
             }
         }
     }
-    
+
     func notifyMerchantOfCvcValidationState() {
         merchantDelegate.cvcValidChanged(isValid: cvcIsValid)
         alreadyNotifiedMerchantOfCvcValidationState = true

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
@@ -4,13 +4,17 @@ class PanValidationFlow {
     private let panValidator: PanValidator
     private let panValidationStateHandler: PanValidationStateHandler
     private let cvcFlow: CvcValidationFlow
-    
-    init(_ panValidator: PanValidator, _ panValidationStateHandler: PanValidationStateHandler, _ cvcFlow: CvcValidationFlow) {
+
+    init(
+        _ panValidator: PanValidator,
+        _ panValidationStateHandler: PanValidationStateHandler,
+        _ cvcFlow: CvcValidationFlow
+    ) {
         self.panValidator = panValidator
         self.panValidationStateHandler = panValidationStateHandler
         self.cvcFlow = cvcFlow
     }
-    
+
     func validate(pan: String) {
         let result = panValidator.validate(pan: pan)
         if panValidationStateHandler.isCardBrandDifferentFrom(cardBrand: result.cardBrand) {
@@ -19,19 +23,20 @@ class PanValidationFlow {
             } else {
                 cvcFlow.resetValidationRule()
             }
-            
+
             cvcFlow.revalidate()
         }
-        
-        panValidationStateHandler.handlePanValidation(isValid: result.isValid, cardBrand: result.cardBrand)
+
+        panValidationStateHandler.handlePanValidation(
+            isValid: result.isValid,
+            cardBrand: result.cardBrand
+        )
     }
-    
-    func notifyMerchantIfNotAlreadyNotified() {
-        if !panValidationStateHandler.alreadyNotifiedMerchantOfPanValidationState {
-            panValidationStateHandler.notifyMerchantOfPanValidationState()
-        }
+
+    func notifyMerchant() {
+        panValidationStateHandler.notifyMerchantOfPanValidationState()
     }
-    
+
     func getCardBrand() -> CardBrandModel? {
         return panValidationStateHandler.getCardBrand()
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationStateHandler.swift
@@ -4,8 +4,6 @@ protocol PanValidationStateHandler {
     func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
 
     func notifyMerchantOfPanValidationState()
-    
-    func getCardBrand() -> CardBrandModel?
 
-    var alreadyNotifiedMerchantOfPanValidationState: Bool { get }
+    func getCardBrand() -> CardBrandModel?
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
@@ -54,19 +54,19 @@ import Foundation
     
     
     
-     override func notifyMerchantIfNotAlreadyNotified()  {
+     override func notifyMerchant()  {
         
     return cuckoo_manager.call(
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
                 
-                super.notifyMerchantIfNotAlreadyNotified()
+                super.notifyMerchant()
                 ,
-            defaultCall: __defaultImplStub!.notifyMerchantIfNotAlreadyNotified())
+            defaultCall: __defaultImplStub!.notifyMerchant())
         
     }
     
@@ -113,11 +113,11 @@ import Foundation
         
         
         
-        func notifyMerchantIfNotAlreadyNotified() -> Cuckoo.ClassStubNoReturnFunction<()> {
+        func notifyMerchant() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockPanValidationFlow.self, method:
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """, parameterMatchers: matchers))
         }
         
@@ -164,11 +164,11 @@ import Foundation
         
         
         @discardableResult
-        func notifyMerchantIfNotAlreadyNotified() -> Cuckoo.__DoNotUse<(), Void> {
+        func notifyMerchant() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -206,7 +206,7 @@ import Foundation
     
     
     
-     override func notifyMerchantIfNotAlreadyNotified()   {
+     override func notifyMerchant()   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationStateHandler.swift
@@ -25,22 +25,6 @@ import Cuckoo
     
 
     
-    
-    
-    
-     var alreadyNotifiedMerchantOfPanValidationState: Bool {
-        get {
-            return cuckoo_manager.getter("alreadyNotifiedMerchantOfPanValidationState",
-                superclassCall:
-                    
-                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                    ,
-                defaultCall: __defaultImplStub!.alreadyNotifiedMerchantOfPanValidationState)
-        }
-        
-    }
-    
-    
 
     
 
@@ -135,13 +119,6 @@ import Cuckoo
         
         
         
-        var alreadyNotifiedMerchantOfPanValidationState: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockPanValidationStateHandler, Bool> {
-            return .init(manager: cuckoo_manager, name: "alreadyNotifiedMerchantOfPanValidationState")
-        }
-        
-        
-        
-        
         
         func handlePanValidation<M1: Cuckoo.Matchable, M2: Cuckoo.OptionalMatchable>(isValid: M1, cardBrand: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool, CardBrandModel?)> where M1.MatchedType == Bool, M2.OptionalMatchedType == CardBrandModel {
             let matchers: [Cuckoo.ParameterMatcher<(Bool, CardBrandModel?)>] = [wrap(matchable: isValid) { $0.0 }, wrap(matchable: cardBrand) { $0.1 }]
@@ -199,13 +176,6 @@ import Cuckoo
         }
     
         
-        
-        
-        var alreadyNotifiedMerchantOfPanValidationState: Cuckoo.VerifyReadOnlyProperty<Bool> {
-            return .init(manager: cuckoo_manager, name: "alreadyNotifiedMerchantOfPanValidationState", callMatcher: callMatcher, sourceLocation: sourceLocation)
-        }
-        
-        
     
         
         
@@ -261,17 +231,6 @@ import Cuckoo
 
 
  class PanValidationStateHandlerStub: PanValidationStateHandler {
-    
-    
-    
-    
-     var alreadyNotifiedMerchantOfPanValidationState: Bool {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (Bool).self)
-        }
-        
-    }
-    
     
 
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
@@ -32,7 +32,7 @@ class CardValidationStateHandlerTests: XCTestCase {
     
     // MARK: PanValidationStateHandler
     
-    func testShouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromFalse() {
+    func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromFalse() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
         
         validationStateHandler.handlePanValidation(isValid: false, cardBrand: nil)
@@ -40,7 +40,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).panValidChanged(isValid: any())
     }
     
-    func testShouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromTrue() {
+    func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromTrue() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
         
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
@@ -48,7 +48,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).panValidChanged(isValid: any())
     }
     
-    func testShouldNotifyMerchantDelegateWhenPanValidationChangesToFalse() {
+    func testHandlePanValidation_shouldNotifyMerchantDelegateWhenPanValidationChangesToFalse() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
         
         validationStateHandler.handlePanValidation(isValid: false, cardBrand: nil)
@@ -56,7 +56,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).panValidChanged(isValid: false)
     }
     
-    func testShouldNotifyMerchantDelegateWhenPanValidationChangesToTrue() {
+    func testHandlePanValidation_shouldNotifyMerchantDelegateWhenPanValidationChangesToTrue() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
         
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
@@ -64,7 +64,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).panValidChanged(isValid: true)
     }
     
-    func testShouldNotifyMerchantDelegateWhenCardBrandChanges() {
+    func testHandlePanValidation_shouldNotifyMerchantDelegateWhenCardBrandChanges() {
         let expectedCardBrand = createCardBrand(from: visaBrand)
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
@@ -77,7 +77,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).cardBrandChanged(cardBrand: expectedCardBrand)
     }
     
-    func testShouldNotNotifyMerchantDelegateWhenCardBrandDoesNotChange() {
+    func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenCardBrandDoesNotChange() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -89,7 +89,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).cardBrandChanged(cardBrand: any())
     }
     
-    func testShouldReturnFalseWhenCardBrandInStateIsSameAsCardBrandInParameter() {
+    func testIsCardBrandDifferentFrom_shouldReturnFalseWhenCardBrandInStateIsSameAsCardBrandInParameter() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -99,7 +99,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertFalse(validationStateHandler.isCardBrandDifferentFrom(cardBrand: visaBrand))
     }
     
-    func testShouldReturnTrueWhenCardBrandInStateIsNilAndCardBrandInParameterIsNot() {
+    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNilAndCardBrandInParameterIsNot() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -109,7 +109,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: visaBrand))
     }
     
-    func testShouldReturnTrueWhenCardBrandInStateIsDifferentFromCardBrandInParameter() {
+    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsDifferentFromCardBrandInParameter() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -119,7 +119,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: maestroBrand))
     }
     
-    func testShouldReturnTrueWhenCardBrandInStateIsNotNilAndCardBrandInParameterIs() {
+    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNotNilAndCardBrandInParameterIs() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -129,7 +129,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: nil))
     }
     
-    func testShouldReturnFalseWhenCardBrandRemainsNil() {
+    func testIsCardBrandDifferentFrom_shouldReturnFalseWhenCardBrandRemainsNil() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
@@ -139,15 +139,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertFalse(validationStateHandler.isCardBrandDifferentFrom(cardBrand: nil))
     }
     
-    func testNotifyMerchantOfPanValidationStateSetsNotificationState() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate)
-        
-        validationStateHandler.notifyMerchantOfPanValidationState()
-        
-        XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfPanValidationState)
-    }
-    
-    func testNotifyMerchantOfPanValidationStateNotifiesMerchantOfValidPan() {
+    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfValidPan() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
         
         validationStateHandler.notifyMerchantOfPanValidationState()
@@ -155,7 +147,16 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).panValidChanged(isValid: true)
     }
     
-    func testNotifyMerchantOfPanValidationStateNotifiesMerchantOfInvalidPan() {
+    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfValidPanOnlyOnceWhenCalledMultipleTimes() {
+        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
+        
+        validationStateHandler.notifyMerchantOfPanValidationState()
+        validationStateHandler.notifyMerchantOfPanValidationState()
+        
+        verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
+    }
+    
+    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfInvalidPan() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
         
         validationStateHandler.notifyMerchantOfPanValidationState()
@@ -163,13 +164,23 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).panValidChanged(isValid: false)
     }
     
-    func testShouldReturnCardBrandIfKnownBrand() {
+    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfInvalidPanOnlyOnceWhenCalledMultipleTimes() {
+        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
+        
+        validationStateHandler.notifyMerchantOfPanValidationState()
+        validationStateHandler.notifyMerchantOfPanValidationState()
+        
+        verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
+    }
+    
+    
+    func testGetCardBrand_shouldReturnCardBrandIfKnownBrand() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: visaBrand)
         
         XCTAssertEqual(validationStateHandler.getCardBrand(), visaBrand)
     }
     
-    func testShouldReturnNilCardBrandIfUnknownBrand() {
+    func testGetCardBrand_shouldReturnNilCardBrandIfUnknownBrand() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: nil)
         
         XCTAssertEqual(validationStateHandler.getCardBrand(), nil)
@@ -177,7 +188,7 @@ class CardValidationStateHandlerTests: XCTestCase {
     
     // MARK: ExpiryDateValidationStateHandler
     
-    func testShouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromFalse() {
+    func testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromFalse() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: false
@@ -187,7 +198,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }
     
-    func testShouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromTrue() {
+    func testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromTrue() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: true
@@ -197,7 +208,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }
     
-    func testShouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromFalse() {
+    func testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromFalse() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: false
@@ -207,7 +218,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
     }
     
-    func testShouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromTrue() {
+    func testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromTrue() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: true
@@ -217,7 +228,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
     
-    func testNotifyMerchantOfExpiryDateValidationStateSetsNotificationState() {
+    func testNotifyMerchantOfExpiryDateValidationState_setsNotificationState() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate)
         
         validationStateHandler.notifyMerchantOfExpiryDateValidationState()
@@ -225,7 +236,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfExpiryDateValidationState)
     }
     
-    func testNotifyMerchantOfExpiryDateValidationStateNotifiesMerchantOfValidExpiryDate() {
+    func testNotifyMerchantOfExpiryDateValidationState_notifiesMerchantOfValidExpiryDate() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, expiryDateValidationState: true)
         
         validationStateHandler.notifyMerchantOfExpiryDateValidationState()
@@ -233,7 +244,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
     }
     
-    func testNotifyMerchantOfExpiryDateValidationStateNotifiesMerchantOfInvalidExpiryDate() {
+    func testNotifyMerchantOfExpiryDateValidationState_notifiesMerchantOfInvalidExpiryDate() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, expiryDateValidationState: false)
         
         validationStateHandler.notifyMerchantOfExpiryDateValidationState()
@@ -243,7 +254,7 @@ class CardValidationStateHandlerTests: XCTestCase {
     
     // MARK: CvcValidationStateHandler
     
-    func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse() {
+    func testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: false
@@ -253,7 +264,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
     
-    func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue() {
+    func testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: true
@@ -263,7 +274,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
     
-    func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse() {
+    func testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: false
@@ -273,7 +284,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
     
-    func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue() {
+    func testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: true
@@ -283,7 +294,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
     
-    func testNotifyMerchantOfCvcValidationStateSetsNotificationState() {
+    func testNotifyMerchantOfCvcValidationState_setsNotificationState() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate)
         
         validationStateHandler.notifyMerchantOfCvcValidationState()
@@ -291,7 +302,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfCvcValidationState)
     }
     
-    func testNotifyMerchantOfCvcValidationStateNotifiesMerchantOfValidCvc() {
+    func testNotifyMerchantOfCvcValidationState_notifiesMerchantOfValidCvc() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, cvcValidationState: true)
         
         validationStateHandler.notifyMerchantOfCvcValidationState()
@@ -299,7 +310,7 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
     
-    func testNotifyMerchantOfCvcValidationStateNotifiesMerchantOfInvalidCvc() {
+    func testNotifyMerchantOfCvcValidationState_notifiesMerchantOfInvalidCvc() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, cvcValidationState: false)
         
         validationStateHandler.notifyMerchantOfCvcValidationState()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CvcOnlyValidationStateHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CvcOnlyValidationStateHandlerTests.swift
@@ -1,67 +1,82 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class CvcOnlyValidationStateHandlerTests: XCTestCase {
     private let merchantDelegate = MockAccessCheckoutCvcOnlyValidationDelegate()
-    
+
     override func setUp() {
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
     }
-    
+
     func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvcValidationState: false)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate,
+            cvcValidationState: false
+        )
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
+
     func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvcValidationState: true)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate,
+            cvcValidationState: true
+        )
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
+
     func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvcValidationState: false)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate,
+            cvcValidationState: false
+        )
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
-    
+
     func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvcValidationState: true)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate,
+            cvcValidationState: true
+        )
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
+
     func testNotifyMerchantOfCvcValidationStateSetsNotificationState() {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.notifyMerchantOfCvcValidationState()
-        
+
         XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfCvcValidationState)
     }
-    
+
     // MARK: Tests for notification that all fields are valid
-    
+
     func testShouldNotifyMerchantDelegateWhenAllFieldsAreValid() {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate).validationSuccess()
     }
-    
-    func testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAndCvcIsChangedToAnotherValidValue() {
+
+    func
+        testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAndCvcIsChangedToAnotherValidValue()
+    {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowTests.swift
@@ -1,122 +1,128 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanValidationFlowTests: XCTestCase {
     let visaBrand = CardBrandModel(
         name: "visa",
         images: [],
-        panValidationRule: ValidationRule(matcher: "^(?!^493698\\d*$)4\\d*$", validLengths: [16, 18, 19]),
+        panValidationRule: ValidationRule(
+            matcher: "^(?!^493698\\d*$)4\\d*$",
+            validLengths: [16, 18, 19]
+        ),
         cvcValidationRule: ValidationRule(matcher: nil, validLengths: [3])
     )
-    
+
     private let panValidationStateHandler = MockPanValidationStateHandler()
-    
+
     override func setUp() {
-        panValidationStateHandler.getStubbingProxy().handlePanValidation(isValid: any(), cardBrand: any()).thenDoNothing()
+        panValidationStateHandler.getStubbingProxy().handlePanValidation(
+            isValid: any(),
+            cardBrand: any()
+        ).thenDoNothing()
     }
-    
+
     func testValidateValidatesPanAndCallsValidationStateHandlerWithResult() {
         let cvcFlow = mockCvcFlow()
         let expectedResult = PanValidationResult(true, visaBrand)
         let panValidator = createMockPanValidator(thatReturns: expectedResult)
         let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any()).thenReturn(false)
-        
+        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any())
+            .thenReturn(false)
+
         panValidationFlow.validate(pan: "1234")
-        
+
         verify(panValidator).validate(pan: "1234")
-        verify(panValidationStateHandler).handlePanValidation(isValid: expectedResult.isValid, cardBrand: expectedResult.cardBrand)
+        verify(panValidationStateHandler).handlePanValidation(
+            isValid: expectedResult.isValid,
+            cardBrand: expectedResult.cardBrand
+        )
     }
-    
+
     func testValidateUpdatesCvcValidationRuleAndRevalidatesCvcWhenCardBrandHasChanged() {
         let cvcFlow = mockCvcFlow()
         let expectedResult = PanValidationResult(true, visaBrand)
         let panValidator = createMockPanValidator(thatReturns: expectedResult)
         let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any()).thenReturn(true)
+        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any())
+            .thenReturn(true)
         cvcFlow.getStubbingProxy().updateValidationRule(with: any()).thenDoNothing()
         cvcFlow.getStubbingProxy().revalidate().thenDoNothing()
-        
+
         panValidationFlow.validate(pan: "1234")
-        
+
         verify(cvcFlow).updateValidationRule(with: visaBrand.cvcValidationRule)
         verify(cvcFlow).revalidate()
     }
-    
-    func testValidateResetsCvcValidationRuleAndRevalidatesCvcWhenCardBrandHasChangedAndNoBrandHasBeenIdentified() {
+
+    func
+        testValidateResetsCvcValidationRuleAndRevalidatesCvcWhenCardBrandHasChangedAndNoBrandHasBeenIdentified()
+    {
         let cvcFlow = mockCvcFlow()
         let expectedResult = PanValidationResult(true, nil)
         let panValidator = createMockPanValidator(thatReturns: expectedResult)
         let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any()).thenReturn(true)
+        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any())
+            .thenReturn(true)
         cvcFlow.getStubbingProxy().resetValidationRule().thenDoNothing()
         cvcFlow.getStubbingProxy().revalidate().thenDoNothing()
-        
+
         panValidationFlow.validate(pan: "1234")
-        
+
         verify(cvcFlow).resetValidationRule()
         verify(cvcFlow).revalidate()
     }
-    
+
     func testValidateDoesNotAffectCvcValidationWhenCardBrandHasNotChanged() {
         let cvcFlow = mockCvcFlow()
-        
+
         let expectedResult = PanValidationResult(true, visaBrand)
         let panValidator = createMockPanValidator(thatReturns: expectedResult)
         let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any()).thenReturn(false)
-        
+        panValidationStateHandler.getStubbingProxy().isCardBrandDifferentFrom(cardBrand: any())
+            .thenReturn(false)
+
         panValidationFlow.validate(pan: "1234")
         verifyNoMoreInteractions(cvcFlow)
     }
-    
-    func testCanNotifyMerchantIfNotAlreadyNotified() {
+
+    func testCanNotifyMerchant() {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
         let cvcFlow = mockCvcFlow()
-        let panValidator = PanValidator(CardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock()))
+        let panValidator = PanValidator(
+            CardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        )
         let panValidationStateHandler = CardValidationStateHandler(merchantDelegate)
         let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        
-        panValidationFlow.notifyMerchantIfNotAlreadyNotified()
-        
+
+        panValidationFlow.notifyMerchant()
+
         verify(merchantDelegate).panValidChanged(isValid: false)
     }
-    
-    func testCannotNotifyMerchantIfAlreadyNotified() {
-        let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
-        merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
-        let cvcFlow = mockCvcFlow()
-        let panValidator = PanValidator(CardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock()))
-        let panValidationStateHandler = CardValidationStateHandler(merchantDelegate)
-        let panValidationFlow = PanValidationFlow(panValidator, panValidationStateHandler, cvcFlow)
-        
-        panValidationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
-        verify(merchantDelegate).panValidChanged(isValid: true)
-        clearInvocations(merchantDelegate)
-        
-        panValidationFlow.notifyMerchantIfNotAlreadyNotified()
-        
-        verify(merchantDelegate, never()).panValidChanged(isValid: any())
-    }
-    
-    private func createMockPanValidator(thatReturns result: PanValidationResult) -> MockPanValidator {
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+
+    private func createMockPanValidator(thatReturns result: PanValidationResult) -> MockPanValidator
+    {
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let mock = MockPanValidator(configurationProvider)
-        
+
         mock.getStubbingProxy().validate(pan: any()).thenReturn(result)
-        
+
         return mock
     }
-    
+
     private func mockCardConfiguration() -> CardBrandsConfiguration {
         return CardBrandsConfiguration(allCardBrands: [visaBrand], acceptedCardBrands: [])
     }
-    
+
     private func mockCvcFlow() -> MockCvcValidationFlow {
-        let cvcFlow = MockCvcValidationFlow(MockCvcValidator(),
-                                            MockCvcValidationStateHandler())
+        let cvcFlow = MockCvcValidationFlow(
+            MockCvcValidator(),
+            MockCvcValidationStateHandler()
+        )
         cvcFlow.getStubbingProxy().revalidate().thenDoNothing()
         return cvcFlow
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterCardSpacingTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterCardSpacingTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanViewPresenterCardSpacingTests: PresenterTestSuite {
     private let panValidationFlowMock = mockPanValidationFlow()
@@ -9,68 +10,103 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
     private let visaBrand = TestFixtures.visaBrand()
     private let maestroBrand = TestFixtures.maestroBrand()
     private let unknownBrand = TestFixtures.unknownBrand()
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock()
+    )
 
     private let validVisaPan = TestFixtures.validVisaPan1
     private let validVisaPanWithSpaces = TestFixtures.validVisaPan1WithSpaces
 
-    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures.validVisaPanAsLongAsMaxLengthAllowed
-    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures.validVisaPanAsLongAsMaxLengthAllowedWithSpaces
+    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowed
+    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowedWithSpaces
 
     private let visaPanThatFailsLuhnCheck = TestFixtures.visaPanThatFailsLuhnCheck
-    private let visaPanThatFailsLuhnCheckWithSpaces = TestFixtures.visaPanThatFailsLuhnCheckWithSpaces
+    private let visaPanThatFailsLuhnCheckWithSpaces = TestFixtures
+        .visaPanThatFailsLuhnCheckWithSpaces
 
     private let visaPanTooLong = TestFixtures.visaPanTooLong
     private let visaPanTooLongWithSpaces = TestFixtures.visaPanTooLongWithSpaces
 
     override func setUp() {
         panValidationFlowMock.getStubbingProxy().validate(pan: any()).thenDoNothing()
-        panValidationFlowMock.getStubbingProxy().notifyMerchantIfNotAlreadyNotified().thenDoNothing()
+        panValidationFlowMock.getStubbingProxy().notifyMerchant().thenDoNothing()
     }
 
     private static func mockPanValidationFlow() -> MockPanValidationFlow {
-        let validationStateHandler = CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate())
+        let validationStateHandler = CardValidationStateHandler(
+            MockAccessCheckoutCardValidationDelegate()
+        )
         let cvcValidationFlow = MockCvcValidationFlow(CvcValidator(), validationStateHandler)
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let panValidator = PanValidator(configurationProvider)
 
         return MockPanValidationFlow(panValidator, validationStateHandler, cvcValidationFlow)
     }
 
-    private func createPresenterWithCardSpacing(detectedCardBrand: CardBrandModel?) -> PanViewPresenter {
+    private func createPresenterWithCardSpacing(detectedCardBrand: CardBrandModel?)
+        -> PanViewPresenter
+    {
         let panFormattingEnabled = true
-        let cardBrandsConfiguration = CardBrandsConfiguration(allCardBrands: [visaBrand, maestroBrand], acceptedCardBrands: [])
+        let cardBrandsConfiguration = CardBrandsConfiguration(
+            allCardBrands: [visaBrand, maestroBrand],
+            acceptedCardBrands: []
+        )
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
         panValidationFlowMock.getStubbingProxy().getCardBrand().thenReturn(detectedCardBrand)
 
         let panValidator = PanValidator(configurationProvider)
-        return PanViewPresenter(panValidationFlowMock, panValidator, panFormattingEnabled: panFormattingEnabled)
+        return PanViewPresenter(
+            panValidationFlowMock,
+            panValidator,
+            panFormattingEnabled: panFormattingEnabled
+        )
     }
 
-    private func createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [CardBrandModel]) -> PanViewPresenter {
+    private func createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [CardBrandModel])
+        -> PanViewPresenter
+    {
         let acceptedCardBrands: [String] = []
 
         let merchantValidationDelegate = MockAccessCheckoutCardValidationDelegate()
-        merchantValidationDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
-        merchantValidationDelegate.getStubbingProxy().cardBrandChanged(cardBrand: any()).thenDoNothing()
+        merchantValidationDelegate.getStubbingProxy().panValidChanged(isValid: any())
+            .thenDoNothing()
+        merchantValidationDelegate.getStubbingProxy().cardBrandChanged(cardBrand: any())
+            .thenDoNothing()
 
-        let configuration = CardBrandsConfiguration(allCardBrands: allCardBrands, acceptedCardBrands: acceptedCardBrands)
+        let configuration = CardBrandsConfiguration(
+            allCardBrands: allCardBrands,
+            acceptedCardBrands: acceptedCardBrands
+        )
         let configurationFactory = CardBrandsConfigurationFactoryMock()
         configurationFactory.willReturn(configuration)
 
         let configurationProvider = CardBrandsConfigurationProvider(configurationFactory)
-        configurationProvider.retrieveRemoteConfiguration(baseUrl: "", acceptedCardBrands: acceptedCardBrands)
+        configurationProvider.retrieveRemoteConfiguration(
+            baseUrl: "",
+            acceptedCardBrands: acceptedCardBrands
+        )
 
         let panValidator = PanValidator(configurationProvider)
         let validationStateHandler = CardValidationStateHandler(merchantValidationDelegate)
         let cvcValidationFlow = CvcValidationFlow(CvcValidator(), validationStateHandler)
-        let panValidationFlow = PanValidationFlow(panValidator, validationStateHandler, cvcValidationFlow)
+        let panValidationFlow = PanValidationFlow(
+            panValidator,
+            validationStateHandler,
+            cvcValidationFlow
+        )
 
         return PanViewPresenter(panValidationFlow, panValidator, panFormattingEnabled: true)
     }
 
     private func caretPosition() -> Int {
-        return panTextField.offset(from: panTextField.beginningOfDocument, to: panTextField.selectedTextRange!.start)
+        return panTextField.offset(
+            from: panTextField.beginningOfDocument,
+            to: panTextField.selectedTextRange!.start
+        )
     }
 
     private func waitThen(assertClosure: @escaping () -> Void) {
@@ -95,15 +131,21 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
 
         presenter.onEditEnd()
 
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
+        verify(panValidationFlowMock).notifyMerchant()
     }
 
     func testCanChangeTextChecksIfTheTextCanBeEnteredButDoesNotTriggerValidationFlow() {
         let panFormattingEnabled = true
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let panValidatorMock = MockPanValidator(configurationProvider)
         panValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(true)
-        let presenter = PanViewPresenter(panValidationFlowMock, panValidatorMock, panFormattingEnabled: panFormattingEnabled)
+        let presenter = PanViewPresenter(
+            panValidationFlowMock,
+            panValidatorMock,
+            panFormattingEnabled: panFormattingEnabled
+        )
 
         _ = presenter.canChangeText(with: "123")
 
@@ -125,7 +167,7 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
 
         presenter.textFieldDidEndEditing(panTextField)
 
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
+        verify(panValidationFlowMock).notifyMerchant()
     }
 
     // MARK: testing what the end user can and cannot type
@@ -135,10 +177,13 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let range = NSRange(location: 0, length: 3)
         panTextField.text = "123"
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: range, replacementString: "")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: range,
+            replacementString: ""
+        )
 
         XCTAssertEqual(panTextField.text, "")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "")
     }
 
@@ -147,7 +192,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let range = NSRange(location: 0, length: 0)
         panTextField.text = nil
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: range, replacementString: "123")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: range,
+            replacementString: "123"
+        )
 
         XCTAssertEqual(panTextField.text, "123")
     }
@@ -179,50 +228,65 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
 
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPan)
         XCTAssertEqual(panTextField.text, validVisaPanWithSpaces)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPanWithSpaces)
     }
 
     func testCanTypeValidVisaPanWithSpaces() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPanWithSpaces)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            validVisaPanWithSpaces
+        )
         XCTAssertEqual(panTextField.text, validVisaPanWithSpaces)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPanWithSpaces)
     }
 
     func testCanTypeVisaPanWithSpacesThatFailsLuhnCheck() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, visaPanThatFailsLuhnCheckWithSpaces)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            visaPanThatFailsLuhnCheckWithSpaces
+        )
         XCTAssertEqual(panTextField.text, visaPanThatFailsLuhnCheckWithSpaces)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: visaPanThatFailsLuhnCheckWithSpaces)
     }
 
     func testCanTypeVisaPanAsLongAsMaxLengthAllowed() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPanAsLongAsMaxLengthAllowed)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            validVisaPanAsLongAsMaxLengthAllowed
+        )
         XCTAssertEqual(panTextField.text, validVisaPanAsLongAsMaxLengthAllowedWithSpaces)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPanAsLongAsMaxLengthAllowedWithSpaces)
     }
 
     func testCanTypeVisaPanWithSpacesAsLongAsMaxLengthAllowed() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPanAsLongAsMaxLengthAllowedWithSpaces)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            validVisaPanAsLongAsMaxLengthAllowedWithSpaces
+        )
         XCTAssertEqual(panTextField.text, validVisaPanAsLongAsMaxLengthAllowedWithSpaces)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPanAsLongAsMaxLengthAllowedWithSpaces)
     }
 
     func testCutsToMaxLengthAVisaPanWithSpacesThatExceedsMaximiumLength() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, visaPanTooLongWithSpaces)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            visaPanTooLongWithSpaces
+        )
 
         XCTAssertEqual(panTextField.text, "4111 1111 1111 1111 111")
     }
@@ -230,39 +294,54 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
     //  This test is important because the Visa pattern excludes explictly the Maestro pattern so we want
     // to make sure that it does not prevent the user from typing a maestro PAN
     func testCanTypeStartOfMaestroPan() {
-        let cardBrandsConfiguration = CardBrandsConfiguration(allCardBrands: [visaBrand, maestroBrand], acceptedCardBrands: [])
+        let cardBrandsConfiguration = CardBrandsConfiguration(
+            allCardBrands: [visaBrand, maestroBrand],
+            acceptedCardBrands: []
+        )
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
         panValidationFlowMock.getStubbingProxy().getCardBrand().thenReturn(maestroBrand)
 
         let panValidator = PanValidator(configurationProvider)
-        let presenter = PanViewPresenter(panValidationFlowMock, panValidator, panFormattingEnabled: true)
+        let presenter = PanViewPresenter(
+            panValidationFlowMock,
+            panValidator,
+            panFormattingEnabled: true
+        )
 
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "493698123")
 
         XCTAssertEqual(panTextField.text, "4936 9812 3")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "4936 9812 3")
     }
 
     func testCanTypePanOfUnknownBrandAsLongAsMaxLengthAllowed() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: unknownBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "1234567890123456789")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "1234567890123456789"
+        )
         XCTAssertEqual(panTextField.text, "1234 5678 9012 3456 789")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "1234 5678 9012 3456 789")
     }
 
     func testCutsToMaxLengthAPanOfUnknownBrandThatExceedsMaxLength() {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: unknownBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "1234 5678 9012 3456 7890")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "1234 5678 9012 3456 7890"
+        )
 
         XCTAssertEqual(panTextField.text, "1234 5678 9012 3456 789")
     }
 
     func testShouldFormatCorrectlyAmexCardEnteredInABlankUITextfield() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
 
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "345678901234567")
 
@@ -270,69 +349,111 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
     }
 
     func testShouldFormatCorrectlyCardWithDifferentFormatEnteredAfterAmexCard() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "3456 789012 34567")
         XCTAssertEqual(panTextField.text, "3456 789012 34567")
 
         let allTextSelected = NSRange(location: 0, length: panTextField.text!.count)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: allTextSelected, replacementString: "4444123456789012")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: allTextSelected,
+            replacementString: "4444123456789012"
+        )
 
         XCTAssertEqual(panTextField.text, "4444 1234 5678 9012")
     }
 
     func testShouldFormatCorrectlyAmexEnteredAfterCardWithDifferentFormat() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "4444123456789012")
         XCTAssertEqual(panTextField.text, "4444 1234 5678 9012")
 
         let allTextSelected = NSRange(location: 0, length: panTextField.text!.count)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: allTextSelected, replacementString: "345678901234567")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: allTextSelected,
+            replacementString: "345678901234567"
+        )
 
         XCTAssertEqual(panTextField.text, "3456 789012 34567")
     }
 
     func testShouldFormatCorrectlyCardWhenItBecomesAmex() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "45678912345")
         XCTAssertEqual(panTextField.text, "4567 8912 345")
 
         let noTextSelected = NSRange(location: 0, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: noTextSelected, replacementString: "3")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: noTextSelected,
+            replacementString: "3"
+        )
 
         XCTAssertEqual(panTextField.text, "3456 789123 45")
     }
 
     func testShouldFormatCorrectlyCardWhenItBecomesCardWithStandardFormat() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "345678912345")
         XCTAssertEqual(panTextField.text, "3456 789123 45")
 
         let noTextSelected = NSRange(location: 0, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: noTextSelected, replacementString: "4")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: noTextSelected,
+            replacementString: "4"
+        )
 
         XCTAssertEqual(panTextField.text, "4345 6789 1234 5")
     }
 
     func testShouldCutToFirstXDigitsPanWhichIsLongerThanTheMaxLength() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "44443333222211110000999988887777")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "44443333222211110000999988887777"
+        )
 
         XCTAssertEqual(panTextField.text, "4444 3333 2222 1111 000")
     }
 
-    func testShouldCutToFirstXDigitsPanWhichIsLongerThanTheMaxLengthWithBrandDifferentFromCurrentBrand() {
-        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [visaBrand, amexBrand])
+    func
+        testShouldCutToFirstXDigitsPanWhichIsLongerThanTheMaxLengthWithBrandDifferentFromCurrentBrand()
+    {
+        let presenter = createPresenterWithCardSpacingAndFullOnValidation(allCardBrands: [
+            visaBrand, amexBrand,
+        ])
         panTextField.text = "3455 55666 677"
 
         var noTextSelected = NSRange(location: 2, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: noTextSelected, replacementString: "8888")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: noTextSelected,
+            replacementString: "8888"
+        )
         // Cuts pan to 15 digits due to Amex max length
         XCTAssertEqual("3488 885555 66667", panTextField.text)
 
         // Cuts pan to 19 digits due to visa max length
         noTextSelected = NSRange(location: 0, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: noTextSelected, replacementString: "44442222")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: noTextSelected,
+            replacementString: "44442222"
+        )
         XCTAssertEqual("4444 2222 3488 8855 556", panTextField.text)
     }
 
@@ -343,7 +464,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "44443333"
         let caretPosition = NSRange(location: 0, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 3333", panTextField.text)
         waitThen {
@@ -357,7 +482,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "1"
         let caretPosition = NSRange(location: 6, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 3133 3", panTextField.text)
         waitThen {
@@ -371,7 +500,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "11"
         let caretPosition = NSRange(location: 0, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1144 43", panTextField.text)
         waitThen {
@@ -379,13 +512,19 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         }
     }
 
-    func testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionShorterThanNumberOfDigitsInserted() {
+    func
+        testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionShorterThanNumberOfDigitsInserted()
+    {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: unknownBrand)
         panTextField.text = "4443"
         let textToInsert = "11"
         let selection = NSRange(location: 0, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1144 3", panTextField.text)
         waitThen {
@@ -393,13 +532,19 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         }
     }
 
-    func testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionLongerThanNumberOfDigitsInserted() {
+    func
+        testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionLongerThanNumberOfDigitsInserted()
+    {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: unknownBrand)
         panTextField.text = "4444 3333"
         let textToInsert = "11"
         let selection = NSRange(location: 0, length: 3)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1143 333", panTextField.text)
         waitThen {
@@ -413,7 +558,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "11"
         let selection = NSRange(location: 5, length: 4)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 1122 22", panTextField.text)
         waitThen {
@@ -427,7 +576,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 1, length: 2)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1456 78", panTextField.text)
         waitThen {
@@ -441,7 +594,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 5, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1234 678", panTextField.text)
         waitThen {
@@ -455,7 +612,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "2  2abc"
         let caretPosition = NSRange(location: 6, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 3223 33", panTextField.text)
         waitThen {
@@ -469,7 +630,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "abc"
         let caretPosition = NSRange(location: 6, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 3333", panTextField.text)
         waitThen {
@@ -477,13 +642,19 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         }
     }
 
-    func testShouldMoveCaretAfterSpaceWhenDigitInsertedAsTheLastDigitOfAGroupThatAlreadyHasASpaceAfterIt() {
+    func
+        testShouldMoveCaretAfterSpaceWhenDigitInsertedAsTheLastDigitOfAGroupThatAlreadyHasASpaceAfterIt()
+    {
         let presenter = createPresenterWithCardSpacing(detectedCardBrand: unknownBrand)
         panTextField.text = "4444 3333"
         let textToInsert = "2"
         let caretPosition = NSRange(location: 3, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4442 4333 3", panTextField.text)
         waitThen {
@@ -497,7 +668,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "2"
         let caretPosition = NSRange(location: 4, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 2333 3", panTextField.text)
         waitThen {
@@ -511,7 +686,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 4, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4443 333", panTextField.text)
         waitThen {
@@ -525,7 +704,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 5, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 333", panTextField.text)
         waitThen {
@@ -539,7 +722,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 4, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4443 333", panTextField.text)
         waitThen {
@@ -553,7 +740,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = "9999"
         let selection = NSRange(location: 1, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4999 9444 3333 2222 111", panTextField.text)
         waitThen {
@@ -567,7 +758,11 @@ class PanViewPresenterCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 4, length: 3)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444 3322 2211 1100 0", panTextField.text)
         waitThen {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterNoCardSpacingTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterNoCardSpacingTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
     private let panValidatorMock = mockPanValidator()
@@ -9,53 +10,76 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
     private let visaBrand = TestFixtures.visaBrand()
     private let maestroBrand = TestFixtures.maestroBrand()
     private let unknownBrand = TestFixtures.unknownBrand()
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock()
+    )
 
     private let validVisaPan = TestFixtures.validVisaPan1
     private let validVisaPanWithSpaces = TestFixtures.validVisaPan1WithSpaces
 
-    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures.validVisaPanAsLongAsMaxLengthAllowed
-    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures.validVisaPanAsLongAsMaxLengthAllowedWithSpaces
+    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowed
+    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowedWithSpaces
 
     private let visaPanThatFailsLuhnCheck = TestFixtures.visaPanThatFailsLuhnCheck
-    private let visaPanThatFailsLuhnCheckWithSpaces = TestFixtures.visaPanThatFailsLuhnCheckWithSpaces
+    private let visaPanThatFailsLuhnCheckWithSpaces = TestFixtures
+        .visaPanThatFailsLuhnCheckWithSpaces
 
     private let visaPanTooLong = TestFixtures.visaPanTooLong
 
     override func setUp() {
         panValidationFlowMock.getStubbingProxy().validate(pan: any()).thenDoNothing()
-        panValidationFlowMock.getStubbingProxy().notifyMerchantIfNotAlreadyNotified().thenDoNothing()
+        panValidationFlowMock.getStubbingProxy().notifyMerchant().thenDoNothing()
         panValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(true)
     }
 
     private static func mockPanValidationFlow() -> MockPanValidationFlow {
-        let validationStateHandler = CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate())
+        let validationStateHandler = CardValidationStateHandler(
+            MockAccessCheckoutCardValidationDelegate()
+        )
         let cvcValidationFlow = MockCvcValidationFlow(CvcValidator(), validationStateHandler)
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let panValidator = PanValidator(configurationProvider)
 
         return MockPanValidationFlow(panValidator, validationStateHandler, cvcValidationFlow)
     }
 
     static func mockPanValidator() -> MockPanValidator {
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let panValidator = MockPanValidator(configurationProvider)
 
         return panValidator
     }
 
-    private func createPresenterWithoutCardSpacing(detectedCardBrand: CardBrandModel?) -> PanViewPresenter {
+    private func createPresenterWithoutCardSpacing(detectedCardBrand: CardBrandModel?)
+        -> PanViewPresenter
+    {
         let panFormattingEnabled = false
-        let cardBrandsConfiguration = CardBrandsConfiguration(allCardBrands: [visaBrand, maestroBrand], acceptedCardBrands: [])
+        let cardBrandsConfiguration = CardBrandsConfiguration(
+            allCardBrands: [visaBrand, maestroBrand],
+            acceptedCardBrands: []
+        )
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
         panValidationFlowMock.getStubbingProxy().getCardBrand().thenReturn(detectedCardBrand)
 
         let panValidator = PanValidator(configurationProvider)
-        return PanViewPresenter(panValidationFlowMock, panValidator, panFormattingEnabled: panFormattingEnabled)
+        return PanViewPresenter(
+            panValidationFlowMock,
+            panValidator,
+            panFormattingEnabled: panFormattingEnabled
+        )
     }
 
     private func caretPosition() -> Int {
-        return panTextField.offset(from: panTextField.beginningOfDocument, to: panTextField.selectedTextRange!.start)
+        return panTextField.offset(
+            from: panTextField.beginningOfDocument,
+            to: panTextField.selectedTextRange!.start
+        )
     }
 
     private func waitThen(assertClosure: @escaping () -> Void) {
@@ -80,15 +104,21 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
 
         presenter.onEditEnd()
 
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
+        verify(panValidationFlowMock).notifyMerchant()
     }
 
     func testCanChangeTextChecksIfTheTextCanBeEnteredAndDoesNotTriggerValidationFlow() {
         let panFormattingEnabled = false
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
         let panValidatorMock = MockPanValidator(configurationProvider)
         panValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(true)
-        let presenter = PanViewPresenter(panValidationFlowMock, panValidatorMock, panFormattingEnabled: panFormattingEnabled)
+        let presenter = PanViewPresenter(
+            panValidationFlowMock,
+            panValidatorMock,
+            panFormattingEnabled: panFormattingEnabled
+        )
 
         _ = presenter.canChangeText(with: "123")
 
@@ -110,7 +140,7 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
 
         presenter.textFieldDidEndEditing(panTextField)
 
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
+        verify(panValidationFlowMock).notifyMerchant()
     }
 
     // MARK: testing what the end user can and cannot type
@@ -120,10 +150,13 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let range = NSRange(location: 0, length: 3)
         panTextField.text = "123"
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: range, replacementString: "")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: range,
+            replacementString: ""
+        )
 
         XCTAssertEqual(panTextField.text, "")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "")
     }
 
@@ -132,7 +165,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let range = NSRange(location: 0, length: 0)
         panTextField.text = nil
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: range, replacementString: "123")
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: range,
+            replacementString: "123"
+        )
 
         XCTAssertEqual(panTextField.text, "123")
     }
@@ -164,25 +201,30 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
 
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPan)
         XCTAssertEqual(panTextField.text, validVisaPan)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPan)
     }
 
     func testCanTypeVisaPanThatFailsLuhnCheck() {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, visaPanThatFailsLuhnCheck)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            visaPanThatFailsLuhnCheck
+        )
         XCTAssertEqual(panTextField.text, visaPanThatFailsLuhnCheck)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: visaPanThatFailsLuhnCheck)
     }
 
     func testCanTypeVisaPanAsLongAsMaxLengthAllowed() {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, validVisaPanAsLongAsMaxLengthAllowed)
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            validVisaPanAsLongAsMaxLengthAllowed
+        )
         XCTAssertEqual(panTextField.text, validVisaPanAsLongAsMaxLengthAllowed)
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: validVisaPanAsLongAsMaxLengthAllowed)
     }
 
@@ -197,33 +239,46 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
     // This test is important because the Visa pattern excludes explictly the Maestro pattern so we want
     // to make sure that it does not prevent the user from typing a maestro PAN
     func testCanTypeStartOfMaestroPan() {
-        let cardBrandsConfiguration = CardBrandsConfiguration(allCardBrands: [visaBrand, maestroBrand], acceptedCardBrands: [])
+        let cardBrandsConfiguration = CardBrandsConfiguration(
+            allCardBrands: [visaBrand, maestroBrand],
+            acceptedCardBrands: []
+        )
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
         panValidationFlowMock.getStubbingProxy().getCardBrand().thenReturn(maestroBrand)
 
         let panValidator = PanValidator(configurationProvider)
-        let presenter = PanViewPresenter(panValidationFlowMock, panValidator, panFormattingEnabled: false)
+        let presenter = PanViewPresenter(
+            panValidationFlowMock,
+            panValidator,
+            panFormattingEnabled: false
+        )
 
         enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "493698123")
 
         XCTAssertEqual(panTextField.text, "493698123")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "493698123")
     }
 
     func testCanTypePanOfUnknownBrandAsLongAsMaxLengthAllowed() {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: nil)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "1234567890123456789")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "1234567890123456789"
+        )
         XCTAssertEqual(panTextField.text, "1234567890123456789")
-        verify(panValidationFlowMock).notifyMerchantIfNotAlreadyNotified()
         verify(panValidationFlowMock).validate(pan: "1234567890123456789")
     }
 
     func testShouldCutToMaxLengthUnknownBrandWhichIsLongerThanTheMaxLength() {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: nil)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "12345678901234567890")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "12345678901234567890"
+        )
 
         XCTAssertEqual(panTextField.text, "1234567890123456789")
     }
@@ -231,7 +286,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
     func testShouldCutToMaxLengthVisaPanWhichIsLongerThanTheMaxLength() {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: visaBrand)
 
-        enterPanInUITextField(presenter: presenter, uiTextField: panTextField, "44443333222211110000999988887777")
+        enterPanInUITextField(
+            presenter: presenter,
+            uiTextField: panTextField,
+            "44443333222211110000999988887777"
+        )
 
         XCTAssertEqual(panTextField.text, "4444333322221111000")
     }
@@ -242,7 +301,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: unknownBrand)
         let textToInsert = "44443333"
         let caretPosition = NSRange(location: 0, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("44443333", panTextField.text)
         waitThen {
@@ -255,7 +318,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         panTextField.text = "44443333"
         let textToInsert = "1"
         let caretPosition = NSRange(location: 6, length: 0)
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("444433133", panTextField.text)
         waitThen {
@@ -269,7 +336,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = "11"
         let caretPosition = NSRange(location: 0, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("114443", panTextField.text)
         waitThen {
@@ -277,13 +348,19 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         }
     }
 
-    func testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionShorterThanNumberOfDigitsInserted() {
+    func
+        testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionShorterThanNumberOfDigitsInserted()
+    {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: unknownBrand)
         panTextField.text = "4443"
         let textToInsert = "11"
         let selection = NSRange(location: 0, length: 1)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("11443", panTextField.text)
         waitThen {
@@ -291,13 +368,19 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         }
     }
 
-    func testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionLongerThanNumberOfDigitsInserted() {
+    func
+        testShouldMoveCaretAfterMultipleDigitsInsertedAtStartOverSelectionLongerThanNumberOfDigitsInserted()
+    {
         let presenter = createPresenterWithoutCardSpacing(detectedCardBrand: unknownBrand)
         panTextField.text = "44443333"
         let textToInsert = "11"
         let selection = NSRange(location: 0, length: 3)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("1143333", panTextField.text)
         waitThen {
@@ -311,7 +394,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = "11"
         let selection = NSRange(location: 5, length: 4)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444311222", panTextField.text)
         waitThen {
@@ -325,7 +412,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = ""
         let selection = NSRange(location: 1, length: 2)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("443333", panTextField.text)
         waitThen {
@@ -339,7 +430,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = "2  2abc"
         let caretPosition = NSRange(location: 6, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4444332233", panTextField.text)
         waitThen {
@@ -353,7 +448,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = "abc"
         let caretPosition = NSRange(location: 5, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: caretPosition, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: caretPosition,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("44443333", panTextField.text)
         waitThen {
@@ -367,7 +466,11 @@ class PanViewPresenterNoCardSpacingTests: PresenterTestSuite {
         let textToInsert = "9999"
         let selection = NSRange(location: 1, length: 0)
 
-        _ = presenter.textField(panTextField, shouldChangeCharactersIn: selection, replacementString: textToInsert)
+        _ = presenter.textField(
+            panTextField,
+            shouldChangeCharactersIn: selection,
+            replacementString: textToInsert
+        )
 
         XCTAssertEqual("4999944433332222111", panTextField.text)
         waitThen {


### PR DESCRIPTION
## What
- align behaviour of validation feature for PAN to behaviour of the Android SDK
  - the merchant code will be notified that the PAN is invalid as the user types only if the card number entered by the end user was valid before becoming invalid. This means that when the user first starts typing their card number, the SDK does not notify anymore the merchant code that the PAN is invalid. It will only notify that the PAN is invalid if the end user removes the focus from the PAN field and the card number is invalid.
  - if the end user does not type anything into the PAN field and removes the focus from the PAN field, the merchant code will be notified that the card number is invalid
  - the rest of the validation remains unchanged

## How
- `PanViewPresenter` does not forcibly notify the merchant when processing the text as the user types
-  We also have removed the `PanViewPresenter.alreadyNotifiedMerchantOfPanValidationState` flag as it is not needed anymore; it is replaced by an internal flag  on`CardValidationStateHandler` (`merchantNeverNotifiedOfPanValidationChange`). That flag is used internally so that we can forcibly notify the merchant the first time the end user exits the PAN field and if the card number is invalid. After the first time, the change of validation state will be automatically handled by the `CardValidationStateHandler` as normal
- `CardValidationStateHandler.notifyMerchantOfPanValidationState()` has been changed so that it notifies the merchant only once when called multiple times

## Why
- this is to make the merchant and end user experience similar between iOS and Android