### PR TITLE
US2144987: refactor expiry date validation code to match implementation of Pan validation

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -161,7 +161,6 @@ class CardFlowViewController: UIViewController {
 
         AccessCheckoutValidationInitialiser().initialise(validationConfig)
 
-        expiryDateValidChanged(isValid: false)
         cvcValidChanged(isValid: false)
         disableSubmitIfNotValid(valid: false)
         cardBrandChanged(cardBrand: nil)

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -105,6 +105,8 @@ class CardFlowCardValidationTests: XCTestCase {
 
     func testPartialExpiryDateIsInvalid() {
         view!.typeTextIntoExpiryDate("12")
+        
+        view!.panField.tap() // we move the focus to another field so that the validation triggers
 
         XCTAssertEqual(view!.expiryDateIsValidLabel.label, "invalid")
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
@@ -1,16 +1,18 @@
 class CardValidationStateHandler {
     private(set) var merchantDelegate: AccessCheckoutCardValidationDelegate
 
-    private var notifyMerchantOfPanValidationChangeIsPending = false
-    private var merchantNeverNotifiedOfPanValidationChange = true
-
     private(set) var panIsValid = false
-    private(set) var cardBrand: CardBrandModel?
     private(set) var expiryDateIsValid = false
     private(set) var cvcIsValid = false
+    private(set) var cardBrand: CardBrandModel?
     private let cardBrandModelTransformer: CardBrandModelTransformer
 
-    private(set) var alreadyNotifiedMerchantOfExpiryDateValidationState = false
+    private var notifyMerchantOfPanValidationChangeIsPending = false
+    private var merchantNeverNotifiedOfPanValidationChange = true
+    
+    private var notifyMerchantOfExpiryDateValidationChangeIsPending = false
+    private var merchantNeverNotifiedOfExpiryDateValidationChange = true
+    
     private(set) var alreadyNotifiedMerchantOfCvcValidationState = false
 
     init(_ merchantDelegate: AccessCheckoutCardValidationDelegate) {
@@ -110,6 +112,7 @@ extension CardValidationStateHandler: ExpiryDateValidationStateHandler {
     func handleExpiryDateValidation(isValid: Bool) {
         if isValid != expiryDateIsValid {
             expiryDateIsValid = isValid
+            notifyMerchantOfExpiryDateValidationChangeIsPending = true
             notifyMerchantOfExpiryDateValidationState()
 
             if allFieldsValid() {
@@ -119,8 +122,14 @@ extension CardValidationStateHandler: ExpiryDateValidationStateHandler {
     }
 
     func notifyMerchantOfExpiryDateValidationState() {
-        merchantDelegate.expiryDateValidChanged(isValid: expiryDateIsValid)
-        alreadyNotifiedMerchantOfExpiryDateValidationState = true
+        if notifyMerchantOfExpiryDateValidationChangeIsPending
+            || merchantNeverNotifiedOfExpiryDateValidationChange{
+            
+            merchantNeverNotifiedOfExpiryDateValidationChange = false
+            notifyMerchantOfExpiryDateValidationChangeIsPending = false
+            
+            merchantDelegate.expiryDateValidChanged(isValid: expiryDateIsValid)
+        }
     }
 }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/expiryDate/ExpiryDateValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/expiryDate/ExpiryDateValidationFlow.swift
@@ -12,9 +12,7 @@ class ExpiryDateValidationFlow {
         expiryValidationStateHandler.handleExpiryDateValidation(isValid: result)
     }
 
-    func notifyMerchantIfNotAlreadyNotified() {
-        if !expiryValidationStateHandler.alreadyNotifiedMerchantOfExpiryDateValidationState {
-            expiryValidationStateHandler.notifyMerchantOfExpiryDateValidationState()
-        }
+    func notifyMerchant() {
+        expiryValidationStateHandler.notifyMerchantOfExpiryDateValidationState()
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/expiryDate/ExpiryDateValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/expiryDate/ExpiryDateValidationStateHandler.swift
@@ -2,6 +2,4 @@ protocol ExpiryDateValidationStateHandler {
     func handleExpiryDateValidation(isValid: Bool)
     
     func notifyMerchantOfExpiryDateValidationState()
-    
-    var alreadyNotifiedMerchantOfExpiryDateValidationState: Bool { get }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/ExpiryDateViewPresenter.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/ExpiryDateViewPresenter.swift
@@ -19,7 +19,7 @@ class ExpiryDateViewPresenter: NSObject, Presenter {
     }
     
     func onEditEnd(text: String) {
-        validationFlow.notifyMerchantIfNotAlreadyNotified()
+        validationFlow.notifyMerchant()
     }
     
     func canChangeText(with text: String) -> Bool {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationFlow.swift
@@ -52,19 +52,19 @@ import Cuckoo
     
     
     
-     override func notifyMerchantIfNotAlreadyNotified()  {
+     override func notifyMerchant()  {
         
     return cuckoo_manager.call(
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
                 
-                super.notifyMerchantIfNotAlreadyNotified()
+                super.notifyMerchant()
                 ,
-            defaultCall: __defaultImplStub!.notifyMerchantIfNotAlreadyNotified())
+            defaultCall: __defaultImplStub!.notifyMerchant())
         
     }
     
@@ -91,11 +91,11 @@ import Cuckoo
         
         
         
-        func notifyMerchantIfNotAlreadyNotified() -> Cuckoo.ClassStubNoReturnFunction<()> {
+        func notifyMerchant() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidationFlow.self, method:
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """, parameterMatchers: matchers))
         }
         
@@ -131,11 +131,11 @@ import Cuckoo
         
         
         @discardableResult
-        func notifyMerchantIfNotAlreadyNotified() -> Cuckoo.__DoNotUse<(), Void> {
+        func notifyMerchant() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
     """
-    notifyMerchantIfNotAlreadyNotified()
+    notifyMerchant()
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -161,7 +161,7 @@ import Cuckoo
     
     
     
-     override func notifyMerchantIfNotAlreadyNotified()   {
+     override func notifyMerchant()   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationStateHandler.swift
@@ -25,22 +25,6 @@ import Cuckoo
     
 
     
-    
-    
-    
-     var alreadyNotifiedMerchantOfExpiryDateValidationState: Bool {
-        get {
-            return cuckoo_manager.getter("alreadyNotifiedMerchantOfExpiryDateValidationState",
-                superclassCall:
-                    
-                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                    ,
-                defaultCall: __defaultImplStub!.alreadyNotifiedMerchantOfExpiryDateValidationState)
-        }
-        
-    }
-    
-    
 
     
 
@@ -95,13 +79,6 @@ import Cuckoo
         
         
         
-        var alreadyNotifiedMerchantOfExpiryDateValidationState: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockExpiryDateValidationStateHandler, Bool> {
-            return .init(manager: cuckoo_manager, name: "alreadyNotifiedMerchantOfExpiryDateValidationState")
-        }
-        
-        
-        
-        
         
         func handleExpiryDateValidation<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
@@ -137,13 +114,6 @@ import Cuckoo
         }
     
         
-        
-        
-        var alreadyNotifiedMerchantOfExpiryDateValidationState: Cuckoo.VerifyReadOnlyProperty<Bool> {
-            return .init(manager: cuckoo_manager, name: "alreadyNotifiedMerchantOfExpiryDateValidationState", callMatcher: callMatcher, sourceLocation: sourceLocation)
-        }
-        
-        
     
         
         
@@ -175,17 +145,6 @@ import Cuckoo
 
 
  class ExpiryDateValidationStateHandlerStub: ExpiryDateValidationStateHandler {
-    
-    
-    
-    
-     var alreadyNotifiedMerchantOfExpiryDateValidationState: Bool {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (Bool).self)
-        }
-        
-    }
-    
     
 
     

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
@@ -228,14 +228,6 @@ class CardValidationStateHandlerTests: XCTestCase {
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
     
-    func testNotifyMerchantOfExpiryDateValidationState_setsNotificationState() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate)
-        
-        validationStateHandler.notifyMerchantOfExpiryDateValidationState()
-        
-        XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfExpiryDateValidationState)
-    }
-    
     func testNotifyMerchantOfExpiryDateValidationState_notifiesMerchantOfValidExpiryDate() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, expiryDateValidationState: true)
         

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidationFlowTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidationFlowTests.swift
@@ -19,14 +19,14 @@ class ExpiryDateValidationFlowTests: XCTestCase {
         verify(expiryDateValidationStateHandler).handleExpiryDateValidation(isValid: expectedResult)
     }
     
-    func testCanNotifyMerchantIfNotAlreadyNotified() {
+    func testCanNotifyMerchant() {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().expiryDateValidChanged(isValid: any()).thenDoNothing()
         let expiryDateValidator = ExpiryDateValidator()
         let expiryDateValidationStateHandler = CardValidationStateHandler(merchantDelegate)
         let expiryDateValidationFlow = ExpiryDateValidationFlow(expiryDateValidator, expiryDateValidationStateHandler)
         
-        expiryDateValidationFlow.notifyMerchantIfNotAlreadyNotified()
+        expiryDateValidationFlow.notifyMerchant()
         
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
@@ -42,7 +42,7 @@ class ExpiryDateValidationFlowTests: XCTestCase {
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
         clearInvocations(merchantDelegate)
         
-        expiryDateValidationFlow.notifyMerchantIfNotAlreadyNotified()
+        expiryDateValidationFlow.notifyMerchant()
         
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/ExpiryDateViewPresenterTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/ExpiryDateViewPresenterTests.swift
@@ -8,7 +8,7 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
 
     override func setUp() {
         expiryDateValidationFlow.getStubbingProxy().validate(expiryDate: any()).thenDoNothing()
-        expiryDateValidationFlow.getStubbingProxy().notifyMerchantIfNotAlreadyNotified().thenDoNothing()
+        expiryDateValidationFlow.getStubbingProxy().notifyMerchant().thenDoNothing()
         expiryDateValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(true)
     }
 
@@ -27,7 +27,7 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
 
         presenter.onEditEnd(text: expiryDate)
 
-        verify(expiryDateValidationFlow).notifyMerchantIfNotAlreadyNotified()
+        verify(expiryDateValidationFlow).notifyMerchant()
     }
 
     func testCanChangeTextWithEmptyText() {
@@ -75,7 +75,7 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
         presenter.textFieldDidEndEditing(expiryDateTextField)
-        verify(expiryDateValidationFlow).notifyMerchantIfNotAlreadyNotified()
+        verify(expiryDateValidationFlow).notifyMerchant()
     }
 
     // MARK: tests for the text formatting


### PR DESCRIPTION
### What
- refactor expiry date validation code to match implementation of Pan validation
- The validation behaviour remains unchaanged:
  - the merchant code will be notified that the expiry date is invalid as the user types only if the Expiry date entered by the end user was valid before becoming invalid. This means that when the user first starts typing their Expiry date, the SDK does not notify the merchant code that the Expiry date is invalid. It will only notify them if the end user removes the focus from the Expiry date field and the Expiry date is invalid.
  - if the end user does not type anything into the Expiry date field and removes the focus from the Expiry date field, the merchant code will be notified that the Expiry date is invalid
  - the merchant code will be notified that the expiry date is valid as the user types and the expiry date is detected as valid

### How
- We have removed the `ExpiryDateViewPresenter.alreadyNotifiedMerchantOfExpiryDateValidationState` flag as it is not needed anymore; it is replaced by an internal flag `onCardValidationStateHandler`(`merchantNeverNotifiedOfExpiryDateValidationChange`). That flag is used internally so that we can forcibly notify the merchant the first time the end user exits the Expiry date field and if the expiry date is invalid. After the first time, the change of validation state will be automatically handled by the `CardValidationStateHandler` as normal
- CardValidationStateHandler.notifyMerchantOfExpiryDateValidationState()` has been changed so that it notifies the merchant only once when called multiple times

### Why
- this is to make our implementation of the validation consistent across our SDK