### PR TITLE
US2132075: Added support for field hints

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -29,7 +29,7 @@ class CardFlowViewController: UIViewController {
 
         let sessionTypes: Set<SessionType> =
             paymentsCvcSessionToggle.isOn
-            ? [SessionType.card, SessionType.cvc] : [SessionType.card]
+                ? [SessionType.card, SessionType.cvc] : [SessionType.card]
 
         let cardDetails = try! CardDetailsBuilder().pan(panTextField)
             .expiryDate(expiryDateTextField)
@@ -57,9 +57,9 @@ class CardFlowViewController: UIViewController {
                     if sessionTypes.count > 1 {
                         titleToDisplay = "Card & CVC Sessions"
                         messageToDisplay = """
-                            \(sessions[SessionType.card]!)
-                            \(sessions[SessionType.cvc]!)
-                            """
+                        \(sessions[SessionType.card]!)
+                        \(sessions[SessionType.cvc]!)
+                        """
                     } else {
                         titleToDisplay = "Card Session"
                         messageToDisplay = "\(sessions[SessionType.card]!)"
@@ -130,37 +130,43 @@ class CardFlowViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         panTextField.placeholder = "Card Number"
         expiryDateTextField.placeholder = "MM/YY"
         cvcTextField.placeholder = "CVC"
-        
-        //Apply onfocus listeners
-        panTextField.setOnFocusChangedListener{view, hasFocus in
-            if #available(iOS 13.0, *) {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray5
-            } else {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray
-            }
-        }
-        
-        expiryDateTextField.setOnFocusChangedListener{view, hasFocus in
-            if #available(iOS 13.0, *) {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray5
-            } else {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray
-            }
-        }
-        
-        cvcTextField.setOnFocusChangedListener{view, hasFocus in
-            if #available(iOS 13.0, *) {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray5
-            } else {
-                view.borderColor = hasFocus ? .systemBlue : .systemGray
 
+        panTextField.textContentType = UITextContentType.creditCardNumber
+        if #available(iOS 17.0, *) {
+            // creditCardExpiration and creditCardSecurityCode are only available in iOS17+
+            expiryDateTextField.textContentType = UITextContentType.creditCardExpiration
+            cvcTextField.textContentType = UITextContentType.creditCardSecurityCode
+        }
+
+        // Apply onfocus listeners
+        panTextField.setOnFocusChangedListener { view, hasFocus in
+            if #available(iOS 13.0, *) {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray5
+            } else {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray
             }
         }
-        
+
+        expiryDateTextField.setOnFocusChangedListener { view, hasFocus in
+            if #available(iOS 13.0, *) {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray5
+            } else {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray
+            }
+        }
+
+        cvcTextField.setOnFocusChangedListener { view, hasFocus in
+            if #available(iOS 13.0, *) {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray5
+            } else {
+                view.borderColor = hasFocus ? .systemBlue : .systemGray
+            }
+        }
+
         panTextField.font = .preferredFont(forTextStyle: .body)
         expiryDateTextField.font = .preferredFont(forTextStyle: .body)
         cvcTextField.font = .preferredFont(forTextStyle: .body)
@@ -223,7 +229,7 @@ class CardFlowViewController: UIViewController {
 extension CardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandChanged(cardBrand: CardBrand?) {
         if let imageUrl = cardBrand?.images.filter({ $0.type == "image/png" }).first?.url,
-            let url = URL(string: imageUrl)
+           let url = URL(string: imageUrl)
         {
             updateCardBrandImage(url: url)
         } else {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
@@ -7,14 +7,14 @@ class CvcFlowViewController: UIViewController {
     @IBOutlet var spinner: UIActivityIndicatorView!
     @IBOutlet var cvcIsValidLabel: UILabel!
 
-    @IBOutlet weak var dismissKeyboardButton: UIButton!
+    @IBOutlet var dismissKeyboardButton: UIButton!
 
     @IBAction func onDismissKeyboardTap(_ sender: Any) {
         _ = cvcTextField.resignFirstResponder()
     }
 
     @IBAction func submitTouchUpInsideHandler(_ sender: Any) {
-        self.cvcTextField.isEnabled = false
+        cvcTextField.isEnabled = false
 
         spinner.startAnimating()
 
@@ -41,13 +41,15 @@ class CvcFlowViewController: UIViewController {
                         closeHandler: {
                             self.cvcTextField.isEnabled = true
                             self.cvcTextField.clear()
-                        })
+                        }
+                    )
                 case .failure(let error):
                     self.cvcTextField.isEnabled = true
                     self.highlightCvcField(error: error)
 
                     AlertView.display(
-                        using: self, title: "Error", message: error.localizedDescription)
+                        using: self, title: "Error", message: error.localizedDescription
+                    )
                 }
             }
         }
@@ -60,17 +62,22 @@ class CvcFlowViewController: UIViewController {
         // This configuration property is only ever set up to true
         // wheh a specific launch argument is set to true
         // See AppLauncher in the AccessCheckoutDemoUITests
-        self.dismissKeyboardButton.isHidden = !Configuration.displayDismissKeyboardButton
+        dismissKeyboardButton.isHidden = !Configuration.displayDismissKeyboardButton
 
         cvcTextField.placeholder = "123"
         cvcTextField.font = .preferredFont(forTextStyle: .body)
-        //Apply onfocus listeners
-        cvcTextField.setOnFocusChangedListener{view, hasFocus in
+
+        if #available(iOS 17.0, *) {
+            // creditCardSecurityCode is only available in iOS17+
+            cvcTextField.textContentType = UITextContentType.creditCardSecurityCode
+        }
+
+        // Apply onfocus listeners
+        cvcTextField.setOnFocusChangedListener { view, hasFocus in
             if #available(iOS 13.0, *) {
                 view.borderColor = hasFocus ? .systemBlue : .systemGray5
             } else {
                 view.borderColor = hasFocus ? .systemBlue : .systemGray
-
             }
         }
 
@@ -104,9 +111,9 @@ class CvcFlowViewController: UIViewController {
         }
 
         var fieldToReturn: String?
-        validationErrors.forEach { validationError in
+        for validationError in validationErrors {
             if validationError.errorName == "stringFailedRegexCheck",
-                validationError.jsonPath == "$.cvv"
+               validationError.jsonPath == "$.cvv"
             {
                 fieldToReturn = validationError.jsonPath
             }

--- a/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
@@ -2,10 +2,10 @@ import AccessCheckoutSDK
 import UIKit
 
 class RestrictedCardFlowViewController: UIViewController {
-    @IBOutlet weak var panTextField: AccessCheckoutUITextField!
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var panIsValidLabel: UILabel!
-    @IBOutlet weak var dismissKeyboardButton: UIButton!
+    @IBOutlet var panTextField: AccessCheckoutUITextField!
+    @IBOutlet var imageView: UIImageView!
+    @IBOutlet var panIsValidLabel: UILabel!
+    @IBOutlet var dismissKeyboardButton: UIButton!
 
     @IBAction func onDismissKeyboardTap(_ sender: Any) {
         _ = panTextField.resignFirstResponder()
@@ -20,20 +20,22 @@ class RestrictedCardFlowViewController: UIViewController {
         // This configuration property is only ever set up to true
         // wheh a specific launch argument is set to true
         // See AppLauncher in the AccessCheckoutDemoUITests
-        self.dismissKeyboardButton.isHidden = !Configuration.displayDismissKeyboardButton
+        dismissKeyboardButton.isHidden = !Configuration.displayDismissKeyboardButton
 
+        panTextField.textContentType
         panTextField.placeholder = "Card Number"
         panTextField.font = .preferredFont(forTextStyle: .body)
-        
-        //Apply onfocus listeners
-        panTextField.setOnFocusChangedListener{view, hasFocus in
+        panTextField.textContentType = UITextContentType.creditCardNumber
+
+        // Apply onfocus listeners
+        panTextField.setOnFocusChangedListener { view, hasFocus in
             if #available(iOS 13.0, *) {
                 view.borderColor = hasFocus ? .systemBlue : .systemGray5
             } else {
                 view.borderColor = hasFocus ? .systemBlue : .systemGray
             }
         }
-        
+
         // Control used as helpers for the automated tests - Start of section
         // Label colour is changed to make it invisible
         panIsValidLabel.textColor = Configuration.backgroundColor
@@ -71,7 +73,7 @@ class RestrictedCardFlowViewController: UIViewController {
 extension RestrictedCardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandChanged(cardBrand: CardBrand?) {
         if let imageUrl = cardBrand?.images.filter({ $0.type == "image/png" }).first?.url,
-            let url = URL(string: imageUrl)
+           let url = URL(string: imageUrl)
         {
             updateCardBrandImage(url: url)
         } else {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -1,6 +1,6 @@
 import Foundation
-import UIKit
 import os
+import UIKit
 
 /// A UI component to capture the pan, expiry date or cvc of a payment card without being exposed to the text entered by the shopper.
 /// This design is to allow merchants to reach the lowest level of compliance (SAQ-A)
@@ -23,12 +23,12 @@ public final class AccessCheckoutUITextField: UIView {
 
     private var uiTextFieldConstraints: [NSLayoutConstraint] = []
 
-    private var _horizontalPadding:CGFloat = defaults.horizontalPadding
-    //Event Support
-    internal var externalOnFocusChangeListener: ((AccessCheckoutUITextField, Bool)-> Void)?
+    private var _horizontalPadding: CGFloat = defaults.horizontalPadding
+    // Event Support
+    internal var externalOnFocusChangeListener: ((AccessCheckoutUITextField, Bool) -> Void)?
 
     private func buildTextFieldWithDefaults() -> UITextField {
-        let uiTextField = FocusAwareUITextField(owner: self )
+        let uiTextField = FocusAwareUITextField(owner: self)
 
         // Apply defaults to UITextField
         uiTextField.translatesAutoresizingMaskIntoConstraints = false
@@ -39,36 +39,37 @@ public final class AccessCheckoutUITextField: UIView {
         addSubview(uiTextField)
         return uiTextField
     }
-    
+
     private final class FocusAwareUITextField: UITextField {
         var owner: AccessCheckoutUITextField
-        
-        init(owner: AccessCheckoutUITextField){
+
+        init(owner: AccessCheckoutUITextField) {
             self.owner = owner
-            //.zero is used to set size via AutoLayout instead
+            // .zero is used to set size via AutoLayout instead
             super.init(frame: .zero)
         }
-        
-        //Required initializer for UIKit support when loading from storyboards or XIBs (not supported in this case)
+
+        // Required initializer for UIKit support when loading from storyboards or XIBs (not supported in this case)
+        @available(*, unavailable)
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-        
+
         override func becomeFirstResponder() -> Bool {
             let result = super.becomeFirstResponder()
-            //Pass view
-            if result {owner.externalOnFocusChangeListener?(owner, true)}
+            // Pass view
+            if result { self.owner.externalOnFocusChangeListener?(self.owner, true) }
             return result
         }
-        
+
         override func resignFirstResponder() -> Bool {
             let result = super.resignFirstResponder()
-            //Pass view
-            if result {owner.externalOnFocusChangeListener?(owner, false)}
+            // Pass view
+            if result { self.owner.externalOnFocusChangeListener?(self.owner, false) }
             return result
         }
     }
-    
+
     /// Sets a listener to be invoked when the focus state of the `AccessCheckoutUITextField` changes.
     ///
     /// - Parameter listener: A closure that takes two parameters:
@@ -86,7 +87,7 @@ public final class AccessCheckoutUITextField: UIView {
     /// ```
     /// In the example above, the border color of the `myfield` changes to `systemBlue` when it gains focus,
     /// and reverts to `systemGray` when it loses focus.
-    public func setOnFocusChangedListener(_ listener: @escaping (AccessCheckoutUITextField, Bool)-> Void) {
+    public func setOnFocusChangedListener(_ listener: @escaping (AccessCheckoutUITextField, Bool) -> Void) {
         self.externalOnFocusChangeListener = listener
     }
 
@@ -117,37 +118,37 @@ public final class AccessCheckoutUITextField: UIView {
     }
 
     private func setLayout() {
-        if !uiTextFieldConstraints.isEmpty {
-            NSLayoutConstraint.deactivate(uiTextFieldConstraints)
+        if !self.uiTextFieldConstraints.isEmpty {
+            NSLayoutConstraint.deactivate(self.uiTextFieldConstraints)
         }
 
-        uiTextFieldConstraints = [
-            uiTextField.topAnchor.constraint(
+        self.uiTextFieldConstraints = [
+            self.uiTextField.topAnchor.constraint(
                 equalTo: topAnchor,
                 constant: AccessCheckoutUITextField.defaults.verticalPadding
             ),
-            uiTextField.bottomAnchor.constraint(
+            self.uiTextField.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
                 constant: -AccessCheckoutUITextField.defaults.verticalPadding
             ),
-            uiTextField.leadingAnchor.constraint(
+            self.uiTextField.leadingAnchor.constraint(
                 equalTo: leadingAnchor,
                 constant: self.horizontalPadding
             ),
-            uiTextField.trailingAnchor.constraint(
+            self.uiTextField.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
                 constant: -self.horizontalPadding
             ),
         ]
 
-        NSLayoutConstraint.activate(uiTextFieldConstraints)
+        NSLayoutConstraint.activate(self.uiTextFieldConstraints)
     }
 
     override public var intrinsicContentSize: CGSize {
-        let width = uiTextField.intrinsicContentSize.height
+        let width = self.uiTextField.intrinsicContentSize.height
         let height =
-            uiTextField.intrinsicContentSize.height
-            + 2 * (self.borderWidth + AccessCheckoutUITextField.defaults.verticalPadding)
+            self.uiTextField.intrinsicContentSize.height
+                + 2 * (self.borderWidth + AccessCheckoutUITextField.defaults.verticalPadding)
 
         return CGSize(width: width, height: height)
     }
@@ -172,6 +173,7 @@ public final class AccessCheckoutUITextField: UIView {
         self.uiTextField.placeholder = self.placeholder
         self.uiTextField.font = self.font
     }
+
     // MARK: Public properties
 
     /* Accessibility properties */
@@ -192,7 +194,6 @@ public final class AccessCheckoutUITextField: UIView {
         get { nil }
     }
 
-    
     /**
      An id that uniquely identifies an instance of this UI component
      */
@@ -329,6 +330,15 @@ public final class AccessCheckoutUITextField: UIView {
      */
     public var keyboardAppearance: UIKeyboardAppearance = defaults.keyboardAppearance {
         didSet { self.uiTextField.keyboardAppearance = self.keyboardAppearance }
+    }
+
+    /**
+     This property is used to improve keyboard suggestions and autofill behavior.
+     Default is nil, which means no specific content type is set.
+     */
+    @IBInspectable
+    public var textContentType: UITextContentType? {
+        didSet { self.uiTextField.textContentType = self.textContentType }
     }
 
     /* Enabled properties */

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -352,6 +352,7 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(expected, textField.uiTextField.textAlignment)
     }
     
+    
     // MARK: Placeholder properties
     
     // textAlignment
@@ -454,6 +455,19 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         textField.keyboardAppearance = expected
         
         XCTAssertEqual(expected, textField.uiTextField.keyboardAppearance)
+    }
+    
+    func testtextContentTypeByDefaultIsNil() {
+        let textField = createTextField()
+        XCTAssertEqual(nil , textField.uiTextField.textContentType)
+    }
+    
+    func testtextContentTypeSetterSetsUITextFieldProperty() {
+        let textField = createTextField()
+
+        textField.textContentType = UITextContentType.creditCardNumber
+    
+        XCTAssertEqual(UITextContentType.creditCardNumber, textField.uiTextField.textContentType)
     }
     
     // MARK: enabled properties


### PR DESCRIPTION
### What 

- Added support for field hints via textContent 
- Reformat file using swift format

### Why

So that our merchants can customize the semantic meaning of the text input fields to improve keyboard suggestions and autofill behavior, enhancing the user experience.

### How

The textContentType property was exposed as an @IBInspectable property. This allows developers to configure the UITextField's textContentType directly in Interface Builder or programmatically. 

The property synchronizes with the internal UITextField to apply the specified content type. If no value is set, the default behavior remains unchanged (nil).