### PR TITLE
Us2132077 add support for input accessory view

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -29,7 +29,7 @@ class CardFlowViewController: UIViewController {
 
         let sessionTypes: Set<SessionType> =
             paymentsCvcSessionToggle.isOn
-                ? [SessionType.card, SessionType.cvc] : [SessionType.card]
+            ? [SessionType.card, SessionType.cvc] : [SessionType.card]
 
         let cardDetails = try! CardDetailsBuilder().pan(panTextField)
             .expiryDate(expiryDateTextField)
@@ -57,9 +57,9 @@ class CardFlowViewController: UIViewController {
                     if sessionTypes.count > 1 {
                         titleToDisplay = "Card & CVC Sessions"
                         messageToDisplay = """
-                        \(sessions[SessionType.card]!)
-                        \(sessions[SessionType.cvc]!)
-                        """
+                            \(sessions[SessionType.card]!)
+                            \(sessions[SessionType.cvc]!)
+                            """
                     } else {
                         titleToDisplay = "Card Session"
                         messageToDisplay = "\(sessions[SessionType.card]!)"
@@ -224,7 +224,7 @@ class CardFlowViewController: UIViewController {
 extension CardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandChanged(cardBrand: CardBrand?) {
         if let imageUrl = cardBrand?.images.filter({ $0.type == "image/png" }).first?.url,
-           let url = URL(string: imageUrl)
+            let url = URL(string: imageUrl)
         {
             updateCardBrandImage(url: url)
         } else {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CvcFlowViewController.swift
@@ -108,7 +108,7 @@ class CvcFlowViewController: UIViewController {
         var fieldToReturn: String?
         for validationError in validationErrors {
             if validationError.errorName == "stringFailedRegexCheck",
-               validationError.jsonPath == "$.cvv"
+                validationError.jsonPath == "$.cvv"
             {
                 fieldToReturn = validationError.jsonPath
             }

--- a/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
@@ -73,7 +73,7 @@ class RestrictedCardFlowViewController: UIViewController {
 extension RestrictedCardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandChanged(cardBrand: CardBrand?) {
         if let imageUrl = cardBrand?.images.filter({ $0.type == "image/png" }).first?.url,
-           let url = URL(string: imageUrl)
+            let url = URL(string: imageUrl)
         {
             updateCardBrandImage(url: url)
         } else {

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -159,7 +159,7 @@ class CardFlowCardValidationTests: XCTestCase {
 
     func testPartialCvcIsInvalid() {
         view!.typeTextIntoCvc("12")
-        
+
         view!.panField.tap()  // we move the focus to another field so that the validation triggers
 
         XCTAssertEqual(view!.cvcIsValidLabel.label, "invalid")

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -1,6 +1,6 @@
 import Foundation
-import os
 import UIKit
+import os
 
 /// A UI component to capture the pan, expiry date or cvc of a payment card without being exposed to the text entered by the shopper.
 /// This design is to allow merchants to reach the lowest level of compliance (SAQ-A)
@@ -26,6 +26,8 @@ public final class AccessCheckoutUITextField: UIView {
     private var _horizontalPadding: CGFloat = defaults.horizontalPadding
     // Event Support
     internal var externalOnFocusChangeListener: ((AccessCheckoutUITextField, Bool) -> Void)?
+
+    private var _inputAccessoryView: UIView?
 
     private func buildTextFieldWithDefaults() -> UITextField {
         let uiTextField = FocusAwareUITextField(owner: self)
@@ -339,6 +341,19 @@ public final class AccessCheckoutUITextField: UIView {
     @IBInspectable
     public var textContentType: UITextContentType? {
         didSet { self.uiTextField.textContentType = self.textContentType }
+    }
+
+    /**
+     The accessory view to attach to the keyboard when this component receives focus
+     */
+    public override var inputAccessoryView: UIView? {
+        get {
+            _inputAccessoryView
+        }
+        set {
+            _inputAccessoryView = newValue
+            self.uiTextField.inputAccessoryView = _inputAccessoryView
+        }
     }
 
     /* Enabled properties */

--- a/AccessCheckoutSDK/AccessCheckoutSDKPactTests/CardSessionsApiDiscoveryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKPactTests/CardSessionsApiDiscoveryMock.swift
@@ -8,7 +8,10 @@ class CardSessionsApiDiscoveryMock: CardSessionsApiDiscovery {
         super.init()
     }
 
-    override func discover(baseUrl: String, completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void) {
+    override func discover(
+        baseUrl: String,
+        completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void
+    ) {
         completionHandler(.success(discoveredUrl))
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKPactTests/CvcSessionsApiDiscoveryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKPactTests/CvcSessionsApiDiscoveryMock.swift
@@ -8,7 +8,10 @@ class CvcSessionsApiDiscoveryMock: CvcSessionsApiDiscovery {
         super.init()
     }
 
-    override func discover(baseUrl: String, completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void) {
+    override func discover(
+        baseUrl: String,
+        completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void
+    ) {
         completionHandler(.success(discoveredUrl))
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKPactTests/ServiceStubs.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKPactTests/ServiceStubs.swift
@@ -1,32 +1,33 @@
-@testable import AccessCheckoutSDK
 import Swifter
+
+@testable import AccessCheckoutSDK
 
 struct ServiceStubs {
     init() {
-        self.port = UInt16.random(in: 7000 ..< 8000)
+        self.port = UInt16.random(in: 7000..<8000)
         self.httpServer = .init()
         self.baseUrl = "http://localhost:\(port)"
     }
-    
+
     let baseUrl: String
-    
+
     private let port: UInt16
     private let httpServer: HttpServer
-    
+
     func get200(path: String, jsonResponse: String) -> ServiceStubs {
         let jsonData = try! toJSON(jsonResponse)
         httpServer.GET[path] = { _ in .ok(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func start() {
         try! httpServer.start(port)
     }
-    
+
     func stop() {
         httpServer.stop()
     }
-    
+
     private func toJSON(_ content: String) throws -> Any? {
         let data = content.data(using: .utf8)
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKPactTests/SessionsConsumerPactTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKPactTests/SessionsConsumerPactTests.swift
@@ -1,16 +1,22 @@
-@testable import AccessCheckoutSDK
 import PactConsumerSwift
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class SessionsConsumerPactTests: XCTestCase {
-    let baseURI: String = Bundle(for: SessionsConsumerPactTests.self).infoDictionary?["ACCESS_CHECKOUT_BASE_URI"] as? String ?? "http://pacttest"
-    
-    let requestHeaders: [String: Any] = ["Accept": ApiHeaders.sessionsHeaderValue, "content-type": ApiHeaders.sessionsHeaderValue]
+    let baseURI: String =
+        Bundle(for: SessionsConsumerPactTests.self).infoDictionary?["ACCESS_CHECKOUT_BASE_URI"]
+        as? String ?? "http://pacttest"
+
+    let requestHeaders: [String: Any] = [
+        "Accept": ApiHeaders.sessionsHeaderValue, "content-type": ApiHeaders.sessionsHeaderValue,
+    ]
     let responseHeaders: [String: Any] = ["Content-Type": ApiHeaders.sessionsHeaderValue]
-    
-    let sessionsMockService = MockService(provider: "sessions",
-                                          consumer: "access-checkout-iOS-sdk")
-    
+
+    let sessionsMockService = MockService(
+        provider: "sessions",
+        consumer: "access-checkout-iOS-sdk")
+
     // MARK: Service discovery
 
     func testCvcSessionEndPointServiceDiscovery() {
@@ -19,44 +25,48 @@ class SessionsConsumerPactTests: XCTestCase {
         let responseJson = [
             "_links": [
                 "sessions:card": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/card", generate: expectedCardSessionUrl)
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/card", generate: expectedCardSessionUrl)
                 ],
                 "sessions:paymentsCvc": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/payments/cvc", generate: expectedPaymentsCvcSessionUrl)
-                ]
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/payments/cvc",
+                        generate: expectedPaymentsCvcSessionUrl)
+                ],
             ]
         ]
-        
+
         sessionsMockService
             .uponReceiving("GET request to /sessions to discover cvc session endpoint")
             .withRequest(
                 method: .GET,
                 path: "/sessions",
-                headers: requestHeaders)
+                headers: requestHeaders
+            )
             .willRespondWith(
                 status: 200,
                 headers: responseHeaders,
                 body: responseJson)
-        
+
         let rootResponseJson = """
-        {
-            "_links": {
-                "service:sessions": {
-                    "href": "\(sessionsMockService.baseUrl)/sessions"
+            {
+                "_links": {
+                    "service:sessions": {
+                        "href": "\(sessionsMockService.baseUrl)/sessions"
+                    }
                 }
             }
-        }
-        """
-        
+            """
+
         let serviceStubs = ServiceStubs().get200(path: "", jsonResponse: rootResponseJson)
         serviceStubs.start()
-        
+
         let discovery = CvcSessionsApiDiscovery()
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
             discovery.discover(baseUrl: serviceStubs.baseUrl) { result in
                 serviceStubs.stop()
-                
+
                 switch result {
                 case .success(let discoveredUrl):
                     XCTAssertEqual(discoveredUrl, expectedPaymentsCvcSessionUrl)
@@ -67,51 +77,55 @@ class SessionsConsumerPactTests: XCTestCase {
             }
         }
     }
-    
+
     func testCardSessionEndPointServiceDiscovery() {
         let expectedCardSessionUrl = "\(baseURI)/sessions/card"
         let expectedPaymentsCvcSessionUrl = "\(baseURI)/sessions/payments/cvc"
         let responseJson = [
             "_links": [
                 "sessions:card": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/card", generate: expectedCardSessionUrl)
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/card", generate: expectedCardSessionUrl)
                 ],
                 "sessions:paymentsCvc": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/payments/cvc", generate: expectedPaymentsCvcSessionUrl)
-                ]
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/payments/cvc",
+                        generate: expectedPaymentsCvcSessionUrl)
+                ],
             ]
         ]
-        
+
         sessionsMockService
             .uponReceiving("GET request to /sessions to discover card session endpoint")
             .withRequest(
                 method: .GET,
                 path: "/sessions",
-                headers: requestHeaders)
+                headers: requestHeaders
+            )
             .willRespondWith(
                 status: 200,
                 headers: responseHeaders,
                 body: responseJson)
-        
+
         let rootResponseJson = """
-        {
-            "_links": {
-                "service:sessions": {
-                    "href": "\(sessionsMockService.baseUrl)/sessions"
+            {
+                "_links": {
+                    "service:sessions": {
+                        "href": "\(sessionsMockService.baseUrl)/sessions"
+                    }
                 }
             }
-        }
-        """
-        
+            """
+
         let serviceStubs = ServiceStubs().get200(path: "", jsonResponse: rootResponseJson)
         serviceStubs.start()
-        
+
         let discovery = CardSessionsApiDiscovery()
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
             discovery.discover(baseUrl: serviceStubs.baseUrl) { result in
                 serviceStubs.stop()
-                
+
                 switch result {
                 case .success(let discoveredUrl):
                     XCTAssertEqual(discoveredUrl, expectedCardSessionUrl)
@@ -122,40 +136,45 @@ class SessionsConsumerPactTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: CVC session
 
     func testValidCvcSessionRequest_receivesCvcSession() {
         let requestJson: [String: Any] = [
             "cvc": "1234",
-            "identity": "identity"
+            "identity": "identity",
         ]
-        
+
         let expectedValue = "\(baseURI)/sessions/sessionURI"
         let responseJson = [
             "_links": [
                 "sessions:session": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/.+", generate: expectedValue)
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/.+", generate: expectedValue)
                 ]
             ]
         ]
-        
+
         sessionsMockService
             .uponReceiving("POST request to /sessions/payments/cvc with valid body")
             .withRequest(
                 method: .POST,
                 path: "/sessions/payments/cvc",
                 headers: requestHeaders,
-                body: requestJson)
-            .willRespondWith(status: 201,
-                             headers: responseHeaders,
-                             body: responseJson)
-        
-        let mockDiscovery = CvcSessionsApiDiscoveryMock(discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/payments/cvc")
+                body: requestJson
+            )
+            .willRespondWith(
+                status: 201,
+                headers: responseHeaders,
+                body: responseJson)
+
+        let mockDiscovery = CvcSessionsApiDiscoveryMock(
+            discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/payments/cvc")
         let sessionsClient = CvcSessionsApiClient(discovery: mockDiscovery)
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
-            sessionsClient.createSession(baseUrl: "", checkoutId: "identity", cvc: "1234") { result in
+            sessionsClient.createSession(baseUrl: "", checkoutId: "identity", cvc: "1234") {
+                result in
                 switch result {
                 case .success(let session):
                     XCTAssertEqual(session, expectedValue)
@@ -166,24 +185,26 @@ class SessionsConsumerPactTests: XCTestCase {
             }
         }
     }
-    
+
     func testCvcSessionRequestWithInvalidCheckoutId_receives400() {
         let request = PactCvcSessionRequest(
             identity: "incorrectValue",
             cvc: "123")
-        
+
         let expectedErrorResponse = ExpectedPactErrorResponse(
             mainErrorName: "bodyDoesNotMatchSchema",
             mainErrorMessage: "The json body provided does not match the expected schema",
             validationErrorName: "fieldHasInvalidValue",
             validationErrorMessage: "Identity is invalid",
             validationJsonPath: "$.identity")
-        
-        performCvcSessionTestCase(forScenario: "POST request to /sessions/payments/cvc with invalid identity in body", withRequest: request, andErrorResponse: expectedErrorResponse)
+
+        performCvcSessionTestCase(
+            forScenario: "POST request to /sessions/payments/cvc with invalid identity in body",
+            withRequest: request, andErrorResponse: expectedErrorResponse)
     }
-    
+
     // MARK: Card session
-    
+
     func testValidCardSessionRequest_receivesCardSession() {
         let requestJson: [String: Any] = [
             "cvc": "123",
@@ -191,37 +212,42 @@ class SessionsConsumerPactTests: XCTestCase {
             "cardNumber": "4111111111111111",
             "cardExpiryDate": [
                 "month": 12,
-                "year": 2099
-            ]
+                "year": 2099,
+            ],
         ]
-        
+
         let expectedValue = "\(baseURI)/sessions/sampleSessionID"
         let responseJson = [
             "_links": [
                 "sessions:session": [
-                    "href": Matcher.term(matcher: "https?://[^/]+/sessions/.+", generate: expectedValue)
+                    "href": Matcher.term(
+                        matcher: "https?://[^/]+/sessions/.+", generate: expectedValue)
                 ]
             ]
         ]
-        
+
         sessionsMockService
             .uponReceiving("POST request to /sessions/card with valid body")
             .withRequest(
                 method: .POST,
                 path: "/sessions/card",
                 headers: requestHeaders,
-                body: requestJson)
-            .willRespondWith(status: 201,
-                             headers: responseHeaders,
-                             body: responseJson)
-        
-        let mockDiscovery = CardSessionsApiDiscoveryMock(discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/card")
+                body: requestJson
+            )
+            .willRespondWith(
+                status: 201,
+                headers: responseHeaders,
+                body: responseJson)
+
+        let mockDiscovery = CardSessionsApiDiscoveryMock(
+            discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/card")
         let cardSessionClient = CardSessionsApiClient(discovery: mockDiscovery)
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
-            cardSessionClient.createSession(baseUrl: "", checkoutId: "identity", pan: "4111111111111111",
-                                            expiryMonth: 12, expiryYear: 2099, cvc: "123")
-            { result in
+            cardSessionClient.createSession(
+                baseUrl: "", checkoutId: "identity", pan: "4111111111111111",
+                expiryMonth: 12, expiryYear: 2099, cvc: "123"
+            ) { result in
                 switch result {
                 case .success(let session):
                     XCTAssertEqual(session, expectedValue)
@@ -232,7 +258,7 @@ class SessionsConsumerPactTests: XCTestCase {
             }
         }
     }
-    
+
     func testCardSessionRequestWithInvalidCheckoutId_receives400() {
         let request = PactCardSessionRequest(
             identity: "incorrectValue",
@@ -240,17 +266,19 @@ class SessionsConsumerPactTests: XCTestCase {
             cardNumber: "4111111111111111",
             expiryMonth: 12,
             expiryYear: 2099)
-        
+
         let expectedErrorResponse = ExpectedPactErrorResponse(
             mainErrorName: "bodyDoesNotMatchSchema",
             mainErrorMessage: "The json body provided does not match the expected schema",
             validationErrorName: "fieldHasInvalidValue",
             validationErrorMessage: "Identity is invalid",
             validationJsonPath: "$.identity")
-        
-        performCardSessionTestCase(forScenario: "POST request to /sessions/card with invalid identity in body", withRequest: request, andErrorResponse: expectedErrorResponse)
+
+        performCardSessionTestCase(
+            forScenario: "POST request to /sessions/card with invalid identity in body",
+            withRequest: request, andErrorResponse: expectedErrorResponse)
     }
-    
+
     func testCardSessionRequestWithCardNumberThatFailsLuhnCheck_receives400() {
         let request = PactCardSessionRequest(
             identity: "identity",
@@ -258,17 +286,20 @@ class SessionsConsumerPactTests: XCTestCase {
             cardNumber: "4111111111111110",
             expiryMonth: 12,
             expiryYear: 2099)
-        
+
         let expectedErrorResponse = ExpectedPactErrorResponse(
             mainErrorName: "bodyDoesNotMatchSchema",
             mainErrorMessage: "The json body provided does not match the expected schema",
             validationErrorName: "panFailedLuhnCheck",
-            validationErrorMessage: "The identified field contains a PAN that has failed the Luhn check.",
+            validationErrorMessage:
+                "The identified field contains a PAN that has failed the Luhn check.",
             validationJsonPath: "$.cardNumber")
-        
-        performCardSessionTestCase(forScenario: "POST request to /sessions/card with PAN that does not pass Luhn check", withRequest: request, andErrorResponse: expectedErrorResponse)
+
+        performCardSessionTestCase(
+            forScenario: "POST request to /sessions/card with PAN that does not pass Luhn check",
+            withRequest: request, andErrorResponse: expectedErrorResponse)
     }
-    
+
     func testCardSessionRequestWithInvalidMonthInExpiryDate_receives400() {
         let request = PactCardSessionRequest(
             identity: "identity",
@@ -276,17 +307,19 @@ class SessionsConsumerPactTests: XCTestCase {
             cardNumber: "4111111111111111",
             expiryMonth: 13,
             expiryYear: 2099)
-        
+
         let expectedErrorResponse = ExpectedPactErrorResponse(
             mainErrorName: "bodyDoesNotMatchSchema",
             mainErrorMessage: "The json body provided does not match the expected schema",
             validationErrorName: "integerIsTooLarge",
             validationErrorMessage: "Card expiry month is too large - must be between 1 & 12",
             validationJsonPath: "$.cardExpiryDate.month")
-        
-        performCardSessionTestCase(forScenario: "POST request to /sessions/card with expiry date month that is too large", withRequest: request, andErrorResponse: expectedErrorResponse)
+
+        performCardSessionTestCase(
+            forScenario: "POST request to /sessions/card with expiry date month that is too large",
+            withRequest: request, andErrorResponse: expectedErrorResponse)
     }
-    
+
     func testCardSessionRequestWithCardNumberThatIsNotANumber_receives400() {
         let request = PactCardSessionRequest(
             identity: "identity",
@@ -294,17 +327,19 @@ class SessionsConsumerPactTests: XCTestCase {
             cardNumber: "notACardNumber",
             expiryMonth: 1,
             expiryYear: 2099)
-        
+
         let expectedErrorResponse = ExpectedPactErrorResponse(
             mainErrorName: "bodyDoesNotMatchSchema",
             mainErrorMessage: "The json body provided does not match the expected schema",
             validationErrorName: "fieldHasInvalidValue",
             validationErrorMessage: "Card number must be numeric",
             validationJsonPath: "$.cardNumber")
-        
-        performCardSessionTestCase(forScenario: "POST request to /sessions/card with PAN containing letters", withRequest: request, andErrorResponse: expectedErrorResponse)
+
+        performCardSessionTestCase(
+            forScenario: "POST request to /sessions/card with PAN containing letters",
+            withRequest: request, andErrorResponse: expectedErrorResponse)
     }
-    
+
     private struct PactCardSessionRequest {
         let identity: String
         let cvc: String
@@ -312,22 +347,22 @@ class SessionsConsumerPactTests: XCTestCase {
         let expiryMonth: UInt
         let expiryYear: UInt
     }
-    
+
     private func performCardSessionTestCase(
         forScenario scenario: String,
         withRequest request: PactCardSessionRequest,
-        andErrorResponse response: ExpectedPactErrorResponse)
-    {
+        andErrorResponse response: ExpectedPactErrorResponse
+    ) {
         let requestJson: [String: Any] = [
             "cvc": request.cvc,
             "identity": request.identity,
             "cardNumber": request.cardNumber,
             "cardExpiryDate": [
                 "month": request.expiryMonth,
-                "year": request.expiryYear
-            ]
+                "year": request.expiryYear,
+            ],
         ]
-        
+
         let responseJson: [String: Any] = [
             "errorName": response.mainErrorName,
             "message": Matcher.somethingLike(response.mainErrorMessage),
@@ -335,57 +370,68 @@ class SessionsConsumerPactTests: XCTestCase {
                 [
                     "errorName": response.validationErrorName,
                     "message": Matcher.somethingLike(response.validationErrorMessage),
-                    "jsonPath": response.validationJsonPath
+                    "jsonPath": response.validationJsonPath,
                 ]
-            ]
+            ],
         ]
-        
+
         sessionsMockService
             .uponReceiving(scenario)
-            .withRequest(method: .POST,
-                         path: "/sessions/card",
-                         headers: requestHeaders,
-                         body: requestJson)
-            .willRespondWith(status: 400,
-                             headers: responseHeaders,
-                             body: responseJson)
-        
-        let mockDiscovery = CardSessionsApiDiscoveryMock(discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/card")
+            .withRequest(
+                method: .POST,
+                path: "/sessions/card",
+                headers: requestHeaders,
+                body: requestJson
+            )
+            .willRespondWith(
+                status: 400,
+                headers: responseHeaders,
+                body: responseJson)
+
+        let mockDiscovery = CardSessionsApiDiscoveryMock(
+            discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/card")
         let cardSessionClient = CardSessionsApiClient(discovery: mockDiscovery)
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
-            cardSessionClient.createSession(baseUrl: "", checkoutId: request.identity, pan: request.cardNumber,
-                                            expiryMonth: request.expiryMonth, expiryYear: request.expiryYear, cvc: request.cvc)
-            { result in
+            cardSessionClient.createSession(
+                baseUrl: "", checkoutId: request.identity, pan: request.cardNumber,
+                expiryMonth: request.expiryMonth, expiryYear: request.expiryYear, cvc: request.cvc
+            ) { result in
                 switch result {
                 case .success:
                     XCTFail("Service response expected to be unsuccessful")
                 case .failure(let error):
                     print(error)
-                    XCTAssertTrue(error.localizedDescription.contains(response.mainErrorName), "Error msg must contain general error code")
-                    XCTAssertTrue(error.localizedDescription.contains(response.validationErrorName), "Error msg must contain specific validation error code")
-                    XCTAssertTrue(error.localizedDescription.contains(response.validationJsonPath), "Error msg must contain path to error value")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.mainErrorName),
+                        "Error msg must contain general error code")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.validationErrorName),
+                        "Error msg must contain specific validation error code")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.validationJsonPath),
+                        "Error msg must contain path to error value")
                 }
                 testComplete()
             }
         }
     }
-    
+
     private struct PactCvcSessionRequest {
         let identity: String
         let cvc: String
     }
-    
+
     private func performCvcSessionTestCase(
         forScenario scenario: String,
         withRequest request: PactCvcSessionRequest,
-        andErrorResponse response: ExpectedPactErrorResponse)
-    {
+        andErrorResponse response: ExpectedPactErrorResponse
+    ) {
         let requestJson: [String: Any] = [
             "cvc": request.cvc,
-            "identity": request.identity
+            "identity": request.identity,
         ]
-        
+
         let responseJson: [String: Any] = [
             "errorName": response.mainErrorName,
             "message": Matcher.somethingLike(response.mainErrorMessage),
@@ -393,40 +439,52 @@ class SessionsConsumerPactTests: XCTestCase {
                 [
                     "errorName": response.validationErrorName,
                     "message": Matcher.somethingLike(response.validationErrorMessage),
-                    "jsonPath": response.validationJsonPath
+                    "jsonPath": response.validationJsonPath,
                 ]
-            ]
+            ],
         ]
-        
+
         sessionsMockService
             .uponReceiving(scenario)
-            .withRequest(method: .POST,
-                         path: "/sessions/payments/cvc",
-                         headers: requestHeaders,
-                         body: requestJson)
-            .willRespondWith(status: 400,
-                             headers: responseHeaders,
-                             body: responseJson)
-        
-        let mockDiscovery = CvcSessionsApiDiscoveryMock(discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/payments/cvc")
+            .withRequest(
+                method: .POST,
+                path: "/sessions/payments/cvc",
+                headers: requestHeaders,
+                body: requestJson
+            )
+            .willRespondWith(
+                status: 400,
+                headers: responseHeaders,
+                body: responseJson)
+
+        let mockDiscovery = CvcSessionsApiDiscoveryMock(
+            discoveredUrl: "\(sessionsMockService.baseUrl)/sessions/payments/cvc")
         let sessionsClient = CvcSessionsApiClient(discovery: mockDiscovery)
-        
+
         sessionsMockService.run(timeout: 10) { testComplete in
-            sessionsClient.createSession(baseUrl: "", checkoutId: request.identity, cvc: request.cvc) { result in
+            sessionsClient.createSession(
+                baseUrl: "", checkoutId: request.identity, cvc: request.cvc
+            ) { result in
                 switch result {
                 case .success:
                     XCTFail("Service response expected to be unsuccessful")
                 case .failure(let error):
                     print(error)
-                    XCTAssertTrue(error.localizedDescription.contains(response.mainErrorName), "Error msg must contain general error code")
-                    XCTAssertTrue(error.localizedDescription.contains(response.validationErrorName), "Error msg must contain specific validation error code")
-                    XCTAssertTrue(error.localizedDescription.contains(response.validationJsonPath), "Error msg must contain path to error value")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.mainErrorName),
+                        "Error msg must contain general error code")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.validationErrorName),
+                        "Error msg must contain specific validation error code")
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(response.validationJsonPath),
+                        "Error msg must contain path to error value")
                 }
                 testComplete()
             }
         }
     }
-    
+
     private struct ExpectedPactErrorResponse {
         let mainErrorName: String
         let mainErrorMessage: String

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/AppDelegate.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/AppDelegate.swift
@@ -3,27 +3,33 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        return UISceneConfiguration(
+            name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    func application(
+        _ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>
+    ) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
 }
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/SceneDelegate.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/SceneDelegate.swift
@@ -4,12 +4,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(
+        _ scene: UIScene, willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard (scene as? UIWindowScene) != nil else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -40,6 +42,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
 }
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
@@ -14,18 +14,22 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        panWithSpacing.addTarget(self, action: #selector(recordPanWithSpacingCaretPosition), for: .editingDidEnd)
+        panWithSpacing.addTarget(
+            self, action: #selector(recordPanWithSpacingCaretPosition), for: .editingDidEnd)
         initialiseValidation(usingCardNumberField: panWithSpacing, cardNumberSpacingEnabled: true)
 
-        panWithoutSpacing.addTarget(self, action: #selector(recordPanWithoutSpacingCaretPosition), for: .editingDidEnd)
-        initialiseValidation(usingCardNumberField: panWithoutSpacing, cardNumberSpacingEnabled: false)
+        panWithoutSpacing.addTarget(
+            self, action: #selector(recordPanWithoutSpacingCaretPosition), for: .editingDidEnd)
+        initialiseValidation(
+            usingCardNumberField: panWithoutSpacing, cardNumberSpacingEnabled: false)
     }
 
     // MARK: Event handlers for Methods for pan with spacing
 
     @IBAction func panWithSpacingSetButton_touchHandler(_ sender: Any) {
         guard let caretPositionText = setPanWithSpacingCaretPositionTextField.text,
-            !caretPositionText.isEmpty else {
+            !caretPositionText.isEmpty
+        else {
             return
         }
 
@@ -41,7 +45,8 @@ class ViewController: UIViewController {
 
     @IBAction func panWithoutSpacingSetButton_touchHandler(_ sender: Any) {
         guard let caretPositionText = setPanWithoutSpacingCaretPositionTextField.text,
-            !caretPositionText.isEmpty else {
+            !caretPositionText.isEmpty
+        else {
             return
         }
 
@@ -53,18 +58,21 @@ class ViewController: UIViewController {
         displayPanCaretPosition(of: sender, in: panWithoutSpacingCaretPositionTextField)
     }
 
-    private func displayPanCaretPosition(of ofUiTextField: UITextField,
-                                         in inTextField: UITextField)
-    {
+    private func displayPanCaretPosition(
+        of ofUiTextField: UITextField,
+        in inTextField: UITextField
+    ) {
         if let textRange = ofUiTextField.selectedTextRange {
-            let caretPosition = ofUiTextField.offset(from: ofUiTextField.beginningOfDocument, to: textRange.start)
+            let caretPosition = ofUiTextField.offset(
+                from: ofUiTextField.beginningOfDocument, to: textRange.start)
             inTextField.text = "\(caretPosition)"
         }
     }
 
-    private func setPanCaret(in accessCheckoutUITextField: AccessCheckoutUITextField,
-                             with caretPositionText: String)
-    {
+    private func setPanCaret(
+        in accessCheckoutUITextField: AccessCheckoutUITextField,
+        with caretPositionText: String
+    ) {
         var caretPositionFrom: UITextPosition
         var caretPositionTo: UITextPosition
 
@@ -73,22 +81,30 @@ class ViewController: UIViewController {
             let split = caretPositionText.split(separator: "|")
             let start = Int(split[0])!
             let length = Int(split[1])!
-            caretPositionFrom = accessCheckoutUITextField.position(from: accessCheckoutUITextField.beginningOfDocument, offset: start)!
-            caretPositionTo = accessCheckoutUITextField.position(from: accessCheckoutUITextField.beginningOfDocument, offset: start + length)!
+            caretPositionFrom = accessCheckoutUITextField.position(
+                from: accessCheckoutUITextField.beginningOfDocument, offset: start)!
+            caretPositionTo = accessCheckoutUITextField.position(
+                from: accessCheckoutUITextField.beginningOfDocument, offset: start + length)!
         } else {
-            caretPositionFrom = accessCheckoutUITextField.position(from: accessCheckoutUITextField.beginningOfDocument, offset: Int(caretPositionText)!)!
-            caretPositionTo = accessCheckoutUITextField.position(from: accessCheckoutUITextField.beginningOfDocument, offset: Int(caretPositionText)!)!
+            caretPositionFrom = accessCheckoutUITextField.position(
+                from: accessCheckoutUITextField.beginningOfDocument, offset: Int(caretPositionText)!
+            )!
+            caretPositionTo = accessCheckoutUITextField.position(
+                from: accessCheckoutUITextField.beginningOfDocument, offset: Int(caretPositionText)!
+            )!
         }
 
         _ = accessCheckoutUITextField.becomeFirstResponder()
-        accessCheckoutUITextField.selectedTextRange = accessCheckoutUITextField.textRange(from: caretPositionFrom, to: caretPositionTo)
+        accessCheckoutUITextField.selectedTextRange = accessCheckoutUITextField.textRange(
+            from: caretPositionFrom, to: caretPositionTo)
     }
 
     // MARK: methods related to Access Checkout SDK
 
-    private func initialiseValidation(usingCardNumberField panAccessCheckoutUITextField: AccessCheckoutUITextField,
-                                      cardNumberSpacingEnabled: Bool)
-    {
+    private func initialiseValidation(
+        usingCardNumberField panAccessCheckoutUITextField: AccessCheckoutUITextField,
+        cardNumberSpacingEnabled: Bool
+    ) {
         let validationConfigBuilder = CardValidationConfig.builder()
             .pan(panAccessCheckoutUITextField)
             .expiryDate(AccessCheckoutUITextField(frame: CGRect()))

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFieldsExistUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFieldsExistUITests.swift
@@ -2,29 +2,29 @@ import XCTest
 
 class PanWithSpacingFieldsExistUITests: XCTestCase {
     private let backspace = String(XCUIKeyboardKey.delete.rawValue)
-    
+
     let app = XCUIApplication()
     var view: PanWithSpacingPageObject?
-    
+
     override func setUp() {
         continueAfterFailure = false
-        
+
         app.launch()
         view = PanWithSpacingPageObject(app)
     }
-    
+
     func testCardNumberTextField_exists() {
         XCTAssertTrue(view!.panField.exists)
     }
-    
+
     func testTextFieldToReadCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.panCaretPositionTextField.exists)
     }
-    
+
     func testTextFieldToSetCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.setPanCaretPositionTextField.exists)
     }
-    
+
     func testButtonToSetCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.setPanCaretPositionButton.exists)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
@@ -1,140 +1,142 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class PanWithSpacingFormattingUITests: XCTestCase {
     private let backspace = String(XCUIKeyboardKey.delete.rawValue)
-    
+
     let app = XCUIApplication()
     var view: PanWithSpacingPageObject?
-    
+
     override func setUp() {
         continueAfterFailure = false
-        
+
         app.launch()
         view = PanWithSpacingPageObject(app)
     }
-    
+
     // MARK: Tests by inserting deleting text
-    
+
     func testCorrectlyFormatsWhenTypingInMiddleOfPan() {
         view!.typeTextIntoPan("4111")
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["4"])
-        
+
         XCTAssertEqual(view!.panText!, "4114 1")
     }
-    
+
     func testCorrectlyFormatsWhenPastingAndTypingInMiddleOfPan() {
         view!.typeTextIntoPan("4111")
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["123", "5"])
-        
+
         XCTAssertEqual(view!.panText!, "4111 2351")
     }
-    
+
     func testCorrectlyFormatsWhenDeletingInMiddleOfPan() {
         view!.typeTextIntoPan("4321 4321")
         view!.setPanCaretAtAndTypeIn(position: 3, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "4314 321")
     }
-    
+
     func testCorrectlyFormatsWhenDeletingAndThenTypingInMiddleOfPan() {
         view!.typeTextIntoPan("4321 4321")
-        view!.setPanCaretAtAndTypeIn(position: 3, text: [backspace, backspace, "3", "1234", backspace])
-        
+        view!.setPanCaretAtAndTypeIn(
+            position: 3, text: [backspace, backspace, "3", "1234", backspace])
+
         XCTAssertEqual(view!.panText!, "4312 3143 21")
     }
-    
+
     func testCanDeleteSingleDigitAfterSpace() {
         view!.typeTextIntoPan("43214")
         XCTAssertEqual(view!.panText!, "4321 4")
-        
+
         view!.typeTextIntoPan(backspace)
         XCTAssertEqual(view!.panText!, "4321")
         XCTAssertEqual(4, view!.panCaretPosition())
     }
-    
+
     func testCanDeleteFirstDigit() {
         view!.typeTextIntoPan("432145")
         XCTAssertEqual(view!.panText!, "4321 45")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 1, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "3214 5")
         XCTAssertEqual(0, view!.panCaretPosition())
     }
-    
+
     func testReformatsCardWhenBrandChanges() {
         view!.typeTextIntoPan("34567890123")
         XCTAssertEqual(view!.panText!, "3456 789012 3")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 0, text: ["4"])
         XCTAssertEqual(view!.panText!, "4345 6789 0123")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 0, text: ["3"])
         XCTAssertEqual(view!.panText!, "3434 567890 123")
     }
-    
+
     // MARK: Tests with text that contains digits and letters and spaces
-    
+
     func testExtractsDigitsOnlyFromAlphanumericEntry() {
         view!.typeTextIntoPan("123abc456defghi789zzzzzzzzzzz       zzzzzzzzz000")
-        
+
         XCTAssertEqual(view!.panText!, "1234 5678 9000")
     }
-    
+
     // MARK: Tests specific to spaces and caret position
-    
+
     func testDeletesSpaceAndPreviousDigitWhenDeletingSpace() {
         view!.typeTextIntoPan("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 5, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "1235 6")
         XCTAssertEqual(3, view!.panCaretPosition())
     }
-    
+
     func testDeletesSpaceAndPreviousDigitWhenDeletingSelectedSpace() {
         view!.typeTextIntoPan("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
-        
+
         view!.selectPanAndTypeIn(position: 4, selectionLength: 1, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "1235 6")
         XCTAssertEqual(3, view!.panCaretPosition())
     }
-    
+
     func testMovesCaretAfterSpaceWhenInsertingDigitAtEndOfDigitsGroup() {
         view!.typeTextIntoPan("12345")
         XCTAssertEqual(view!.panText!, "1234 5")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["6"])
-        
+
         XCTAssertEqual(view!.panText!, "1236 45")
         XCTAssertEqual(5, view!.panCaretPosition())
     }
-    
+
     func testLeavesCaretAfterSpaceWhenDeletingDigitWhichIsJustAfterSpace() {
         view!.typeTextIntoPan("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
-        
+
         view!.setPanCaretAtAndTypeIn(position: 6, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "1234 6")
         XCTAssertEqual(5, view!.panCaretPosition())
     }
-    
+
     func testLeavesCaretAtSamePositionWhenSelectingTextThatStartsWithSpaceAndDeletingIt() {
         view!.typeTextIntoPan("123456789012")
         XCTAssertEqual(view!.panText!, "1234 5678 9012")
-        
+
         view!.selectPanAndTypeIn(position: 4, selectionLength: 3, text: [backspace])
-        
+
         XCTAssertEqual(view!.panText!, "1234 7890 12")
         XCTAssertEqual(4, view!.panCaretPosition())
     }
-    
+
     private func waitFor(timeoutInSeconds: Double) {
         let exp = expectation(description: "Waiting for \(timeoutInSeconds)")
         _ = XCTWaiter.wait(for: [exp], timeout: timeoutInSeconds)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFieldsExistUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFieldsExistUITests.swift
@@ -2,29 +2,29 @@ import XCTest
 
 class PanWithoutSpacingFieldsExistUITests: XCTestCase {
     private let backspace = String(XCUIKeyboardKey.delete.rawValue)
-    
+
     let app = XCUIApplication()
     var view: PanWithoutSpacingPageObject?
-    
+
     override func setUp() {
         continueAfterFailure = false
-        
+
         app.launch()
         view = PanWithoutSpacingPageObject(app)
     }
-    
+
     func testCardNumberTextField_exists() {
         XCTAssertTrue(view!.panField.exists)
     }
-    
+
     func testTextFieldToReadCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.panCaretPositionTextField.exists)
     }
-    
+
     func testTextFieldToSetCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.setPanCaretPositionTextField.exists)
     }
-    
+
     func testButtonToSetCardNumberCaretPosition_exists() {
         XCTAssertTrue(view!.setPanCaretPositionButton.exists)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFormattingUITests.swift
@@ -1,38 +1,39 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class PanWithoutSpacingFormattingUITests: XCTestCase {
     private let backspace = String(XCUIKeyboardKey.delete.rawValue)
-    
+
     let app = XCUIApplication()
     var view: PanWithoutSpacingPageObject?
-    
+
     override func setUp() {
         continueAfterFailure = false
-        
+
         app.launch()
         view = PanWithoutSpacingPageObject(app)
     }
-    
+
     // MARK: Testing disabled PAN formatting
-    
+
     func testDoesNotFormatPan() {
         view!.typeTextIntoPan("4111111111111111")
-        
+
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
-    
+
     func testCanEnterOnlyDigitsInPan() {
         view!.typeTextIntoPan("4abc11111111   1111blahblah   111")
-        
+
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
-    
+
     func testCanDeleteDigits() {
         view!.typeTextIntoPan("4111")
         XCTAssertEqual(view!.panText, "4111")
-        
+
         view!.typeTextIntoPan(backspace)
         wait(0.5)
         XCTAssertEqual(view!.panText, "411")
@@ -49,10 +50,9 @@ class PanWithoutSpacingFormattingUITests: XCTestCase {
         wait(0.5)
         XCTAssertEqual(view!.panText, "Card number")
     }
-    
+
     private func wait(_ timeoutInSeconds: TimeInterval) {
         let exp = XCTestCase().expectation(description: "Waiting for \(timeoutInSeconds)")
         _ = XCTWaiter.wait(for: [exp], timeout: timeoutInSeconds)
     }
 }
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
@@ -8,12 +8,13 @@ class PanBasePageObject {
     private var setPanCaretPositionTextFieldIdentifier: String = ""
     private var setPanCaretPositionButtonIdentifier: String = ""
 
-    init(app: XCUIApplication,
-         panFieldIdentifier: String,
-         panCaretPositionTextFieldIdentifier: String,
-         setPanCaretPositionTextFieldIdentifier: String,
-         setPanCaretPositionButtonIdentifier: String)
-    {
+    init(
+        app: XCUIApplication,
+        panFieldIdentifier: String,
+        panCaretPositionTextFieldIdentifier: String,
+        setPanCaretPositionTextFieldIdentifier: String,
+        setPanCaretPositionButtonIdentifier: String
+    ) {
         self.app = app
         self.panFieldIdentifier = panFieldIdentifier
         self.panCaretPositionTextFieldIdentifier = panCaretPositionTextFieldIdentifier

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanWithSpacingPageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanWithSpacingPageObject.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 
 class PanWithSpacingPageObject: PanBasePageObject {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanWithoutSpacingPageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanWithoutSpacingPageObject.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 
 class PanWithoutSpacingPageObject: PanBasePageObject {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiHeadersTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiHeadersTests.swift
@@ -1,8 +1,10 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ApiHeadersTest: XCTestCase {
     func test_sessionsHeaderValue_pointsToSessionsV1() {
-        XCTAssertEqual(ApiHeaders.sessionsHeaderValue, "application/vnd.worldpay.sessions-v1.hal+json")
+        XCTAssertEqual(
+            ApiHeaders.sessionsHeaderValue, "application/vnd.worldpay.sessions-v1.hal+json")
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiLinksTest.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiLinksTest.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ApiLinksTest: XCTestCase {
     func test_cardSession_discoversSessionServiceAndCardSessionEndPoint() {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiResponseLinkLookupTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiResponseLinkLookupTests.swift
@@ -1,46 +1,47 @@
-@testable import AccessCheckoutSDK
 import XCTest
 
-class ApiResponseLinkLookupTests : XCTestCase {
+@testable import AccessCheckoutSDK
+
+class ApiResponseLinkLookupTests: XCTestCase {
     func testReturnsValueOfLink() {
         let apiResponseLinkLookup = ApiResponseLinkLookup()
         let jsonString = """
-        {
-            "_links": {
-                "some:link": {
-                    "href": "http://www.some-service.co.uk"
-                },
-                "a:link": {
-                    "href": "http://www.a-service.co.uk"
+            {
+                "_links": {
+                    "some:link": {
+                        "href": "http://www.some-service.co.uk"
+                    },
+                    "a:link": {
+                        "href": "http://www.a-service.co.uk"
+                    }
                 }
             }
-        }
-        """
+            """
         let apiResponse = toApiResponse(jsonString)
-        
+
         let result = apiResponseLinkLookup.lookup(link: "a:link", in: apiResponse)
-        
+
         XCTAssertEqual("http://www.a-service.co.uk", result)
     }
-    
+
     func testReturnsNilIfLinkIsNotFound() {
         let apiResponseLinkLookup = ApiResponseLinkLookup()
         let jsonString = """
-        {
-            "_links": {
-                "some:link": {
-                    "href": "http://www.some-service.co.uk"
+            {
+                "_links": {
+                    "some:link": {
+                        "href": "http://www.some-service.co.uk"
+                    }
                 }
             }
-        }
-        """
+            """
         let apiResponse = toApiResponse(jsonString)
-        
+
         let result = apiResponseLinkLookup.lookup(link: "a:link", in: apiResponse)
-        
+
         XCTAssertNil(result)
     }
-    
+
     private func toApiResponse(_ jsonString: String) -> ApiResponse {
         let data = Data(jsonString.utf8)
         return try! JSONDecoder().decode(ApiResponse.self, from: data)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiResponseTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ApiResponseTests.swift
@@ -1,53 +1,54 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ApiResponseTests: XCTestCase {
     func testSuccessfullyDecodesAnApiResponse() throws {
         let expectedLink1Name = "link 1 name"
         let expectedLink1Href = "link 1 value"
-        
+
         let expectedLink2Name = "link 2 name"
         let expectedLink2Href = "link 2 value"
-        
+
         let expectedCurie1Href = "https://access.worldpay.com/rels/sessions/{rel}.json"
         let expectedCurie1Name = "sessions"
         let expectedCurie1Templated = true
-        
+
         let responseAsJsonString = """
-        {
-            "_links": {
-                "\(expectedLink1Name)": {
-                    "href": "\(expectedLink1Href)"
-                },
-                "\(expectedLink2Name)": {
-                    "href": "\(expectedLink2Href)"
-                },
-                "curies": [
-                    {
-                        "href": "\(expectedCurie1Href)",
-                        "name": "\(expectedCurie1Name)",
-                        "templated": \(expectedCurie1Templated)
-                    }
-                ]
+            {
+                "_links": {
+                    "\(expectedLink1Name)": {
+                        "href": "\(expectedLink1Href)"
+                    },
+                    "\(expectedLink2Name)": {
+                        "href": "\(expectedLink2Href)"
+                    },
+                    "curies": [
+                        {
+                            "href": "\(expectedCurie1Href)",
+                            "name": "\(expectedCurie1Name)",
+                            "templated": \(expectedCurie1Templated)
+                        }
+                    ]
+                }
             }
-        }
-        """
-        
+            """
+
         let response = try decode(responseAsJsonString, into: ApiResponse.self)
-        
+
         XCTAssertEqual(2, response.links.endpoints.count)
         XCTAssertEqual(expectedLink1Href, response.links.endpoints[expectedLink1Name]?.href)
         XCTAssertEqual(expectedLink2Href, response.links.endpoints[expectedLink2Name]?.href)
-        
+
         XCTAssertEqual(1, response.links.curies?.count)
         XCTAssertEqual(expectedCurie1Href, response.links.curies?.first?.href)
         XCTAssertEqual(expectedCurie1Name, response.links.curies?.first?.name)
         XCTAssertEqual(expectedCurie1Templated, response.links.curies?.first?.templated)
     }
-    
+
     private func decode<T: Decodable>(_ json: String, into: T.Type) throws -> T {
         let data = json.data(using: .utf8)!
-        
+
         return try JSONDecoder().decode(T.self, from: data)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class RestClientTests: XCTestCase {
     private var serviceStubs: ServiceStubs?
@@ -20,7 +21,8 @@ class RestClientTests: XCTestCase {
         let urlSessionDataTaskMock = URLSessionDataTaskMock()
         let urlSession = URLSessionMock(forRequest: request, usingDataTask: urlSessionDataTaskMock)
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self) { _ in }
+        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
+        { _ in }
 
         XCTAssertTrue(urlSession.dataTaskCalled)
         XCTAssertTrue(urlSessionDataTaskMock.resumeCalled)
@@ -33,13 +35,14 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get200(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self) { result in
+        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
+        { result in
             switch result {
-                case .success(let response):
-                    XCTAssertEqual(1, response.id)
-                    XCTAssertEqual("some name", response.name)
-                case .failure(let error):
-                    XCTFail(error.localizedDescription)
+            case .success(let response):
+                XCTAssertEqual(1, response.id)
+                XCTAssertEqual("some name", response.name)
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
             }
             expectationToWaitFor.fulfill()
         }
@@ -51,20 +54,23 @@ class RestClientTests: XCTestCase {
         let expectationToWaitFor = XCTestExpectation(description: "")
         let request = createRequest(url: "\(serviceStubs!.baseUrl)/somewhere", method: "GET")
         let jsonResponse = """
-        {
-            "errorName": "bodyDoesNotMatchSchema",
-            "message": "The json body provided does not match the expected schema"
-        }
-        """
+            {
+                "errorName": "bodyDoesNotMatchSchema",
+                "message": "The json body provided does not match the expected schema"
+            }
+            """
         serviceStubs!.get400(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self) { result in
+        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
+        { result in
             switch result {
-                case .success:
-                    XCTFail("Expected failed response but received successful response")
-                case .failure(let error):
-                    XCTAssertEqual("bodyDoesNotMatchSchema : The json body provided does not match the expected schema", error.message)
+            case .success:
+                XCTFail("Expected failed response but received successful response")
+            case .failure(let error):
+                XCTAssertEqual(
+                    "bodyDoesNotMatchSchema : The json body provided does not match the expected schema",
+                    error.message)
             }
             expectationToWaitFor.fulfill()
         }
@@ -74,18 +80,20 @@ class RestClientTests: XCTestCase {
 
     func testRestClientProvidesGenericErrorToPromiseWhenFailingToTranslateResponse() {
         let expectationToWaitFor = XCTestExpectation(description: "")
-        let expectedError = StubUtils.createError(errorName: "responseDecodingFailed", message: "Failed to decode response data")
+        let expectedError = StubUtils.createError(
+            errorName: "responseDecodingFailed", message: "Failed to decode response data")
         let request = createRequest(url: "\(serviceStubs!.baseUrl)/somewhere", method: "GET")
         let textResponse = "some data returned"
         serviceStubs!.get200(path: "/somewhere", textResponse: textResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self) { result in
+        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
+        { result in
             switch result {
-                case .success:
-                    XCTFail("Expected failed response but received successful response")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Expected failed response but received successful response")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToWaitFor.fulfill()
         }
@@ -98,15 +106,19 @@ class RestClientTests: XCTestCase {
         let request = createRequest(url: "http://localhost/somewhere", method: "GET")
         // On BitRise, the message returned when attempting to connect to an unknown host may occasionally be different
         // Hence why we need to assert on different error messages
-        let expectedError1 = StubUtils.createError(errorName: "unexpectedApiError", message: "Could not connect to the server.")
-        let expectedError2 = StubUtils.createError(errorName: "unexpectedApiError", message: "A server with the specified hostname could not be found.")
+        let expectedError1 = StubUtils.createError(
+            errorName: "unexpectedApiError", message: "Could not connect to the server.")
+        let expectedError2 = StubUtils.createError(
+            errorName: "unexpectedApiError",
+            message: "A server with the specified hostname could not be found.")
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self) { result in
+        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
+        { result in
             switch result {
-                case .success:
-                    XCTFail("Expected failed response but received successful response")
-                case .failure(let error):
-                    XCTAssert(error == expectedError1 || error == expectedError2)
+            case .success:
+                XCTFail("Expected failed response but received successful response")
+            case .failure(let error):
+                XCTAssert(error == expectedError1 || error == expectedError2)
             }
             expectationToWaitFor.fulfill()
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/SingleLinkDiscoveryFactoryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/SingleLinkDiscoveryFactoryTests.swift
@@ -1,14 +1,16 @@
-@testable import AccessCheckoutSDK
 import XCTest
 
-class SingleLinkDiscoveryFactoryTests : XCTestCase {
+@testable import AccessCheckoutSDK
+
+class SingleLinkDiscoveryFactoryTests: XCTestCase {
     func testCreatesASingleLinkDiscovery() {
-        let urlRequest = URLRequest(url:URL(string: "http://localshot")!)
+        let urlRequest = URLRequest(url: URL(string: "http://localshot")!)
         let linkToFind = "a-link"
         let factory = SingleLinkDiscoveryFactory()
-        
-        let result:SingleLinkDiscovery = factory.create(toFindLink: linkToFind, usingRequest: urlRequest)
-        
+
+        let result: SingleLinkDiscovery = factory.create(
+            toFindLink: linkToFind, usingRequest: urlRequest)
+
         XCTAssertEqual(linkToFind, result.linkToFind)
         XCTAssertEqual(urlRequest, result.urlRequest)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/SingleLinkDiscoveryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/SingleLinkDiscoveryTests.swift
@@ -1,123 +1,127 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class SingleLinkDiscoveryTests: XCTestCase {
     private var serviceStubs: ServiceStubs?
     private var urlRequest: URLRequest?
-    
+
     override func setUp() {
         serviceStubs = ServiceStubs()
         urlRequest = URLRequest(url: URL(string: serviceStubs!.baseUrl)!)
     }
-    
+
     override func tearDown() {
         serviceStubs!.stop()
     }
-    
+
     func testsSuccessfullyDiscoversALink() {
         let expectationToFulfill = expectation(description: "")
         let jsonResponse = """
-        {
-            "_links": {
-                "some:link": {
-                    "href": "http://www.some-service.co.uk"
-                },
-                "a:link": {
-                    "href": "http://www.a-service.co.uk"
+            {
+                "_links": {
+                    "some:link": {
+                        "href": "http://www.some-service.co.uk"
+                    },
+                    "a:link": {
+                        "href": "http://www.a-service.co.uk"
+                    }
                 }
             }
-        }
-        """
+            """
         serviceStubs!.get200(path: "", jsonResponse: jsonResponse)
             .start()
-        
+
         let discovery = SingleLinkDiscovery(linkToFind: "a:link", urlRequest: urlRequest!)
-        
+
         discovery.discover { result in
             switch result {
-                case .success(let url):
-                    XCTAssertEqual("http://www.a-service.co.uk", url)
-                case .failure:
-                    XCTFail("Discovery should not have failed")
+            case .success(let url):
+                XCTAssertEqual("http://www.a-service.co.uk", url)
+            case .failure:
+                XCTFail("Discovery should not have failed")
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testReturnsErrorWhenLinkNotFoundInResponse() {
         let expectationToFulfill = expectation(description: "")
-        let expectedError = StubUtils.createError(errorName: "discoveryLinkNotFound", message: "Failed to find link a:link in response")
+        let expectedError = StubUtils.createError(
+            errorName: "discoveryLinkNotFound", message: "Failed to find link a:link in response")
         let jsonResponse = """
-        {
-            "_links": {
-                "some:link": {
-                    "href": "http://www.some-service.co.uk"
+            {
+                "_links": {
+                    "some:link": {
+                        "href": "http://www.some-service.co.uk"
+                    }
                 }
             }
-        }
-        """
+            """
         serviceStubs!.get200(path: "", jsonResponse: jsonResponse)
             .start()
-        
+
         let discovery = SingleLinkDiscovery(linkToFind: "a:link", urlRequest: urlRequest!)
-        
+
         discovery.discover { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testReturnsErrorWhenFailsToDeserialiseResponse() {
         let expectationToFulfill = expectation(description: "")
-        let expectedError = StubUtils.createError(errorName: "responseDecodingFailed", message: "Failed to decode response data")
+        let expectedError = StubUtils.createError(
+            errorName: "responseDecodingFailed", message: "Failed to decode response data")
         let response = "some-content"
-        
+
         let discovery = SingleLinkDiscovery(linkToFind: "a:link", urlRequest: urlRequest!)
 
         serviceStubs!.get200(path: "", textResponse: response)
             .start()
-        
+
         discovery.discover { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testReturnsErrorWhenResponseIsAnError() {
         let expectationToFulfill = expectation(description: "")
-        let expectedError = StubUtils.createError(errorName: "responseDecodingFailed", message: "Failed to decode response data")
+        let expectedError = StubUtils.createError(
+            errorName: "responseDecodingFailed", message: "Failed to decode response data")
         let discovery = SingleLinkDiscovery(linkToFind: "a:link", urlRequest: urlRequest!)
-        
+
         serviceStubs!.get400(path: "", textResponse: "An error")
             .start()
-        
+
         discovery.discover { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/WpSdkHeaderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/WpSdkHeaderTests.swift
@@ -1,56 +1,59 @@
-@testable import AccessCheckoutSDK
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class WpSdkHeaderTests: XCTestCase {
-    let expectedErrorMessage = "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
-    
+    let expectedErrorMessage =
+        "Unsupported version format. This functionality only supports access-checkout-react-native semantic versions or default access-checkout-ios version."
+
     func testAllowsToOverrideVersionWithAccessCheckoutReactNativeVersion() throws {
         let newVersion = "access-checkout-react-native/10.3.15"
-        
+
         try WpSdkHeader.overrideValue(with: newVersion)
-        
+
         XCTAssertEqual(newVersion, WpSdkHeader.value)
     }
-    
+
     func testThrowsErrorWhenSemanticVersionIsNotInXYZFormat() throws {
         let newVersion = "access-checkout-react-native/10.3"
-        
-        
+
         XCTAssertThrowsError(try WpSdkHeader.overrideValue(with: newVersion)) { error in
             XCTAssertEqual(expectedErrorMessage, (error as! WpSdkHeaderValueError).message)
         }
     }
-    
+
     func testThrowsErrorWhenAccessCheckoutReactNativeDoesNotHaveCorrectCase() throws {
         let newVersion = "Access-Checkout-REACT-native/10.3.15"
-        
+
         XCTAssertThrowsError(try WpSdkHeader.overrideValue(with: newVersion)) { error in
             XCTAssertEqual(expectedErrorMessage, (error as! WpSdkHeaderValueError).message)
         }
     }
-    
+
     func testThrowsErrorWhenAttemptingToOverrideWithNonAccessCheckoutReactNativeVersion() throws {
         let newVersion = "something-else/10.3.15"
-        
+
         XCTAssertThrowsError(try WpSdkHeader.overrideValue(with: newVersion)) { error in
             XCTAssertEqual(expectedErrorMessage, (error as! WpSdkHeaderValueError).message)
         }
     }
-    
+
     func testAllowsToOverrideVersionWithDefaultAccessCheckoutIosVersion() throws {
         try WpSdkHeader.overrideValue(with: WpSdkHeader.defaultValue)
-        
+
         XCTAssertEqual(WpSdkHeader.defaultValue, WpSdkHeader.value)
     }
-    
-    func testThrowsErrorWhenAttemptingToOverrideWithAccessCheckoutIosOfDifferentSemanticVersion() throws {
+
+    func testThrowsErrorWhenAttemptingToOverrideWithAccessCheckoutIosOfDifferentSemanticVersion()
+        throws
+    {
         let newVersion = "access-checkout-ios/1.2.3"
-        
+
         XCTAssertThrowsError(try WpSdkHeader.overrideValue(with: newVersion)) { error in
             XCTAssertEqual(expectedErrorMessage, (error as! WpSdkHeaderValueError).message)
         }
     }
-    
+
     override class func tearDown() {
         try! WpSdkHeader.overrideValue(with: WpSdkHeader.defaultValue)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/AccessCheckoutErrorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/AccessCheckoutErrorTests.swift
@@ -1,57 +1,58 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutErrorTests: XCTestCase {
     func testSuccessfullyDecodesAnAccessCheckoutError() throws {
         let expectedErrorName = "root error name"
         let message = "root error message"
         let expectedMessage = "\(expectedErrorName) : \(message)"
-        
+
         let expectedValidationError1ErrorName = "validation error 1"
         let expectedValidationError1Message = "validation error 1 message"
         let expectedValidationError1JsonPath = "validation error 1 json path"
-        
+
         let expectedValidationError2ErrorName = "validation error 2"
         let expectedValidationError2Message = "validation error 2 message"
         let expectedValidationError2JsonPath = "validation error 2 json path"
-        
+
         let errorAsJsonString = """
-        {
-            "errorName": "\(expectedErrorName)",
-            "message": "\(message)",
-            "validationErrors": [
-                {
-                    "errorName": "\(expectedValidationError1ErrorName)",
-                    "message": "\(expectedValidationError1Message)",
-                    "jsonPath": "\(expectedValidationError1JsonPath)"
-                },
-                {
-                    "errorName": "\(expectedValidationError2ErrorName)",
-                    "message": "\(expectedValidationError2Message)",
-                    "jsonPath": "\(expectedValidationError2JsonPath)"
-                }
-            ]
-        }
-        """
-        
+            {
+                "errorName": "\(expectedErrorName)",
+                "message": "\(message)",
+                "validationErrors": [
+                    {
+                        "errorName": "\(expectedValidationError1ErrorName)",
+                        "message": "\(expectedValidationError1Message)",
+                        "jsonPath": "\(expectedValidationError1JsonPath)"
+                    },
+                    {
+                        "errorName": "\(expectedValidationError2ErrorName)",
+                        "message": "\(expectedValidationError2Message)",
+                        "jsonPath": "\(expectedValidationError2JsonPath)"
+                    }
+                ]
+            }
+            """
+
         let error = try decode(errorAsJsonString, into: AccessCheckoutError.self)
-        
+
         XCTAssertEqual(expectedMessage, error.message)
-        
+
         XCTAssertEqual(2, error.validationErrors.count)
-        
+
         XCTAssertEqual(expectedValidationError1ErrorName, error.validationErrors[0].errorName)
         XCTAssertEqual(expectedValidationError1Message, error.validationErrors[0].message)
         XCTAssertEqual(expectedValidationError1JsonPath, error.validationErrors[0].jsonPath)
-        
+
         XCTAssertEqual(expectedValidationError2ErrorName, error.validationErrors[1].errorName)
         XCTAssertEqual(expectedValidationError2Message, error.validationErrors[1].message)
         XCTAssertEqual(expectedValidationError2JsonPath, error.validationErrors[1].jsonPath)
     }
-    
+
     private func decode<T: Decodable>(_ json: String, into: T.Type) throws -> T {
         let data = json.data(using: .utf8)!
-        
+
         return try JSONDecoder().decode(T.self, from: data)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientBuilderTests.swift
@@ -1,29 +1,30 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutClientBuilderTests: XCTestCase {
     func testBuildsAnAccessCheckoutClientUsingCheckoutId() throws {
         let builder = AccessCheckoutClientBuilder().checkoutId("123")
             .accessBaseUrl("some-url")
-        
+
         let result: AccessCheckoutClient = try builder.build()
-        
+
         XCTAssertNotNil(result)
     }
-    
+
     func testCannotBuildAnAccessCheckoutClientWithoutCallToCheckoutId() throws {
         let builder = AccessCheckoutClientBuilder().accessBaseUrl("some-url")
         let expectedMessage = "Expected checkout ID to be provided but was not"
-        
+
         XCTAssertThrowsError(try builder.build()) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
-    
+
     func testCannotBuildAnAccessCheckoutClientWithoutAccessBaseUrl() throws {
         let builder = AccessCheckoutClientBuilder().checkoutId("123")
         let expectedMessage = "Expected base url to be provided but was not"
-        
+
         XCTAssertThrowsError(try builder.build()) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
@@ -1,40 +1,43 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutClientTests: XCTestCase {
     private var serviceStubs: ServiceStubs?
-    
+
     override func setUp() {
         serviceStubs = ServiceStubs()
     }
-    
+
     override func tearDown() {
         serviceStubs?.stop()
     }
-    
+
     func testGeneratesACardSession() throws {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointsDiscoverySuccess()
             .cardSessionSuccess(session: "expected-card-session")
             .start()
-        
+
         try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card]) { result in
             switch result {
-                case .success(let sessions):
-                    XCTAssertEqual("expected-card-session", sessions[.card])
-                case .failure(let error):
-                    XCTFail("got an error back from services: \(String(describing: error.errorDescription))")
+            case .success(let sessions):
+                XCTAssertEqual("expected-card-session", sessions[.card])
+            case .failure(let error):
+                XCTFail(
+                    "got an error back from services: \(String(describing: error.errorDescription))"
+                )
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testGeneratesAPaymentsCvcSession() throws {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
@@ -44,158 +47,179 @@ class AccessCheckoutClientTests: XCTestCase {
             .sessionsEndPointsDiscoverySuccess()
             .sessionsPaymentsCvcSessionSuccess(session: "expected-cvc-session")
             .start()
-        
+
         try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.cvc]) { result in
             switch result {
-                case .success(let sessions):
-                    XCTAssertEqual("expected-cvc-session", sessions[.cvc])
-                case .failure(let error):
-                    XCTFail("got an error back from services: \(String(describing: error.errorDescription))")
+            case .success(let sessions):
+                XCTAssertEqual("expected-cvc-session", sessions[.cvc])
+            case .failure(let error):
+                XCTFail(
+                    "got an error back from services: \(String(describing: error.errorDescription))"
+                )
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testGeneratesACardSessionAndACvcSession() throws {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointsDiscoverySuccess()
             .cardSessionSuccess(session: "expected-card-session")
             .sessionsPaymentsCvcSessionSuccess(session: "expected-cvc-session")
             .start()
-        
-        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) { result in
+
+        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) {
+            result in
             switch result {
-                case .success(let sessions):
-                    XCTAssertEqual("expected-card-session", sessions[.card])
-                    XCTAssertEqual("expected-cvc-session", sessions[.cvc])
-                case .failure(let error):
-                    XCTFail("got an error back from services: \(String(describing: error.errorDescription))")
+            case .success(let sessions):
+                XCTAssertEqual("expected-card-session", sessions[.card])
+                XCTAssertEqual("expected-cvc-session", sessions[.cvc])
+            case .failure(let error):
+                XCTFail(
+                    "got an error back from services: \(String(describing: error.errorDescription))"
+                )
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
-    func testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndOneOfTheServicesResponsesWithAnError() throws {
+
+    func
+        testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndOneOfTheServicesResponsesWithAnError()
+        throws
+    {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
         let expectedError = StubUtils.createError(errorName: "unknown", message: "an error")
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointsDiscoverySuccess()
             .cardSessionFailure(error: expectedError)
             .sessionsPaymentsCvcSessionSuccess(session: "expected-card-session")
             .start()
-        
-        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) { result in
+
+        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) {
+            result in
             switch result {
-                case .success:
-                    XCTFail("Should have received an error but received sessions")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Should have received an error but received sessions")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
-    func testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndBothServicesRespondWithAnError() throws {
+
+    func testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndBothServicesRespondWithAnError()
+        throws
+    {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
         let expectedError = StubUtils.createError(errorName: "unknown", message: "an error")
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointsDiscoverySuccess()
             .cardSessionFailure(error: expectedError)
             .sessionsPaymentsCvcSessionFailure(error: expectedError)
             .start()
-        
-        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) { result in
+
+        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) {
+            result in
             switch result {
-                case .success:
-                    XCTFail("Should have received an error but received sessions")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Should have received an error but received sessions")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
-    func testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndServiceDiscoveryRespondsWithAnError() throws {
+
+    func
+        testSendsBackAnErrorWhenAttemptingToRetrieve2SessionsAndServiceDiscoveryRespondsWithAnError()
+        throws
+    {
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
         let expectedError = StubUtils.createError(errorName: "unknown", message: "an error")
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointDiscoveryFailure(error: expectedError)
             .cardSessionSuccess(session: "expected-card-session")
             .sessionsPaymentsCvcSessionSuccess(session: "expected-cvc-session")
             .start()
-        
-        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) { result in
+
+        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) {
+            result in
             switch result {
-                case .success:
-                    XCTFail("Should have received an error but received sessions")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
+            case .success:
+                XCTFail("Should have received an error but received sessions")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testCanSendBackAnErrorWithValidationErrorDetails() throws {
-        let validationError1 = StubUtils.createApiValidationError(errorName: "validation error 1", message: "error message 1", jsonPath: "field 1")
-        let validationError2 = StubUtils.createApiValidationError(errorName: "validation error 2", message: "error message 2", jsonPath: "field 2")
-        let expectedError = StubUtils.createApiError(errorName: "an error", message: "an error message", validationErrors: [validationError1, validationError2])
-        
+        let validationError1 = StubUtils.createApiValidationError(
+            errorName: "validation error 1", message: "error message 1", jsonPath: "field 1")
+        let validationError2 = StubUtils.createApiValidationError(
+            errorName: "validation error 2", message: "error message 2", jsonPath: "field 2")
+        let expectedError = StubUtils.createApiError(
+            errorName: "an error", message: "an error message",
+            validationErrors: [validationError1, validationError2])
+
         let expectationToFulfill = expectation(description: "Session retrieved")
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
-        
+
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointsDiscoverySuccess()
             .cardSessionFailure(error: expectedError)
             .sessionsPaymentsCvcSessionSuccess(session: "expected-cvc-session")
             .start()
-        
-        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) { result in
+
+        try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.card, .cvc]) {
+            result in
             switch result {
-                case .success:
-                    XCTFail("Should have received an error but received sessions")
-                case .failure(let error):
-                    XCTAssertEqual("an error : an error message", error.message)
-                    
-                    XCTAssertEqual(2, error.validationErrors.count)
-                    
-                    XCTAssertEqual("validation error 1", error.validationErrors[0].errorName)
-                    XCTAssertEqual("error message 1", error.validationErrors[0].message)
-                    XCTAssertEqual("field 1", error.validationErrors[0].jsonPath)
-                    
-                    XCTAssertEqual("validation error 2", error.validationErrors[1].errorName)
-                    XCTAssertEqual("error message 2", error.validationErrors[1].message)
-                    XCTAssertEqual("field 2", error.validationErrors[1].jsonPath)
+            case .success:
+                XCTFail("Should have received an error but received sessions")
+            case .failure(let error):
+                XCTAssertEqual("an error : an error message", error.message)
+
+                XCTAssertEqual(2, error.validationErrors.count)
+
+                XCTAssertEqual("validation error 1", error.validationErrors[0].errorName)
+                XCTAssertEqual("error message 1", error.validationErrors[0].message)
+                XCTAssertEqual("field 1", error.validationErrors[0].jsonPath)
+
+                XCTAssertEqual("validation error 2", error.validationErrors[1].errorName)
+                XCTAssertEqual("error message 2", error.validationErrors[1].message)
+                XCTAssertEqual("field 2", error.validationErrors[1].jsonPath)
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func testDoesNotGenerateAnySessions_whenCardDetailsAreIncompleteForCardSession() throws {
         let expectedMessage = "Expected expiry date to be provided but was not"
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
@@ -203,22 +227,28 @@ class AccessCheckoutClientTests: XCTestCase {
             .pan(UIUtils.createAccessCheckoutUITextField(withText: "pan"))
             .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
             .build()
-        
-        XCTAssertThrowsError(try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.cvc, .card]) { _ in }) { error in
+
+        XCTAssertThrowsError(
+            try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.cvc, .card]) {
+                _ in
+            }
+        ) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
-    
+
     func testDoesNotGenerateAnySessions_whenCardDetailsAreIncompleteForPaymentsCvcSession() throws {
         let expectedMessage = "Expected cvc to be provided but was not"
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = try CardDetailsBuilder().build()
-        
-        XCTAssertThrowsError(try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.cvc]) { _ in }) { error in
+
+        XCTAssertThrowsError(
+            try client.generateSessions(cardDetails: cardDetails, sessionTypes: [.cvc]) { _ in }
+        ) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
-    
+
     private func validCardDetails() -> CardDetails {
         return try! CardDetailsBuilder()
             .pan(UIUtils.createAccessCheckoutUITextField(withText: "pan"))
@@ -226,7 +256,7 @@ class AccessCheckoutClientTests: XCTestCase {
             .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
             .build()
     }
-    
+
     private func createAccessCheckoutClient(baseUrl: String) -> AccessCheckoutClient {
         return try! AccessCheckoutClientBuilder().checkoutId("a-checkout-id")
             .accessBaseUrl(baseUrl)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/CardDetailsBuilderTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardDetailsBuilderTests: XCTestCase {
     // MARK: tests covering SAQ-A compliant way of instiantiating card details
@@ -8,85 +9,86 @@ class CardDetailsBuilderTests: XCTestCase {
         let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
         let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/23")
         let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
-        
+
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
             .cvc(cvcUITextField)
-        
+
         let cardDetails = try cardDetailsBuilder.build()
-        
+
         XCTAssertEqual("1234123412341234", cardDetails.pan)
         XCTAssertEqual(10, cardDetails.expiryMonth)
         XCTAssertEqual(2023, cardDetails.expiryYear)
         XCTAssertEqual("123", cardDetails.cvc)
     }
-    
+
     func testBuildsCardDetailsAndRemoveSpacesWhenPanHasSpaces() throws {
-        let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234 1234 1234 1234")
+        let panUITextField = UIUtils.createAccessCheckoutUITextField(
+            withText: "1234 1234 1234 1234")
         let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/23")
         let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
-    
+
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
             .cvc(cvcUITextField)
-        
+
         let cardDetails = try cardDetailsBuilder.build()
-        
+
         XCTAssertEqual("1234123412341234", cardDetails.pan)
         XCTAssertEqual(10, cardDetails.expiryMonth)
         XCTAssertEqual(2023, cardDetails.expiryYear)
         XCTAssertEqual("123", cardDetails.cvc)
     }
-    
+
     func testBuildsCardDetailsWithCorrectExpiryDateWhenExpiryDateHasNoSlash() throws {
         let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
         let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1023")
         let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
-        
+
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
             .cvc(cvcUITextField)
-        
+
         let cardDetails = try cardDetailsBuilder.build()
-        
+
         XCTAssertEqual("1234123412341234", cardDetails.pan)
         XCTAssertEqual(10, cardDetails.expiryMonth)
         XCTAssertEqual(2023, cardDetails.expiryYear)
         XCTAssertEqual("123", cardDetails.cvc)
     }
-    
+
     func testBuildsCardDetailsWhenPassingOnlyCvc() throws {
         let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
         let cardDetailsBuilder = CardDetailsBuilder().cvc(cvcUITextField)
-        
+
         let cardDetails = try cardDetailsBuilder.build()
-        
+
         XCTAssertNil(cardDetails.pan)
         XCTAssertNil(cardDetails.expiryMonth)
         XCTAssertNil(cardDetails.expiryYear)
         XCTAssertEqual("123", cardDetails.cvc)
     }
-    
+
     func testThrowsErrorWhenExpiryDateIsInIncorrectFormat() throws {
         let panUITextField = UIUtils.createAccessCheckoutUITextField(withText: "1234123412341234")
         let expiryDateUITextField = UIUtils.createAccessCheckoutUITextField(withText: "10/2023")
         let cvcUITextField = UIUtils.createAccessCheckoutUITextField(withText: "123")
-        
+
         let expectedMessage = "Expected expiry date in format MM/YY or MMYY but found 10/2023"
         let cardDetailsBuilder = CardDetailsBuilder().pan(panUITextField)
             .expiryDate(expiryDateUITextField)
             .cvc(cvcUITextField)
-        
+
         XCTAssertThrowsError(try cardDetailsBuilder.build()) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
-    
+
     // MARK: tests covering attempt to build an empty instance of card details
 
     func testCanBuildEmptyCardDetails() throws {
         let cardDetails = try CardDetailsBuilder().build()
-        
+
         XCTAssertNil(cardDetails.pan)
         XCTAssertNil(cardDetails.expiryMonth)
         XCTAssertNil(cardDetails.expiryYear)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
@@ -1,11 +1,13 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class AccessCheckoutValidationInitialiserTests: XCTestCase {
-    let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock())
     var accessCheckoutValidationInitialiser: AccessCheckoutValidationInitialiser?
-    
+
     let panAccessCheckoutUITextField = AccessCheckoutUITextField()
     let expiryDateAccessCheckoutUITextField = AccessCheckoutUITextField()
     let cvcAccessCheckoutUITextField = AccessCheckoutUITextField()
@@ -13,13 +15,17 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
     let baseUrl = "some-url"
     let cardValidationDelegateMock = MockAccessCheckoutCardValidationDelegate()
     let cvcOnlyValidationDelegateMock = MockAccessCheckoutCvcOnlyValidationDelegate()
-    
+
     override func setUp() {
-        accessCheckoutValidationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
-        cardValidationDelegateMock.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any(), acceptedCardBrands: any()).thenDoNothing()
+        accessCheckoutValidationInitialiser = AccessCheckoutValidationInitialiser(
+            configurationProvider)
+        cardValidationDelegateMock.getStubbingProxy().panValidChanged(isValid: any())
+            .thenDoNothing()
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(
+            baseUrl: any(), acceptedCardBrands: any()
+        ).thenDoNothing()
     }
-    
+
     func testInitialisationForCardPaymentFlowWithTextFieldsRetrievesConfiguration() {
         let validationConfig = try! CardValidationConfig.builder()
             .pan(panAccessCheckoutUITextField)
@@ -30,12 +36,13 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])
             .build()
-        
+
         accessCheckoutValidationInitialiser!.initialise(validationConfig)
-        
-        verify(configurationProvider).retrieveRemoteConfiguration(baseUrl: "some-url", acceptedCardBrands: ["amex", "visa"])
+
+        verify(configurationProvider).retrieveRemoteConfiguration(
+            baseUrl: "some-url", acceptedCardBrands: ["amex", "visa"])
     }
-    
+
     func testInitialisationForCardPaymentFlowWithTextFieldsSetsPresentersOnTextFieldAsDelegates() {
         let validationConfig = try! CardValidationConfig.builder()
             .pan(panAccessCheckoutUITextField)
@@ -46,20 +53,22 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])
             .build()
-        
+
         accessCheckoutValidationInitialiser!.initialise(validationConfig)
-        
+
         XCTAssertTrue(panAccessCheckoutUITextField.uiTextField.delegate is PanViewPresenter)
-        XCTAssertTrue(expiryDateAccessCheckoutUITextField.uiTextField.delegate is ExpiryDateViewPresenter)
+        XCTAssertTrue(
+            expiryDateAccessCheckoutUITextField.uiTextField.delegate is ExpiryDateViewPresenter)
         XCTAssertTrue(cvcAccessCheckoutUITextField.uiTextField.delegate is CvcViewPresenter)
     }
-    
-    func testInitialisationForCvcOnlyPaymentFlowWithTextFieldsSetsPresentersOnTextFieldAsDelegate() {
+
+    func testInitialisationForCvcOnlyPaymentFlowWithTextFieldsSetsPresentersOnTextFieldAsDelegate()
+    {
         let validationConfig = try! CvcOnlyValidationConfig.builder()
             .cvc(cvcAccessCheckoutUITextField)
             .validationDelegate(cvcOnlyValidationDelegateMock)
             .build()
-        
+
         accessCheckoutValidationInitialiser!.initialise(validationConfig)
 
         XCTAssertTrue(cvcAccessCheckoutUITextField.uiTextField.delegate is CvcViewPresenter)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_ClearText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_ClearText_Tests.swift
@@ -1,62 +1,63 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCardValidationDelegate_ClearText_Tests: AcceptanceTestSuite {
     private let validVisaPan = TestFixtures.validVisaPan1
-    
+
     func testMerchantDelegateIsNotifiedWhenValidPanIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editPan(text: validVisaPan)
         verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
-        
+
         clearPan()
         verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenInvalidPanIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editPan(text: "1234")
-        
+
         clearPan()
         verify(merchantDelegate, never()).panValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenValidExpiryDateIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editExpiryDate(text: "12/35")
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: true)
-        
+
         clearExpiryDate()
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenInvalidExpiryDateIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editExpiryDate(text: "12/3")
-        
+
         clearExpiryDate()
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenValidCvcIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editCvc(text: "123")
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
-        
+
         clearCvc()
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenInvalidCvcIsCleared() {
         let merchantDelegate = initialiseCardValidation()
-        
+
         editCvc(text: "12")
-        
+
         clearCvc()
         verify(merchantDelegate, never()).cvcValidChanged(isValid: false)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_EditText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_EditText_Tests.swift
@@ -1,227 +1,231 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCardValidationDelegate_EditText_Tests: AcceptanceTestSuite {
     private let visaBrand = TestFixtures.visaBrand()
     private let maestroBrand = TestFixtures.maestroBrand()
     private let amexBrand = TestFixtures.amexBrand()
-    
+
     private let validVisaPan1 = TestFixtures.validVisaPan1
     private let validVisaPan2 = TestFixtures.validVisaPan2
     private let validMasterCardPan = TestFixtures.validMasterCardPan
     private let validAmexPan = TestFixtures.validAmexPan
-    
+
     // MARK: PAN validation tests
-    
+
     func testMerchantDelegateIsNotifiedWhenPANBecomesValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenPANBecomesInvalid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
         editPan(text: "123")
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotifiedOfInvalidPANWhenPANIsValidButBrandIsNotAcceptedByMerchant() {
         let expectedVisaBrand = createCardBrand(from: visaBrand)
         let expectedAmexBrand = createCardBrand(from: amexBrand)
-        let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, amexBrand], acceptedCardBrands: ["visa"])
-        
+        let merchantDelegate = initialiseCardValidation(
+            cardBrands: [visaBrand, amexBrand], acceptedCardBrands: ["visa"])
+
         editPan(text: validVisaPan1)
         editPan(text: validAmexPan)
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedVisaBrand)
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedAmexBrand)
     }
-    
+
     func testMerchantDelegateIsNotifiedOnlyOnceWhenSubsequentValidPANsAreEntered() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
         editPan(text: validVisaPan2)
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
     }
-    
+
     // MARK: Card brand changes
-    
+
     func testMerchantDelegateIsNotifiedWhenCardBrandChanges() {
         let expectedCardBrand = createCardBrand(from: visaBrand)
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: "4")
-        
+
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedCardBrand)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenPanChangesButBrandRemainsTheSame() {
         let expectedCardBrand = createCardBrand(from: visaBrand)
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: "4")
         editPan(text: "49")
-        
+
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedCardBrand)
     }
-    
+
     func testMerchantDelegateIsNotifiedOfAVisaToMaestroCardBrandChange() {
         let expectedVisaBrand = createCardBrand(from: visaBrand)
         let expectedMaestroBrand = createCardBrand(from: maestroBrand)
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: "49369")
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedVisaBrand)
-        
+
         editPan(text: "493698")
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedMaestroBrand)
     }
-    
+
     // MARK: Expiry Date validation tests
-    
+
     func testMerchantDelegateIsNotifiedWhenExpiryDateBecomesValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editExpiryDate(text: "11/32")
-        
+
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: true)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenExpiryDateBecomesInvalid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editExpiryDate(text: "11/32")
         editExpiryDate(text: "11/3")
-        
+
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotifiedOnlyOnceWhenSubsequentValidExpiryDatesAreEntered() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editExpiryDate(text: "11/32")
         editExpiryDate(text: "11/33")
-        
+
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: true)
     }
-    
+
     // MARK: Cvc validation tests
-    
+
     func testMerchantDelegateIsNotifiedWhenCvcBecomesValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editCvc(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenCvcBecomesInvalid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editCvc(text: "123")
         editCvc(text: "12")
-        
+
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotifiedOnlyOnceWhenSubsequentValidCvcsAreEntered() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editCvc(text: "456")
         editCvc(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedOfAnInvalidCvcWhenThePanIsChangedAndRequiresACvcOfADifferentLength() {
+
+    func
+        testMerchantDelegateIsNotifiedOfAnInvalidCvcWhenThePanIsChangedAndRequiresACvcOfADifferentLength()
+    {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, amexBrand])
-        
+
         editPan(text: validVisaPan1)
         editCvc(text: "123")
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
         clearInvocations(merchantDelegate)
-        
+
         editPan(text: validAmexPan)
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenThePanIsChangedAndRequiresACvcOfTheSameLength() {
         let expectedVisaCardBrand = createCardBrand(from: visaBrand)
         let expectedMaestroCardBrand = createCardBrand(from: maestroBrand)
-        
+
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: "49369")
         editCvc(text: "123")
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedVisaCardBrand)
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
         clearInvocations(merchantDelegate)
-        
+
         editPan(text: "493698")
         verify(merchantDelegate, times(1)).cardBrandChanged(cardBrand: expectedMaestroCardBrand)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: true)
     }
-    
+
     // MARK: validation success tests
-    
+
     func testMerchantIsNotifiedOfValidationSuccess() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
         editCvc(text: "123")
         editExpiryDate(text: "12/35")
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
-    
+
     func testMerchantIsNotNotifiedOfValidationSuccessWhenPanIsNotValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: "4111")
         editCvc(text: "123")
         editExpiryDate(text: "12/35")
-        
+
         verify(merchantDelegate, never()).validationSuccess()
     }
-    
+
     func testMerchantIsNotNotifiedOfValidationSuccessWhenExpiryDateIsNotValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
         editCvc(text: "123")
         editExpiryDate(text: "12/19")
-        
+
         verify(merchantDelegate, never()).validationSuccess()
     }
-    
+
     func testMerchantIsNotNotifiedOfValidationSuccessWhenCvcIsNotValid() {
         let merchantDelegate = initialiseCardValidation(cardBrands: [visaBrand, maestroBrand])
-        
+
         editPan(text: validVisaPan1)
         editCvc(text: "12")
         editExpiryDate(text: "12/35")
-        
+
         verify(merchantDelegate, never()).validationSuccess()
     }
-    
+
     private func createCardBrand(from cardBrandModel: CardBrandModel) -> CardBrand? {
         var images = [CardBrandImage]()
-        
+
         for imageToConvert in cardBrandModel.images {
             let image = CardBrandImage(type: imageToConvert.type, url: imageToConvert.url)
             images.append(image)
         }
-        
+
         return CardBrand(name: cardBrandModel.name, images: images)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_FocusOut_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/AccessCheckoutCardValidationDelegate_FocusOut_Tests.swift
@@ -1,106 +1,119 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCardValidationDelegate_FocusOut_Tests: AcceptanceTestSuite {
     private let validVisaPan1 = "4111111111111111"
     private let invalidVisaPan = "123"
-    
+
     // MARK: PAN validation tests
-    
+
     func testMerchantDelegateIsNotNotifiedWhenPanComponentWithValidPanLosesFocus() {
         let merchantDelegate = initialiseCardValidation()
         editPan(text: validVisaPan1)
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromPan()
-        
+
         verify(merchantDelegate, never()).panValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedWhenPanComponentWithInvalidPanLosesFocusAndMerchantHasNeverBeenNotified() {
+
+    func
+        testMerchantDelegateIsNotifiedWhenPanComponentWithInvalidPanLosesFocusAndMerchantHasNeverBeenNotified()
+    {
         let merchantDelegate = initialiseCardValidation()
         editPan(text: invalidVisaPan)
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromPan()
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
     }
-    
-    func testMerchantDelegateIsNotNotifiedWhenPanComponentWithInvalidPanLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidPan() {
+
+    func
+        testMerchantDelegateIsNotNotifiedWhenPanComponentWithInvalidPanLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidPan()
+    {
         let merchantDelegate = initialiseCardValidation()
         editPan(text: validVisaPan1)
         editPan(text: invalidVisaPan)
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromPan()
-        
+
         verify(merchantDelegate, never()).panValidChanged(isValid: false)
     }
-    
+
     // MARK: Expiry Date validation tests
-    
+
     func testMerchantDelegateIsNotNotifiedWhenExpiryDateComponentWithValidExpiryDateLosesFocus() {
         let merchantDelegate = initialiseCardValidation()
         editExpiryDate(text: "11/32")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromExpiryDate()
-        
+
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedWhenExpiryDateComponentWithInvalidExpiryDateLosesFocusAndMerchantHasNeverBeenNotified() {
+
+    func
+        testMerchantDelegateIsNotifiedWhenExpiryDateComponentWithInvalidExpiryDateLosesFocusAndMerchantHasNeverBeenNotified()
+    {
         let merchantDelegate = initialiseCardValidation()
         editExpiryDate(text: "11/3")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromExpiryDate()
-        
+
         verify(merchantDelegate, times(1)).expiryDateValidChanged(isValid: false)
     }
-    
-    func testMerchantDelegateIsNotNotifiedWhenExpiryDateComponentWithInvalidExpiryDateLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidExpiryDate() {
+
+    func
+        testMerchantDelegateIsNotNotifiedWhenExpiryDateComponentWithInvalidExpiryDateLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidExpiryDate()
+    {
         let merchantDelegate = initialiseCardValidation()
         editExpiryDate(text: "11/33")
         editExpiryDate(text: "11/3")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromExpiryDate()
-        
+
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: false)
     }
-    
+
     // MARK: Cvc validation tests
-    
+
     func testMerchantDelegateIsNotNotifiedWhenCvcComponentWithValidCvcLosesFocus() {
         let merchantDelegate = initialiseCardValidation()
         editCvc(text: "123")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate, never()).cvcValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasNeverBeenNotified() {
+
+    func
+        testMerchantDelegateIsNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasNeverBeenNotified()
+    {
         let merchantDelegate = initialiseCardValidation()
         editCvc(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
-    func testMerchantDelegateIsNotNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvc() {
+
+    func
+        testMerchantDelegateIsNotNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvc()
+    {
         let merchantDelegate = initialiseCardValidation()
         editCvc(text: "123")
         editCvc(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate, never()).cvcValidChanged(isValid: false)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardValidationConfigBuilderTests: XCTestCase {
     private let builder = CardValidationConfig.builder()
@@ -11,7 +12,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     private let acceptedCardBrands = ["visa", "amex"]
 
     func testConfigWithHasFormattingNotEnabledByDefault() throws {
-        let config = try! builder
+        let config =
+            try! builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
@@ -23,7 +25,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithPanFormattingEnabled() throws {
-        let config = try! builder
+        let config =
+            try! builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
@@ -36,7 +39,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithoutAcceptedCardBrands() throws {
-        let config = try! builder
+        let config =
+            try! builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
@@ -53,7 +57,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testCanCreateConfigWithAcceptedCardBrands() throws {
-        let config = try! builder
+        let config =
+            try! builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
@@ -71,7 +76,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenPanIsNotSpecified() throws {
-        _ = builder
+        _ =
+            builder
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
@@ -85,7 +91,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenExpiryDateIsNotSpecified() throws {
-        _ = builder
+        _ =
+            builder
             .pan(panAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
@@ -99,7 +106,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenCvcIsNotSpecified() throws {
-        _ = builder
+        _ =
+            builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
@@ -113,7 +121,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenAccessBaseUrlIsNotSpecified() throws {
-        _ = builder
+        _ =
+            builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)
@@ -127,7 +136,8 @@ class CardValidationConfigBuilderTests: XCTestCase {
     }
 
     func testThrowsErrorWhenValidationDelegateIsNotSpecified() throws {
-        _ = builder
+        _ =
+            builder
             .pan(panAccessCheckoutUITextField)
             .expiryDate(expiryDateAccessCheckoutUITextField)
             .cvc(cvcAccessCheckoutUITextField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_ClearText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_ClearText_Tests.swift
@@ -1,22 +1,23 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCvcOnlyValidationDelegate_ClearText_Tests: AcceptanceTestSuite {
     func testMerchantDelegateIsNotifiedWhenValidCvcIsCleared() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "123")
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
-        
+
         clearCvc()
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenInvalidCvcIsCleared() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "12")
-        
+
         clearCvc()
         verify(merchantDelegate, never()).cvcValidChanged(isValid: false)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_EditText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_EditText_Tests.swift
@@ -1,37 +1,38 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCvcOnlyValidationDelegate_EditText_Tests: AcceptanceTestSuite {
     func testMerchantDelegateIsNotifiedOfCvcValidationStateChanges() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenCvcChangesButValidationStatesDoesNotChange() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "456")
         editCvc(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvcValidChanged(isValid: true)
     }
-    
+
     func testMerchantIsNotifiedOfValidationSuccess() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "123")
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
-    
+
     func testMerchantIsNotNotifiedOfValidationSuccessWhenCvcIsNotValid() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "12")
-        
+
         verify(merchantDelegate, never()).validationSuccess()
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_FocusOut_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvcOnlyValidationDelegate_FocusOut_Tests.swift
@@ -1,38 +1,43 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutCvcOnlyValidationDelegate_FocusOut_Tests: AcceptanceTestSuite {
     func testMerchantDelegateIsNotNotifiedWhenCvcComponentWithValidCvcLosesFocus() {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "123")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate, never()).cvcValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasNeverBeenNotified() {
+
+    func
+        testMerchantDelegateIsNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasNeverBeenNotified()
+    {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
-    func testMerchantDelegateIsNotNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvc() {
+
+    func
+        testMerchantDelegateIsNotNotifiedWhenCvcComponentWithInvalidCvcLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvc()
+    {
         let merchantDelegate = initialiseCvcOnlyValidation()
-        
+
         editCvc(text: "123")
         editCvc(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvc()
-        
+
         verify(merchantDelegate, never()).cvcValidChanged(isValid: false)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_ClearText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_ClearText_Tests.swift
@@ -1,43 +1,47 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class AccessCheckoutCvcOnlyValidationDelegate_ClearText_Tests: XCTestCase {
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock())
     private var validationInitialiser: AccessCheckoutValidationInitialiser?
     private let cvvView = CvcView()
     private let merchantDelegate = MockAccessCheckoutCvvOnlyValidationDelegate()
     private let configuration = CardBrandsConfiguration([])
-    
+
     override func setUp() {
         validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
-        
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any()).thenDoNothing()
+
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any())
+            .thenDoNothing()
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        
+
         merchantDelegate.getStubbingProxy().cvvValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
-        
+
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
     }
-    
+
     func testMerchantDelegateIsNotifiedWhenValidCvvIsCleared() {
         editCvv(text: "123")
         verify(merchantDelegate, times(1)).cvvValidChanged(isValid: true)
-        
+
         cvvView.clear()
         verify(merchantDelegate, times(1)).cvvValidChanged(isValid: false)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenInvalidCvvIsCleared() {
         editCvv(text: "12")
-        
+
         cvvView.clear()
         verify(merchantDelegate, never()).cvvValidChanged(isValid: false)
     }
-    
+
     private func editCvv(text: String) {
         cvvView.textField.text = text
         cvvView.textFieldEditingChanged(cvvView.textField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_EditText_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_EditText_Tests.swift
@@ -1,65 +1,72 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class AccessCheckoutCvcOnlyValidationDelegate_EditText_Tests: XCTestCase {
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock())
     private var validationInitialiser: AccessCheckoutValidationInitialiser?
     private let cvvView = CvcView()
     private let merchantDelegate = MockAccessCheckoutCvvOnlyValidationDelegate()
     private let configuration = CardBrandsConfiguration([])
-    
+
     override func setUp() {
         validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
-        
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any()).thenDoNothing()
+
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any())
+            .thenDoNothing()
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        
+
         merchantDelegate.getStubbingProxy().cvvValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
     }
-    
+
     func testMerchantDelegateIsNotifiedOfCvvValidationStateChanges() {
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
-        
+
         editCvv(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvvValidChanged(isValid: true)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenCvvChangesButValidationStatesDoesNotChange() {
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
-        
+
         editCvv(text: "456")
         editCvv(text: "123")
-        
+
         verify(merchantDelegate, times(1)).cvvValidChanged(isValid: true)
     }
-    
+
     func testMerchantIsNotifiedOfValidationSuccess() {
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
-        
+
         editCvv(text: "123")
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
-    
+
     func testMerchantIsNotNotifiedOfValidationSuccessWhenCvvIsNotValid() {
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
-        
+
         editCvv(text: "12")
-        
+
         verify(merchantDelegate, never()).validationSuccess()
     }
-    
+
     private func editCvv(text: String) {
         cvvView.textField.text = text
         cvvView.textFieldEditingChanged(cvvView.textField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_FocusOut_Tests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/AccessCheckoutCvvOnlyValidationDelegate_FocusOut_Tests.swift
@@ -1,61 +1,69 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class AccessCheckoutCvcOnlyValidationDelegate_FocusOut_Tests: XCTestCase {
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock())
     private var validationInitialiser: AccessCheckoutValidationInitialiser?
     private let cvvView = CvcView()
     private let merchantDelegate = MockAccessCheckoutCvvOnlyValidationDelegate()
     private let configuration = CardBrandsConfiguration([])
-    
+
     override func setUp() {
         validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
-        
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any()).thenDoNothing()
+
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any())
+            .thenDoNothing()
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        
+
         merchantDelegate.getStubbingProxy().cvvValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
-        
+
         configurationProvider.getStubbingProxy().get().thenReturn(configuration)
-        let validationConfiguration = CvcOnlyValidationConfig(cvcView: cvvView, validationDelegate: merchantDelegate)
+        let validationConfiguration = CvcOnlyValidationConfig(
+            cvcView: cvvView, validationDelegate: merchantDelegate)
         validationInitialiser!.initialise(validationConfiguration)
     }
-    
+
     func testMerchantDelegateIsNotNotifiedWhenCvvComponentWithValidCvvLosesFocus() {
         editCvv(text: "123")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvv()
-        
+
         verify(merchantDelegate, never()).cvvValidChanged(isValid: true)
     }
-    
-    func testMerchantDelegateIsNotifiedWhenCvvComponentWithInvalidCvvLosesFocusAndMerchantHasNeverBeenNotified() {
+
+    func
+        testMerchantDelegateIsNotifiedWhenCvvComponentWithInvalidCvvLosesFocusAndMerchantHasNeverBeenNotified()
+    {
         editCvv(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvv()
-        
+
         verify(merchantDelegate).cvvValidChanged(isValid: false)
     }
-    
-    func testMerchantDelegateIsNotNotifiedWhenCvvComponentWithInvalidCvvLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvv() {
+
+    func
+        testMerchantDelegateIsNotNotifiedWhenCvvComponentWithInvalidCvvLosesFocusAndMerchantHasAlreadyBeenNotifiedOfTheInvalidCvv()
+    {
         editCvv(text: "123")
         editCvv(text: "12")
         clearInvocations(merchantDelegate)
-        
+
         removeFocusFromCvv()
-        
+
         verify(merchantDelegate, never()).cvvValidChanged(isValid: false)
     }
-    
+
     private func editCvv(text: String) {
         cvvView.textField.text = text
         cvvView.textFieldEditingChanged(cvvView.textField)
     }
-    
+
     private func removeFocusFromCvv() {
         cvvView.textFieldDidEndEditing(cvvView.textField)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/cvcOnly/CvcOnlyValidationConfigBuilderTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcOnlyValidationConfigBuilderTests: XCTestCase {
     private let builder = CvcOnlyValidationConfig.builder()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/excluded/AccessCheckoutUITextFieldExtensionTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/excluded/AccessCheckoutUITextFieldExtensionTests.swift
@@ -1,95 +1,98 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutUITextFieldExtensionTests: XCTestCase {
     func testBeginningOfDocumentDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let position = UITextPosition()
         uiTextFieldMock.setBeginningOfDocument(position)
-        
+
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         XCTAssertTrue(textField.beginningOfDocument === position)
     }
-    
+
     func testEndOfDocumentDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let position = UITextPosition()
         uiTextFieldMock.setEndOfDocument(position)
-        
+
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         XCTAssertTrue(textField.endOfDocument === position)
     }
-    
+
     func testOffsetDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         _ = textField.offset(from: UITextPosition(), to: UITextPosition())
-        
+
         XCTAssertTrue(uiTextFieldMock.offsetCalled)
     }
-    
+
     func testPositionDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         _ = textField.position(from: UITextPosition(), offset: 1)
-        
+
         XCTAssertTrue(uiTextFieldMock.positionCalled)
     }
-    
+
     func testTextRangeDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         _ = textField.textRange(from: UITextPosition(), to: UITextPosition())
-        
+
         XCTAssertTrue(uiTextFieldMock.textRangeCalled)
     }
-    
+
     func testSelectedTextRangeGetterReturnsUITextFieldSelectedTextRange() {
         let uiTextField = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextField)
 
         let selectedTextRange = UITextRange()
         uiTextField.selectedTextRange = selectedTextRange
-        
+
         XCTAssertNotNil(textField.selectedTextRange)
         XCTAssertTrue(textField.selectedTextRange === selectedTextRange)
     }
-    
+
     func testSelectedTextRangeSetterSetsUITextFieldSelectedTextRange() {
         let uiTextField = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextField)
-        
+
         let selectedTextRange = UITextRange()
         textField.selectedTextRange = selectedTextRange
 
         XCTAssertNotNil(textField.uiTextField.selectedTextRange)
         XCTAssertTrue(textField.uiTextField.selectedTextRange === selectedTextRange)
     }
-    
+
     func testAddTargetDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
-        textField.addTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingDidEnd)
-        
+
+        textField.addTarget(
+            self, action: #selector(textFieldEditingChanged(_:)), for: .editingDidEnd)
+
         XCTAssertTrue(uiTextFieldMock.addTargetCalled)
     }
-    
+
     func testRemoveTargetDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
-        textField.removeTarget(self, action: #selector(textFieldEditingChanged(_:)), for: .editingDidEnd)
-        
+
+        textField.removeTarget(
+            self, action: #selector(textFieldEditingChanged(_:)), for: .editingDidEnd)
+
         XCTAssertTrue(uiTextFieldMock.removeTargetCalled)
     }
-    
+
     @objc
     private func textFieldEditingChanged(_ textField: UITextField) {}
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardBrandsConfigurationFactoryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardBrandsConfigurationFactoryMock.swift
@@ -4,21 +4,25 @@ class CardBrandsConfigurationFactoryMock: CardBrandsConfigurationFactory {
     private(set) var baseUrlPassed: String?
     private(set) var acceptedBrandsPassed: [String]?
     private(set) var createCalled: Bool = false
-    private var cardBrandsConfigurationToReturn = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-    
+    private var cardBrandsConfigurationToReturn = CardBrandsConfiguration(
+        allCardBrands: [], acceptedCardBrands: [])
+
     init() {
         super.init(RestClientMock<String>(replyWith: ""), MockCardBrandDtoTransformer())
     }
-    
+
     func willReturn(_ expectedConfiguration: CardBrandsConfiguration) {
         cardBrandsConfigurationToReturn = expectedConfiguration
     }
-    
-    override func create(baseUrl: String, acceptedCardBrands: [String], completionHandler: @escaping (CardBrandsConfiguration) -> Void) {
+
+    override func create(
+        baseUrl: String, acceptedCardBrands: [String],
+        completionHandler: @escaping (CardBrandsConfiguration) -> Void
+    ) {
         createCalled = true
         baseUrlPassed = baseUrl
         acceptedBrandsPassed = acceptedCardBrands
-        
+
         completionHandler(cardBrandsConfigurationToReturn)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionURLRequestFactoryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionURLRequestFactoryMock.swift
@@ -9,7 +9,10 @@ class CardSessionURLRequestFactoryMock: CardSessionURLRequestFactory {
     private(set) var cvcPassed: String?
     private var requestToReturn: URLRequest?
 
-    override func create(url: String, checkoutId: String, pan: String, expiryMonth: UInt, expiryYear: UInt, cvc: String) -> URLRequest {
+    override func create(
+        url: String, checkoutId: String, pan: String, expiryMonth: UInt, expiryYear: UInt,
+        cvc: String
+    ) -> URLRequest {
         createCalled = true
         urlPassed = url
         panPassed = pan

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionsApiClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionsApiClientMock.swift
@@ -4,22 +4,24 @@ class CardSessionsApiClientMock: CardSessionsApiClient {
     var createSessionCalled: Bool = false
     var sessionToReturn: String?
     var error: AccessCheckoutError?
-    
+
     init(sessionToReturn: String?) {
         self.sessionToReturn = sessionToReturn
         super.init()
     }
-    
+
     init(error: AccessCheckoutError?) {
         self.error = error
         super.init()
     }
-    
-    override func createSession(baseUrl: String, checkoutId: String, pan: String, expiryMonth: UInt, expiryYear: UInt, cvc: String,
-                                completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void)
-    {
+
+    override func createSession(
+        baseUrl: String, checkoutId: String, pan: String, expiryMonth: UInt, expiryYear: UInt,
+        cvc: String,
+        completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void
+    ) {
         createSessionCalled = true
-        
+
         if let sessionToReturn = sessionToReturn {
             completionHandler(.success(sessionToReturn))
         } else if let error = error {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionsApiDiscoveryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardSessionsApiDiscoveryMock.swift
@@ -3,19 +3,22 @@
 class CardSessionsApiDiscoveryMock: CardSessionsApiDiscovery {
     private var url: String?
     private var error: AccessCheckoutError?
-    
-    override func discover(baseUrl: String, completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void) {
+
+    override func discover(
+        baseUrl: String,
+        completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void
+    ) {
         if let url = url {
             completionHandler(.success(url))
         } else if let error = error {
             completionHandler(.failure(error))
         }
     }
-    
+
     func willComplete(with url: String) {
         self.url = url
     }
-    
+
     func willComplete(with error: AccessCheckoutError) {
         self.error = error
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockAccessCheckoutCardValidationDelegate.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockAccessCheckoutCardValidationDelegate.swift
@@ -1,326 +1,271 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+public class MockAccessCheckoutCardValidationDelegate: AccessCheckoutCardValidationDelegate, Cuckoo
+        .ProtocolMock
+{
 
-
-
-
-
-public class MockAccessCheckoutCardValidationDelegate: AccessCheckoutCardValidationDelegate, Cuckoo.ProtocolMock {
-    
     public typealias MocksType = AccessCheckoutCardValidationDelegate
-    
+
     public typealias Stubbing = __StubbingProxy_AccessCheckoutCardValidationDelegate
     public typealias Verification = __VerificationProxy_AccessCheckoutCardValidationDelegate
 
-    public let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
+    public let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
 
-    
     private var __defaultImplStub: AccessCheckoutCardValidationDelegate?
 
     public func enableDefaultImplementation(_ stub: AccessCheckoutCardValidationDelegate) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    public func cardBrandChanged(cardBrand: CardBrand?) {
 
-    
-
-    
-    
-    
-    
-    public func cardBrandChanged(cardBrand: CardBrand?)  {
-        
-    return cuckoo_manager.call(
-    """
-    cardBrandChanged(cardBrand: CardBrand?)
-    """,
+        return cuckoo_manager.call(
+            """
+            cardBrandChanged(cardBrand: CardBrand?)
+            """,
             parameters: (cardBrand),
             escapingParameters: (cardBrand),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.cardBrandChanged(cardBrand: cardBrand))
-        
+
     }
-    
-    
-    
-    
-    
-    public func panValidChanged(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    panValidChanged(isValid: Bool)
-    """,
+
+    public func panValidChanged(isValid: Bool) {
+
+        return cuckoo_manager.call(
+            """
+            panValidChanged(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.panValidChanged(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-    public func expiryDateValidChanged(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    expiryDateValidChanged(isValid: Bool)
-    """,
+
+    public func expiryDateValidChanged(isValid: Bool) {
+
+        return cuckoo_manager.call(
+            """
+            expiryDateValidChanged(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.expiryDateValidChanged(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-    public func cvcValidChanged(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    cvcValidChanged(isValid: Bool)
-    """,
+
+    public func cvcValidChanged(isValid: Bool) {
+
+        return cuckoo_manager.call(
+            """
+            cvcValidChanged(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.cvcValidChanged(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-    public func validationSuccess()  {
-        
-    return cuckoo_manager.call(
-    """
-    validationSuccess()
-    """,
+
+    public func validationSuccess() {
+
+        return cuckoo_manager.call(
+            """
+            validationSuccess()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.validationSuccess())
-        
+
     }
-    
-    
 
     public struct __StubbingProxy_AccessCheckoutCardValidationDelegate: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
+
         public init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func cardBrandChanged<M1: Cuckoo.OptionalMatchable>(cardBrand: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(CardBrand?)> where M1.OptionalMatchedType == CardBrand {
-            let matchers: [Cuckoo.ParameterMatcher<(CardBrand?)>] = [wrap(matchable: cardBrand) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCardValidationDelegate.self, method:
-    """
-    cardBrandChanged(cardBrand: CardBrand?)
-    """, parameterMatchers: matchers))
+
+        func cardBrandChanged<M1: Cuckoo.OptionalMatchable>(cardBrand: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(CardBrand?)>
+        where M1.OptionalMatchedType == CardBrand {
+            let matchers: [Cuckoo.ParameterMatcher<(CardBrand?)>] = [
+                wrap(matchable: cardBrand) { $0 }
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCardValidationDelegate.self,
+                    method:
+                        """
+                        cardBrandChanged(cardBrand: CardBrand?)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func panValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func panValidChanged<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCardValidationDelegate.self, method:
-    """
-    panValidChanged(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCardValidationDelegate.self,
+                    method:
+                        """
+                        panValidChanged(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func expiryDateValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func expiryDateValidChanged<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCardValidationDelegate.self, method:
-    """
-    expiryDateValidChanged(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCardValidationDelegate.self,
+                    method:
+                        """
+                        expiryDateValidChanged(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCardValidationDelegate.self, method:
-    """
-    cvcValidChanged(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCardValidationDelegate.self,
+                    method:
+                        """
+                        cvcValidChanged(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func validationSuccess() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCardValidationDelegate.self, method:
-    """
-    validationSuccess()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCardValidationDelegate.self,
+                    method:
+                        """
+                        validationSuccess()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-    public struct __VerificationProxy_AccessCheckoutCardValidationDelegate: Cuckoo.VerificationProxy {
+    public struct __VerificationProxy_AccessCheckoutCardValidationDelegate: Cuckoo.VerificationProxy
+    {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-        public init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        public init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func cardBrandChanged<M1: Cuckoo.OptionalMatchable>(cardBrand: M1) -> Cuckoo.__DoNotUse<(CardBrand?), Void> where M1.OptionalMatchedType == CardBrand {
-            let matchers: [Cuckoo.ParameterMatcher<(CardBrand?)>] = [wrap(matchable: cardBrand) { $0 }]
+        func cardBrandChanged<M1: Cuckoo.OptionalMatchable>(cardBrand: M1)
+            -> Cuckoo.__DoNotUse<(CardBrand?), Void> where M1.OptionalMatchedType == CardBrand
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(CardBrand?)>] = [
+                wrap(matchable: cardBrand) { $0 }
+            ]
             return cuckoo_manager.verify(
-    """
-    cardBrandChanged(cardBrand: CardBrand?)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                cardBrandChanged(cardBrand: CardBrand?)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func panValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func panValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void>
+        where M1.MatchedType == Bool {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    panValidChanged(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                panValidChanged(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func expiryDateValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func expiryDateValidChanged<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    expiryDateValidChanged(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                expiryDateValidChanged(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void>
+        where M1.MatchedType == Bool {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    cvcValidChanged(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                cvcValidChanged(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func validationSuccess() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    validationSuccess()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validationSuccess()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
-
 
 public class AccessCheckoutCardValidationDelegateStub: AccessCheckoutCardValidationDelegate {
-    
 
-    
+    public func cardBrandChanged(cardBrand: CardBrand?) {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
 
-    
-    
-    
-    
-    public func cardBrandChanged(cardBrand: CardBrand?)   {
+    public func panValidChanged(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-    public func panValidChanged(isValid: Bool)   {
+
+    public func expiryDateValidChanged(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-    public func expiryDateValidChanged(isValid: Bool)   {
+
+    public func cvcValidChanged(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-    public func cvcValidChanged(isValid: Bool)   {
+
+    public func validationSuccess() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-    public func validationSuccess()   {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockAccessCheckoutCvcOnlyValidationDelegate.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockAccessCheckoutCvcOnlyValidationDelegate.swift
@@ -1,173 +1,137 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+public class MockAccessCheckoutCvcOnlyValidationDelegate: AccessCheckoutCvcOnlyValidationDelegate,
+    Cuckoo.ProtocolMock
+{
 
-
-
-
-
-public class MockAccessCheckoutCvcOnlyValidationDelegate: AccessCheckoutCvcOnlyValidationDelegate, Cuckoo.ProtocolMock {
-    
     public typealias MocksType = AccessCheckoutCvcOnlyValidationDelegate
-    
+
     public typealias Stubbing = __StubbingProxy_AccessCheckoutCvcOnlyValidationDelegate
     public typealias Verification = __VerificationProxy_AccessCheckoutCvcOnlyValidationDelegate
 
-    public let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
+    public let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
 
-    
     private var __defaultImplStub: AccessCheckoutCvcOnlyValidationDelegate?
 
     public func enableDefaultImplementation(_ stub: AccessCheckoutCvcOnlyValidationDelegate) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    public func cvcValidChanged(isValid: Bool) {
 
-    
-
-    
-    
-    
-    
-    public func cvcValidChanged(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    cvcValidChanged(isValid: Bool)
-    """,
+        return cuckoo_manager.call(
+            """
+            cvcValidChanged(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.cvcValidChanged(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-    public func validationSuccess()  {
-        
-    return cuckoo_manager.call(
-    """
-    validationSuccess()
-    """,
+
+    public func validationSuccess() {
+
+        return cuckoo_manager.call(
+            """
+            validationSuccess()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.validationSuccess())
-        
+
     }
-    
-    
 
     public struct __StubbingProxy_AccessCheckoutCvcOnlyValidationDelegate: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
+
         public init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCvcOnlyValidationDelegate.self, method:
-    """
-    cvcValidChanged(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCvcOnlyValidationDelegate.self,
+                    method:
+                        """
+                        cvcValidChanged(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func validationSuccess() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockAccessCheckoutCvcOnlyValidationDelegate.self, method:
-    """
-    validationSuccess()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockAccessCheckoutCvcOnlyValidationDelegate.self,
+                    method:
+                        """
+                        validationSuccess()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-    public struct __VerificationProxy_AccessCheckoutCvcOnlyValidationDelegate: Cuckoo.VerificationProxy {
+    public struct __VerificationProxy_AccessCheckoutCvcOnlyValidationDelegate: Cuckoo
+            .VerificationProxy
+    {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-        public init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        public init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func cvcValidChanged<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void>
+        where M1.MatchedType == Bool {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    cvcValidChanged(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                cvcValidChanged(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func validationSuccess() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    validationSuccess()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validationSuccess()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
-
 
 public class AccessCheckoutCvcOnlyValidationDelegateStub: AccessCheckoutCvcOnlyValidationDelegate {
-    
 
-    
-
-    
-    
-    
-    
-    public func cvcValidChanged(isValid: Bool)   {
+    public func cvcValidChanged(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-    public func validationSuccess()   {
+
+    public func validationSuccess() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBrandDtoTransformer.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBrandDtoTransformer.swift
@@ -1,122 +1,94 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockCardBrandDtoTransformer: CardBrandDtoTransformer, Cuckoo.ClassMock {
 
+    typealias MocksType = CardBrandDtoTransformer
 
+    typealias Stubbing = __StubbingProxy_CardBrandDtoTransformer
+    typealias Verification = __VerificationProxy_CardBrandDtoTransformer
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
-
- class MockCardBrandDtoTransformer: CardBrandDtoTransformer, Cuckoo.ClassMock {
-    
-     typealias MocksType = CardBrandDtoTransformer
-    
-     typealias Stubbing = __StubbingProxy_CardBrandDtoTransformer
-     typealias Verification = __VerificationProxy_CardBrandDtoTransformer
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: CardBrandDtoTransformer?
 
-     func enableDefaultImplementation(_ stub: CardBrandDtoTransformer) {
+    func enableDefaultImplementation(_ stub: CardBrandDtoTransformer) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func transform(_ dto: CardBrandDto) -> CardBrandModel {
 
-    
-
-    
-    
-    
-    
-     override func transform(_ dto: CardBrandDto) -> CardBrandModel {
-        
-    return cuckoo_manager.call(
-    """
-    transform(_: CardBrandDto) -> CardBrandModel
-    """,
+        return cuckoo_manager.call(
+            """
+            transform(_: CardBrandDto) -> CardBrandModel
+            """,
             parameters: (dto),
             escapingParameters: (dto),
             superclassCall:
-                
-                super.transform(dto)
-                ,
-            defaultCall: __defaultImplStub!.transform(dto))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_CardBrandDtoTransformer: Cuckoo.StubbingProxy {
+                super.transform(dto),
+            defaultCall: __defaultImplStub!.transform(dto))
+
+    }
+
+    struct __StubbingProxy_CardBrandDtoTransformer: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func transform<M1: Cuckoo.Matchable>(_ dto: M1) -> Cuckoo.ClassStubFunction<(CardBrandDto), CardBrandModel> where M1.MatchedType == CardBrandDto {
+
+        func transform<M1: Cuckoo.Matchable>(_ dto: M1)
+            -> Cuckoo.ClassStubFunction<(CardBrandDto), CardBrandModel>
+        where M1.MatchedType == CardBrandDto {
             let matchers: [Cuckoo.ParameterMatcher<(CardBrandDto)>] = [wrap(matchable: dto) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCardBrandDtoTransformer.self, method:
-    """
-    transform(_: CardBrandDto) -> CardBrandModel
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCardBrandDtoTransformer.self,
+                    method:
+                        """
+                        transform(_: CardBrandDto) -> CardBrandModel
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_CardBrandDtoTransformer: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_CardBrandDtoTransformer: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func transform<M1: Cuckoo.Matchable>(_ dto: M1) -> Cuckoo.__DoNotUse<(CardBrandDto), CardBrandModel> where M1.MatchedType == CardBrandDto {
+        func transform<M1: Cuckoo.Matchable>(_ dto: M1)
+            -> Cuckoo.__DoNotUse<(CardBrandDto), CardBrandModel>
+        where M1.MatchedType == CardBrandDto {
             let matchers: [Cuckoo.ParameterMatcher<(CardBrandDto)>] = [wrap(matchable: dto) { $0 }]
             return cuckoo_manager.verify(
-    """
-    transform(_: CardBrandDto) -> CardBrandModel
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                transform(_: CardBrandDto) -> CardBrandModel
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class CardBrandDtoTransformerStub: CardBrandDtoTransformer {
 
- class CardBrandDtoTransformerStub: CardBrandDtoTransformer {
-    
-
-    
-
-    
-    
-    
-    
-     override func transform(_ dto: CardBrandDto) -> CardBrandModel  {
+    override func transform(_ dto: CardBrandDto) -> CardBrandModel {
         return DefaultValueRegistry.defaultValue(for: (CardBrandModel).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBrandsConfigurationProvider.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBrandsConfigurationProvider.swift
@@ -1,175 +1,143 @@
 import Cuckoo
-@testable import AccessCheckoutSDK
-
 import Dispatch
 
+@testable import AccessCheckoutSDK
 
+class MockCardBrandsConfigurationProvider: CardBrandsConfigurationProvider, Cuckoo.ClassMock {
 
+    typealias MocksType = CardBrandsConfigurationProvider
 
+    typealias Stubbing = __StubbingProxy_CardBrandsConfigurationProvider
+    typealias Verification = __VerificationProxy_CardBrandsConfigurationProvider
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
- class MockCardBrandsConfigurationProvider: CardBrandsConfigurationProvider, Cuckoo.ClassMock {
-    
-     typealias MocksType = CardBrandsConfigurationProvider
-    
-     typealias Stubbing = __StubbingProxy_CardBrandsConfigurationProvider
-     typealias Verification = __VerificationProxy_CardBrandsConfigurationProvider
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: CardBrandsConfigurationProvider?
 
-     func enableDefaultImplementation(_ stub: CardBrandsConfigurationProvider) {
+    func enableDefaultImplementation(_ stub: CardBrandsConfigurationProvider) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String]) {
 
-    
-
-    
-    
-    
-    
-     override func retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])  {
-        
-    return cuckoo_manager.call(
-    """
-    retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
-    """,
+        return cuckoo_manager.call(
+            """
+            retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
+            """,
             parameters: (baseUrl, acceptedCardBrands),
             escapingParameters: (baseUrl, acceptedCardBrands),
             superclassCall:
-                
-                super.retrieveRemoteConfiguration(baseUrl: baseUrl, acceptedCardBrands: acceptedCardBrands)
-                ,
-            defaultCall: __defaultImplStub!.retrieveRemoteConfiguration(baseUrl: baseUrl, acceptedCardBrands: acceptedCardBrands))
-        
+
+                super.retrieveRemoteConfiguration(
+                    baseUrl: baseUrl, acceptedCardBrands: acceptedCardBrands),
+            defaultCall: __defaultImplStub!.retrieveRemoteConfiguration(
+                baseUrl: baseUrl, acceptedCardBrands: acceptedCardBrands))
+
     }
-    
-    
-    
-    
-    
-     override func get() -> CardBrandsConfiguration {
-        
-    return cuckoo_manager.call(
-    """
-    get() -> CardBrandsConfiguration
-    """,
+
+    override func get() -> CardBrandsConfiguration {
+
+        return cuckoo_manager.call(
+            """
+            get() -> CardBrandsConfiguration
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                super.get()
-                ,
-            defaultCall: __defaultImplStub!.get())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_CardBrandsConfigurationProvider: Cuckoo.StubbingProxy {
+                super.get(),
+            defaultCall: __defaultImplStub!.get())
+
+    }
+
+    struct __StubbingProxy_CardBrandsConfigurationProvider: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func retrieveRemoteConfiguration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(baseUrl: M1, acceptedCardBrands: M2) -> Cuckoo.ClassStubNoReturnFunction<(String, [String])> where M1.MatchedType == String, M2.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [String])>] = [wrap(matchable: baseUrl) { $0.0 }, wrap(matchable: acceptedCardBrands) { $0.1 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCardBrandsConfigurationProvider.self, method:
-    """
-    retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
-    """, parameterMatchers: matchers))
+
+        func retrieveRemoteConfiguration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(
+            baseUrl: M1, acceptedCardBrands: M2
+        ) -> Cuckoo.ClassStubNoReturnFunction<(String, [String])>
+        where M1.MatchedType == String, M2.MatchedType == [String] {
+            let matchers: [Cuckoo.ParameterMatcher<(String, [String])>] = [
+                wrap(matchable: baseUrl) { $0.0 }, wrap(matchable: acceptedCardBrands) { $0.1 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCardBrandsConfigurationProvider.self,
+                    method:
+                        """
+                        retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func get() -> Cuckoo.ClassStubFunction<(), CardBrandsConfiguration> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockCardBrandsConfigurationProvider.self, method:
-    """
-    get() -> CardBrandsConfiguration
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCardBrandsConfigurationProvider.self,
+                    method:
+                        """
+                        get() -> CardBrandsConfiguration
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_CardBrandsConfigurationProvider: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_CardBrandsConfigurationProvider: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func retrieveRemoteConfiguration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(baseUrl: M1, acceptedCardBrands: M2) -> Cuckoo.__DoNotUse<(String, [String]), Void> where M1.MatchedType == String, M2.MatchedType == [String] {
-            let matchers: [Cuckoo.ParameterMatcher<(String, [String])>] = [wrap(matchable: baseUrl) { $0.0 }, wrap(matchable: acceptedCardBrands) { $0.1 }]
+        func retrieveRemoteConfiguration<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(
+            baseUrl: M1, acceptedCardBrands: M2
+        ) -> Cuckoo.__DoNotUse<(String, [String]), Void>
+        where M1.MatchedType == String, M2.MatchedType == [String] {
+            let matchers: [Cuckoo.ParameterMatcher<(String, [String])>] = [
+                wrap(matchable: baseUrl) { $0.0 }, wrap(matchable: acceptedCardBrands) { $0.1 },
+            ]
             return cuckoo_manager.verify(
-    """
-    retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func get() -> Cuckoo.__DoNotUse<(), CardBrandsConfiguration> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    get() -> CardBrandsConfiguration
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                get() -> CardBrandsConfiguration
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class CardBrandsConfigurationProviderStub: CardBrandsConfigurationProvider {
 
- class CardBrandsConfigurationProviderStub: CardBrandsConfigurationProvider {
-    
-
-    
-
-    
-    
-    
-    
-     override func retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String])   {
+    override func retrieveRemoteConfiguration(baseUrl: String, acceptedCardBrands: [String]) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func get() -> CardBrandsConfiguration  {
+
+    override func get() -> CardBrandsConfiguration {
         return DefaultValueRegistry.defaultValue(for: (CardBrandsConfiguration).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidationFlow.swift
@@ -1,408 +1,313 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockCvcValidationFlow: CvcValidationFlow, Cuckoo.ClassMock {
 
+    typealias MocksType = CvcValidationFlow
 
+    typealias Stubbing = __StubbingProxy_CvcValidationFlow
+    typealias Verification = __VerificationProxy_CvcValidationFlow
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
-
- class MockCvcValidationFlow: CvcValidationFlow, Cuckoo.ClassMock {
-    
-     typealias MocksType = CvcValidationFlow
-    
-     typealias Stubbing = __StubbingProxy_CvcValidationFlow
-     typealias Verification = __VerificationProxy_CvcValidationFlow
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: CvcValidationFlow?
 
-     func enableDefaultImplementation(_ stub: CvcValidationFlow) {
+    func enableDefaultImplementation(_ stub: CvcValidationFlow) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
-    
-    
-    
-     override var validationRule: ValidationRule {
-        get {
-            return cuckoo_manager.getter("validationRule",
-                superclassCall:
-                    
-                    super.validationRule
-                    ,
-                defaultCall: __defaultImplStub!.validationRule)
-        }
-        
+    override var validationRule: ValidationRule {
+        return cuckoo_manager.getter(
+            "validationRule",
+            superclassCall:
+
+                super.validationRule,
+            defaultCall: __defaultImplStub!.validationRule)
+
     }
-    
-    
-    
-    
-    
-     override var cvc: String? {
-        get {
-            return cuckoo_manager.getter("cvc",
-                superclassCall:
-                    
-                    super.cvc
-                    ,
-                defaultCall: __defaultImplStub!.cvc)
-        }
-        
+
+    override var cvc: String? {
+        return cuckoo_manager.getter(
+            "cvc",
+            superclassCall:
+
+                super.cvc,
+            defaultCall: __defaultImplStub!.cvc)
+
     }
-    
-    
 
-    
+    override func validate(cvc: String?) {
 
-    
-    
-    
-    
-     override func validate(cvc: String?)  {
-        
-    return cuckoo_manager.call(
-    """
-    validate(cvc: String?)
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(cvc: String?)
+            """,
             parameters: (cvc),
             escapingParameters: (cvc),
             superclassCall:
-                
-                super.validate(cvc: cvc)
-                ,
+
+                super.validate(cvc: cvc),
             defaultCall: __defaultImplStub!.validate(cvc: cvc))
-        
+
     }
-    
-    
-    
-    
-    
-     override func resetValidationRule()  {
-        
-    return cuckoo_manager.call(
-    """
-    resetValidationRule()
-    """,
+
+    override func resetValidationRule() {
+
+        return cuckoo_manager.call(
+            """
+            resetValidationRule()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                super.resetValidationRule()
-                ,
+
+                super.resetValidationRule(),
             defaultCall: __defaultImplStub!.resetValidationRule())
-        
+
     }
-    
-    
-    
-    
-    
-     override func revalidate()  {
-        
-    return cuckoo_manager.call(
-    """
-    revalidate()
-    """,
+
+    override func revalidate() {
+
+        return cuckoo_manager.call(
+            """
+            revalidate()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                super.revalidate()
-                ,
+
+                super.revalidate(),
             defaultCall: __defaultImplStub!.revalidate())
-        
+
     }
-    
-    
-    
-    
-    
-     override func updateValidationRule(with rule: ValidationRule)  {
-        
-    return cuckoo_manager.call(
-    """
-    updateValidationRule(with: ValidationRule)
-    """,
+
+    override func updateValidationRule(with rule: ValidationRule) {
+
+        return cuckoo_manager.call(
+            """
+            updateValidationRule(with: ValidationRule)
+            """,
             parameters: (rule),
             escapingParameters: (rule),
             superclassCall:
-                
-                super.updateValidationRule(with: rule)
-                ,
+
+                super.updateValidationRule(with: rule),
             defaultCall: __defaultImplStub!.updateValidationRule(with: rule))
-        
+
     }
-    
-    
-    
-    
-    
-     override func notifyMerchant()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchant()
-    """,
+
+    override func notifyMerchant() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchant()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                super.notifyMerchant()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchant())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_CvcValidationFlow: Cuckoo.StubbingProxy {
+                super.notifyMerchant(),
+            defaultCall: __defaultImplStub!.notifyMerchant())
+
+    }
+
+    struct __StubbingProxy_CvcValidationFlow: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        var validationRule: Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCvcValidationFlow, ValidationRule> {
+
+        var validationRule:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCvcValidationFlow, ValidationRule>
+        {
             return .init(manager: cuckoo_manager, name: "validationRule")
         }
-        
-        
-        
-        
+
         var cvc: Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCvcValidationFlow, String?> {
             return .init(manager: cuckoo_manager, name: "cvc")
         }
-        
-        
-        
-        
-        
-        func validate<M1: Cuckoo.OptionalMatchable>(cvc: M1) -> Cuckoo.ClassStubNoReturnFunction<(String?)> where M1.OptionalMatchedType == String {
+
+        func validate<M1: Cuckoo.OptionalMatchable>(cvc: M1)
+            -> Cuckoo.ClassStubNoReturnFunction<(String?)> where M1.OptionalMatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String?)>] = [wrap(matchable: cvc) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationFlow.self, method:
-    """
-    validate(cvc: String?)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationFlow.self,
+                    method:
+                        """
+                        validate(cvc: String?)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func resetValidationRule() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationFlow.self, method:
-    """
-    resetValidationRule()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationFlow.self,
+                    method:
+                        """
+                        resetValidationRule()
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func revalidate() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationFlow.self, method:
-    """
-    revalidate()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationFlow.self,
+                    method:
+                        """
+                        revalidate()
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func updateValidationRule<M1: Cuckoo.Matchable>(with rule: M1) -> Cuckoo.ClassStubNoReturnFunction<(ValidationRule)> where M1.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(ValidationRule)>] = [wrap(matchable: rule) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationFlow.self, method:
-    """
-    updateValidationRule(with: ValidationRule)
-    """, parameterMatchers: matchers))
+
+        func updateValidationRule<M1: Cuckoo.Matchable>(with rule: M1)
+            -> Cuckoo.ClassStubNoReturnFunction<(ValidationRule)>
+        where M1.MatchedType == ValidationRule {
+            let matchers: [Cuckoo.ParameterMatcher<(ValidationRule)>] = [
+                wrap(matchable: rule) { $0 }
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationFlow.self,
+                    method:
+                        """
+                        updateValidationRule(with: ValidationRule)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func notifyMerchant() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationFlow.self, method:
-    """
-    notifyMerchant()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationFlow.self,
+                    method:
+                        """
+                        notifyMerchant()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_CvcValidationFlow: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_CvcValidationFlow: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-        
-        
+
         var validationRule: Cuckoo.VerifyReadOnlyProperty<ValidationRule> {
-            return .init(manager: cuckoo_manager, name: "validationRule", callMatcher: callMatcher, sourceLocation: sourceLocation)
+            return .init(
+                manager: cuckoo_manager, name: "validationRule", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         var cvc: Cuckoo.VerifyReadOnlyProperty<String?> {
-            return .init(manager: cuckoo_manager, name: "cvc", callMatcher: callMatcher, sourceLocation: sourceLocation)
+            return .init(
+                manager: cuckoo_manager, name: "cvc", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
         }
-        
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.OptionalMatchable>(cvc: M1) -> Cuckoo.__DoNotUse<(String?), Void> where M1.OptionalMatchedType == String {
+        func validate<M1: Cuckoo.OptionalMatchable>(cvc: M1) -> Cuckoo.__DoNotUse<(String?), Void>
+        where M1.OptionalMatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String?)>] = [wrap(matchable: cvc) { $0 }]
             return cuckoo_manager.verify(
-    """
-    validate(cvc: String?)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(cvc: String?)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func resetValidationRule() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    resetValidationRule()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                resetValidationRule()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func revalidate() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    revalidate()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                revalidate()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func updateValidationRule<M1: Cuckoo.Matchable>(with rule: M1) -> Cuckoo.__DoNotUse<(ValidationRule), Void> where M1.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(ValidationRule)>] = [wrap(matchable: rule) { $0 }]
+        func updateValidationRule<M1: Cuckoo.Matchable>(with rule: M1)
+            -> Cuckoo.__DoNotUse<(ValidationRule), Void> where M1.MatchedType == ValidationRule
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(ValidationRule)>] = [
+                wrap(matchable: rule) { $0 }
+            ]
             return cuckoo_manager.verify(
-    """
-    updateValidationRule(with: ValidationRule)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                updateValidationRule(with: ValidationRule)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchant() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchant()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchant()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class CvcValidationFlowStub: CvcValidationFlow {
 
- class CvcValidationFlowStub: CvcValidationFlow {
-    
-    
-    
-    
-     override var validationRule: ValidationRule {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (ValidationRule).self)
-        }
-        
-    }
-    
-    
-    
-    
-    
-     override var cvc: String? {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (String?).self)
-        }
-        
-    }
-    
-    
+    override var validationRule: ValidationRule {
+        return DefaultValueRegistry.defaultValue(for: (ValidationRule).self)
 
-    
+    }
 
-    
-    
-    
-    
-     override func validate(cvc: String?)   {
+    override var cvc: String? {
+        return DefaultValueRegistry.defaultValue(for: (String?).self)
+
+    }
+
+    override func validate(cvc: String?) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func resetValidationRule()   {
+
+    override func resetValidationRule() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func revalidate()   {
+
+    override func revalidate() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func updateValidationRule(with rule: ValidationRule)   {
+
+    override func updateValidationRule(with rule: ValidationRule) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func notifyMerchant()   {
+
+    override func notifyMerchant() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidationStateHandler.swift
@@ -1,173 +1,134 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockCvcValidationStateHandler: CvcValidationStateHandler, Cuckoo.ProtocolMock {
 
+    typealias MocksType = CvcValidationStateHandler
 
+    typealias Stubbing = __StubbingProxy_CvcValidationStateHandler
+    typealias Verification = __VerificationProxy_CvcValidationStateHandler
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
 
-
- class MockCvcValidationStateHandler: CvcValidationStateHandler, Cuckoo.ProtocolMock {
-    
-     typealias MocksType = CvcValidationStateHandler
-    
-     typealias Stubbing = __StubbingProxy_CvcValidationStateHandler
-     typealias Verification = __VerificationProxy_CvcValidationStateHandler
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
-
-    
     private var __defaultImplStub: CvcValidationStateHandler?
 
-     func enableDefaultImplementation(_ stub: CvcValidationStateHandler) {
+    func enableDefaultImplementation(_ stub: CvcValidationStateHandler) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    func handleCvcValidation(isValid: Bool) {
 
-    
-
-    
-    
-    
-    
-     func handleCvcValidation(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    handleCvcValidation(isValid: Bool)
-    """,
+        return cuckoo_manager.call(
+            """
+            handleCvcValidation(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.handleCvcValidation(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-     func notifyMerchantOfCvcValidationState()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchantOfCvcValidationState()
-    """,
+
+    func notifyMerchantOfCvcValidationState() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchantOfCvcValidationState()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchantOfCvcValidationState())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_CvcValidationStateHandler: Cuckoo.StubbingProxy {
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.notifyMerchantOfCvcValidationState())
+
+    }
+
+    struct __StubbingProxy_CvcValidationStateHandler: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func handleCvcValidation<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func handleCvcValidation<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationStateHandler.self, method:
-    """
-    handleCvcValidation(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationStateHandler.self,
+                    method:
+                        """
+                        handleCvcValidation(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func notifyMerchantOfCvcValidationState() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidationStateHandler.self, method:
-    """
-    notifyMerchantOfCvcValidationState()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidationStateHandler.self,
+                    method:
+                        """
+                        notifyMerchantOfCvcValidationState()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_CvcValidationStateHandler: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_CvcValidationStateHandler: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func handleCvcValidation<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func handleCvcValidation<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    handleCvcValidation(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                handleCvcValidation(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchantOfCvcValidationState() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchantOfCvcValidationState()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchantOfCvcValidationState()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class CvcValidationStateHandlerStub: CvcValidationStateHandler {
 
- class CvcValidationStateHandlerStub: CvcValidationStateHandler {
-    
-
-    
-
-    
-    
-    
-    
-     func handleCvcValidation(isValid: Bool)   {
+    func handleCvcValidation(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     func notifyMerchantOfCvcValidationState()   {
+
+    func notifyMerchantOfCvcValidationState() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidator.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCvcValidator.swift
@@ -1,173 +1,150 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockCvcValidator: CvcValidator, Cuckoo.ClassMock {
 
+    typealias MocksType = CvcValidator
 
+    typealias Stubbing = __StubbingProxy_CvcValidator
+    typealias Verification = __VerificationProxy_CvcValidator
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
-
- class MockCvcValidator: CvcValidator, Cuckoo.ClassMock {
-    
-     typealias MocksType = CvcValidator
-    
-     typealias Stubbing = __StubbingProxy_CvcValidator
-     typealias Verification = __VerificationProxy_CvcValidator
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: CvcValidator?
 
-     func enableDefaultImplementation(_ stub: CvcValidator) {
+    func enableDefaultImplementation(_ stub: CvcValidator) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func validate(cvc: String?, validationRule: ValidationRule) -> Bool {
 
-    
-
-    
-    
-    
-    
-     override func validate(cvc: String?, validationRule: ValidationRule) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    validate(cvc: String?, validationRule: ValidationRule) -> Bool
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(cvc: String?, validationRule: ValidationRule) -> Bool
+            """,
             parameters: (cvc, validationRule),
             escapingParameters: (cvc, validationRule),
             superclassCall:
-                
-                super.validate(cvc: cvc, validationRule: validationRule)
-                ,
+
+                super.validate(cvc: cvc, validationRule: validationRule),
             defaultCall: __defaultImplStub!.validate(cvc: cvc, validationRule: validationRule))
-        
+
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ text: String, using validationRule: ValidationRule) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    canValidate(_: String, using: ValidationRule) -> Bool
-    """,
+
+    override func canValidate(_ text: String, using validationRule: ValidationRule) -> Bool {
+
+        return cuckoo_manager.call(
+            """
+            canValidate(_: String, using: ValidationRule) -> Bool
+            """,
             parameters: (text, validationRule),
             escapingParameters: (text, validationRule),
             superclassCall:
-                
-                super.canValidate(text, using: validationRule)
-                ,
-            defaultCall: __defaultImplStub!.canValidate(text, using: validationRule))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_CvcValidator: Cuckoo.StubbingProxy {
+                super.canValidate(text, using: validationRule),
+            defaultCall: __defaultImplStub!.canValidate(text, using: validationRule))
+
+    }
+
+    struct __StubbingProxy_CvcValidator: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func validate<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(cvc: M1, validationRule: M2) -> Cuckoo.ClassStubFunction<(String?, ValidationRule), Bool> where M1.OptionalMatchedType == String, M2.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(String?, ValidationRule)>] = [wrap(matchable: cvc) { $0.0 }, wrap(matchable: validationRule) { $0.1 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidator.self, method:
-    """
-    validate(cvc: String?, validationRule: ValidationRule) -> Bool
-    """, parameterMatchers: matchers))
+
+        func validate<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(
+            cvc: M1, validationRule: M2
+        ) -> Cuckoo.ClassStubFunction<(String?, ValidationRule), Bool>
+        where M1.OptionalMatchedType == String, M2.MatchedType == ValidationRule {
+            let matchers: [Cuckoo.ParameterMatcher<(String?, ValidationRule)>] = [
+                wrap(matchable: cvc) { $0.0 }, wrap(matchable: validationRule) { $0.1 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidator.self,
+                    method:
+                        """
+                        validate(cvc: String?, validationRule: ValidationRule) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func canValidate<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ text: M1, using validationRule: M2) -> Cuckoo.ClassStubFunction<(String, ValidationRule), Bool> where M1.MatchedType == String, M2.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(String, ValidationRule)>] = [wrap(matchable: text) { $0.0 }, wrap(matchable: validationRule) { $0.1 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockCvcValidator.self, method:
-    """
-    canValidate(_: String, using: ValidationRule) -> Bool
-    """, parameterMatchers: matchers))
+
+        func canValidate<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(
+            _ text: M1, using validationRule: M2
+        ) -> Cuckoo.ClassStubFunction<(String, ValidationRule), Bool>
+        where M1.MatchedType == String, M2.MatchedType == ValidationRule {
+            let matchers: [Cuckoo.ParameterMatcher<(String, ValidationRule)>] = [
+                wrap(matchable: text) { $0.0 }, wrap(matchable: validationRule) { $0.1 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCvcValidator.self,
+                    method:
+                        """
+                        canValidate(_: String, using: ValidationRule) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_CvcValidator: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_CvcValidator: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(cvc: M1, validationRule: M2) -> Cuckoo.__DoNotUse<(String?, ValidationRule), Bool> where M1.OptionalMatchedType == String, M2.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(String?, ValidationRule)>] = [wrap(matchable: cvc) { $0.0 }, wrap(matchable: validationRule) { $0.1 }]
+        func validate<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable>(
+            cvc: M1, validationRule: M2
+        ) -> Cuckoo.__DoNotUse<(String?, ValidationRule), Bool>
+        where M1.OptionalMatchedType == String, M2.MatchedType == ValidationRule {
+            let matchers: [Cuckoo.ParameterMatcher<(String?, ValidationRule)>] = [
+                wrap(matchable: cvc) { $0.0 }, wrap(matchable: validationRule) { $0.1 },
+            ]
             return cuckoo_manager.verify(
-    """
-    validate(cvc: String?, validationRule: ValidationRule) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(cvc: String?, validationRule: ValidationRule) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func canValidate<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ text: M1, using validationRule: M2) -> Cuckoo.__DoNotUse<(String, ValidationRule), Bool> where M1.MatchedType == String, M2.MatchedType == ValidationRule {
-            let matchers: [Cuckoo.ParameterMatcher<(String, ValidationRule)>] = [wrap(matchable: text) { $0.0 }, wrap(matchable: validationRule) { $0.1 }]
+        func canValidate<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(
+            _ text: M1, using validationRule: M2
+        ) -> Cuckoo.__DoNotUse<(String, ValidationRule), Bool>
+        where M1.MatchedType == String, M2.MatchedType == ValidationRule {
+            let matchers: [Cuckoo.ParameterMatcher<(String, ValidationRule)>] = [
+                wrap(matchable: text) { $0.0 }, wrap(matchable: validationRule) { $0.1 },
+            ]
             return cuckoo_manager.verify(
-    """
-    canValidate(_: String, using: ValidationRule) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                canValidate(_: String, using: ValidationRule) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class CvcValidatorStub: CvcValidator {
 
- class CvcValidatorStub: CvcValidator {
-    
-
-    
-
-    
-    
-    
-    
-     override func validate(cvc: String?, validationRule: ValidationRule) -> Bool  {
+    override func validate(cvc: String?, validationRule: ValidationRule) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ text: String, using validationRule: ValidationRule) -> Bool  {
+
+    override func canValidate(_ text: String, using validationRule: ValidationRule) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationFlow.swift
@@ -1,173 +1,133 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockExpiryDateValidationFlow: ExpiryDateValidationFlow, Cuckoo.ClassMock {
 
+    typealias MocksType = ExpiryDateValidationFlow
 
+    typealias Stubbing = __StubbingProxy_ExpiryDateValidationFlow
+    typealias Verification = __VerificationProxy_ExpiryDateValidationFlow
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
-
- class MockExpiryDateValidationFlow: ExpiryDateValidationFlow, Cuckoo.ClassMock {
-    
-     typealias MocksType = ExpiryDateValidationFlow
-    
-     typealias Stubbing = __StubbingProxy_ExpiryDateValidationFlow
-     typealias Verification = __VerificationProxy_ExpiryDateValidationFlow
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: ExpiryDateValidationFlow?
 
-     func enableDefaultImplementation(_ stub: ExpiryDateValidationFlow) {
+    func enableDefaultImplementation(_ stub: ExpiryDateValidationFlow) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func validate(expiryDate: String) {
 
-    
-
-    
-    
-    
-    
-     override func validate(expiryDate: String)  {
-        
-    return cuckoo_manager.call(
-    """
-    validate(expiryDate: String)
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(expiryDate: String)
+            """,
             parameters: (expiryDate),
             escapingParameters: (expiryDate),
             superclassCall:
-                
-                super.validate(expiryDate: expiryDate)
-                ,
+
+                super.validate(expiryDate: expiryDate),
             defaultCall: __defaultImplStub!.validate(expiryDate: expiryDate))
-        
+
     }
-    
-    
-    
-    
-    
-     override func notifyMerchant()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchant()
-    """,
+
+    override func notifyMerchant() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchant()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                super.notifyMerchant()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchant())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_ExpiryDateValidationFlow: Cuckoo.StubbingProxy {
+                super.notifyMerchant(),
+            defaultCall: __defaultImplStub!.notifyMerchant())
+
+    }
+
+    struct __StubbingProxy_ExpiryDateValidationFlow: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func validate<M1: Cuckoo.Matchable>(expiryDate: M1) -> Cuckoo.ClassStubNoReturnFunction<(String)> where M1.MatchedType == String {
+
+        func validate<M1: Cuckoo.Matchable>(expiryDate: M1)
+            -> Cuckoo.ClassStubNoReturnFunction<(String)> where M1.MatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: expiryDate) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidationFlow.self, method:
-    """
-    validate(expiryDate: String)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidationFlow.self,
+                    method:
+                        """
+                        validate(expiryDate: String)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func notifyMerchant() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidationFlow.self, method:
-    """
-    notifyMerchant()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidationFlow.self,
+                    method:
+                        """
+                        notifyMerchant()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_ExpiryDateValidationFlow: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_ExpiryDateValidationFlow: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.Matchable>(expiryDate: M1) -> Cuckoo.__DoNotUse<(String), Void> where M1.MatchedType == String {
+        func validate<M1: Cuckoo.Matchable>(expiryDate: M1) -> Cuckoo.__DoNotUse<(String), Void>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: expiryDate) { $0 }]
             return cuckoo_manager.verify(
-    """
-    validate(expiryDate: String)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(expiryDate: String)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchant() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchant()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchant()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class ExpiryDateValidationFlowStub: ExpiryDateValidationFlow {
 
- class ExpiryDateValidationFlowStub: ExpiryDateValidationFlow {
-    
-
-    
-
-    
-    
-    
-    
-     override func validate(expiryDate: String)   {
+    override func validate(expiryDate: String) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func notifyMerchant()   {
+
+    override func notifyMerchant() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidationStateHandler.swift
@@ -1,173 +1,135 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockExpiryDateValidationStateHandler: ExpiryDateValidationStateHandler, Cuckoo.ProtocolMock {
 
+    typealias MocksType = ExpiryDateValidationStateHandler
 
+    typealias Stubbing = __StubbingProxy_ExpiryDateValidationStateHandler
+    typealias Verification = __VerificationProxy_ExpiryDateValidationStateHandler
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
 
-
- class MockExpiryDateValidationStateHandler: ExpiryDateValidationStateHandler, Cuckoo.ProtocolMock {
-    
-     typealias MocksType = ExpiryDateValidationStateHandler
-    
-     typealias Stubbing = __StubbingProxy_ExpiryDateValidationStateHandler
-     typealias Verification = __VerificationProxy_ExpiryDateValidationStateHandler
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
-
-    
     private var __defaultImplStub: ExpiryDateValidationStateHandler?
 
-     func enableDefaultImplementation(_ stub: ExpiryDateValidationStateHandler) {
+    func enableDefaultImplementation(_ stub: ExpiryDateValidationStateHandler) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    func handleExpiryDateValidation(isValid: Bool) {
 
-    
-
-    
-    
-    
-    
-     func handleExpiryDateValidation(isValid: Bool)  {
-        
-    return cuckoo_manager.call(
-    """
-    handleExpiryDateValidation(isValid: Bool)
-    """,
+        return cuckoo_manager.call(
+            """
+            handleExpiryDateValidation(isValid: Bool)
+            """,
             parameters: (isValid),
             escapingParameters: (isValid),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
             defaultCall: __defaultImplStub!.handleExpiryDateValidation(isValid: isValid))
-        
+
     }
-    
-    
-    
-    
-    
-     func notifyMerchantOfExpiryDateValidationState()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchantOfExpiryDateValidationState()
-    """,
+
+    func notifyMerchantOfExpiryDateValidationState() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchantOfExpiryDateValidationState()
+            """,
             parameters: (),
             escapingParameters: (),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchantOfExpiryDateValidationState())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_ExpiryDateValidationStateHandler: Cuckoo.StubbingProxy {
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.notifyMerchantOfExpiryDateValidationState())
+
+    }
+
+    struct __StubbingProxy_ExpiryDateValidationStateHandler: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func handleExpiryDateValidation<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool {
+
+        func handleExpiryDateValidation<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.ProtocolStubNoReturnFunction<(Bool)> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidationStateHandler.self, method:
-    """
-    handleExpiryDateValidation(isValid: Bool)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidationStateHandler.self,
+                    method:
+                        """
+                        handleExpiryDateValidation(isValid: Bool)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func notifyMerchantOfExpiryDateValidationState() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
+
+        func notifyMerchantOfExpiryDateValidationState() -> Cuckoo.ProtocolStubNoReturnFunction<()>
+        {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidationStateHandler.self, method:
-    """
-    notifyMerchantOfExpiryDateValidationState()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidationStateHandler.self,
+                    method:
+                        """
+                        notifyMerchantOfExpiryDateValidationState()
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_ExpiryDateValidationStateHandler: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_ExpiryDateValidationStateHandler: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func handleExpiryDateValidation<M1: Cuckoo.Matchable>(isValid: M1) -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool {
+        func handleExpiryDateValidation<M1: Cuckoo.Matchable>(isValid: M1)
+            -> Cuckoo.__DoNotUse<(Bool), Void> where M1.MatchedType == Bool
+        {
             let matchers: [Cuckoo.ParameterMatcher<(Bool)>] = [wrap(matchable: isValid) { $0 }]
             return cuckoo_manager.verify(
-    """
-    handleExpiryDateValidation(isValid: Bool)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                handleExpiryDateValidation(isValid: Bool)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchantOfExpiryDateValidationState() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchantOfExpiryDateValidationState()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchantOfExpiryDateValidationState()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class ExpiryDateValidationStateHandlerStub: ExpiryDateValidationStateHandler {
 
- class ExpiryDateValidationStateHandlerStub: ExpiryDateValidationStateHandler {
-    
-
-    
-
-    
-    
-    
-    
-     func handleExpiryDateValidation(isValid: Bool)   {
+    func handleExpiryDateValidation(isValid: Bool) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     func notifyMerchantOfExpiryDateValidationState()   {
+
+    func notifyMerchantOfExpiryDateValidationState() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidator.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockExpiryDateValidator.swift
@@ -1,175 +1,137 @@
 import Cuckoo
-@testable import AccessCheckoutSDK
-
 import Foundation
 
+@testable import AccessCheckoutSDK
 
+class MockExpiryDateValidator: ExpiryDateValidator, Cuckoo.ClassMock {
 
+    typealias MocksType = ExpiryDateValidator
 
+    typealias Stubbing = __StubbingProxy_ExpiryDateValidator
+    typealias Verification = __VerificationProxy_ExpiryDateValidator
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
- class MockExpiryDateValidator: ExpiryDateValidator, Cuckoo.ClassMock {
-    
-     typealias MocksType = ExpiryDateValidator
-    
-     typealias Stubbing = __StubbingProxy_ExpiryDateValidator
-     typealias Verification = __VerificationProxy_ExpiryDateValidator
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: ExpiryDateValidator?
 
-     func enableDefaultImplementation(_ stub: ExpiryDateValidator) {
+    func enableDefaultImplementation(_ stub: ExpiryDateValidator) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func validate(_ expiryDate: String) -> Bool {
 
-    
-
-    
-    
-    
-    
-     override func validate(_ expiryDate: String) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    validate(_: String) -> Bool
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(_: String) -> Bool
+            """,
             parameters: (expiryDate),
             escapingParameters: (expiryDate),
             superclassCall:
-                
-                super.validate(expiryDate)
-                ,
+
+                super.validate(expiryDate),
             defaultCall: __defaultImplStub!.validate(expiryDate))
-        
+
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ text: String) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    canValidate(_: String) -> Bool
-    """,
+
+    override func canValidate(_ text: String) -> Bool {
+
+        return cuckoo_manager.call(
+            """
+            canValidate(_: String) -> Bool
+            """,
             parameters: (text),
             escapingParameters: (text),
             superclassCall:
-                
-                super.canValidate(text)
-                ,
-            defaultCall: __defaultImplStub!.canValidate(text))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_ExpiryDateValidator: Cuckoo.StubbingProxy {
+                super.canValidate(text),
+            defaultCall: __defaultImplStub!.canValidate(text))
+
+    }
+
+    struct __StubbingProxy_ExpiryDateValidator: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func validate<M1: Cuckoo.Matchable>(_ expiryDate: M1) -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String {
+
+        func validate<M1: Cuckoo.Matchable>(_ expiryDate: M1)
+            -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: expiryDate) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidator.self, method:
-    """
-    validate(_: String) -> Bool
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidator.self,
+                    method:
+                        """
+                        validate(_: String) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func canValidate<M1: Cuckoo.Matchable>(_ text: M1) -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String {
+
+        func canValidate<M1: Cuckoo.Matchable>(_ text: M1)
+            -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: text) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockExpiryDateValidator.self, method:
-    """
-    canValidate(_: String) -> Bool
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockExpiryDateValidator.self,
+                    method:
+                        """
+                        canValidate(_: String) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_ExpiryDateValidator: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_ExpiryDateValidator: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.Matchable>(_ expiryDate: M1) -> Cuckoo.__DoNotUse<(String), Bool> where M1.MatchedType == String {
+        func validate<M1: Cuckoo.Matchable>(_ expiryDate: M1) -> Cuckoo.__DoNotUse<(String), Bool>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: expiryDate) { $0 }]
             return cuckoo_manager.verify(
-    """
-    validate(_: String) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(_: String) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func canValidate<M1: Cuckoo.Matchable>(_ text: M1) -> Cuckoo.__DoNotUse<(String), Bool> where M1.MatchedType == String {
+        func canValidate<M1: Cuckoo.Matchable>(_ text: M1) -> Cuckoo.__DoNotUse<(String), Bool>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: text) { $0 }]
             return cuckoo_manager.verify(
-    """
-    canValidate(_: String) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                canValidate(_: String) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class ExpiryDateValidatorStub: ExpiryDateValidator {
 
- class ExpiryDateValidatorStub: ExpiryDateValidator {
-    
-
-    
-
-    
-    
-    
-    
-     override func validate(_ expiryDate: String) -> Bool  {
+    override func validate(_ expiryDate: String) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ text: String) -> Bool  {
+
+    override func canValidate(_ text: String) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
@@ -1,226 +1,173 @@
 import Cuckoo
-@testable import AccessCheckoutSDK
-
 import Foundation
 
+@testable import AccessCheckoutSDK
 
+class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
 
+    typealias MocksType = PanValidationFlow
 
+    typealias Stubbing = __StubbingProxy_PanValidationFlow
+    typealias Verification = __VerificationProxy_PanValidationFlow
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
- class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
-    
-     typealias MocksType = PanValidationFlow
-    
-     typealias Stubbing = __StubbingProxy_PanValidationFlow
-     typealias Verification = __VerificationProxy_PanValidationFlow
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: PanValidationFlow?
 
-     func enableDefaultImplementation(_ stub: PanValidationFlow) {
+    func enableDefaultImplementation(_ stub: PanValidationFlow) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func validate(pan: String) {
 
-    
-
-    
-    
-    
-    
-     override func validate(pan: String)  {
-        
-    return cuckoo_manager.call(
-    """
-    validate(pan: String)
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(pan: String)
+            """,
             parameters: (pan),
             escapingParameters: (pan),
             superclassCall:
-                
-                super.validate(pan: pan)
-                ,
-            defaultCall: __defaultImplStub!.validate(pan: pan))
-        
-    }
-    
-    
-    
-    
-    
-     override func notifyMerchant()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchant()
-    """,
-            parameters: (),
-            escapingParameters: (),
-            superclassCall:
-                
-                super.notifyMerchant()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchant())
-        
-    }
-    
-    
-    
-    
-    
-     override func getCardBrand() -> CardBrandModel? {
-        
-    return cuckoo_manager.call(
-    """
-    getCardBrand() -> CardBrandModel?
-    """,
-            parameters: (),
-            escapingParameters: (),
-            superclassCall:
-                
-                super.getCardBrand()
-                ,
-            defaultCall: __defaultImplStub!.getCardBrand())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_PanValidationFlow: Cuckoo.StubbingProxy {
+                super.validate(pan: pan),
+            defaultCall: __defaultImplStub!.validate(pan: pan))
+
+    }
+
+    override func notifyMerchant() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchant()
+            """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+
+                super.notifyMerchant(),
+            defaultCall: __defaultImplStub!.notifyMerchant())
+
+    }
+
+    override func getCardBrand() -> CardBrandModel? {
+
+        return cuckoo_manager.call(
+            """
+            getCardBrand() -> CardBrandModel?
+            """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+
+                super.getCardBrand(),
+            defaultCall: __defaultImplStub!.getCardBrand())
+
+    }
+
+    struct __StubbingProxy_PanValidationFlow: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.ClassStubNoReturnFunction<(String)> where M1.MatchedType == String {
+
+        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.ClassStubNoReturnFunction<(String)>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationFlow.self, method:
-    """
-    validate(pan: String)
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationFlow.self,
+                    method:
+                        """
+                        validate(pan: String)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func notifyMerchant() -> Cuckoo.ClassStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationFlow.self, method:
-    """
-    notifyMerchant()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationFlow.self,
+                    method:
+                        """
+                        notifyMerchant()
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func getCardBrand() -> Cuckoo.ClassStubFunction<(), CardBrandModel?> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationFlow.self, method:
-    """
-    getCardBrand() -> CardBrandModel?
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationFlow.self,
+                    method:
+                        """
+                        getCardBrand() -> CardBrandModel?
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_PanValidationFlow: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_PanValidationFlow: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.__DoNotUse<(String), Void> where M1.MatchedType == String {
+        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.__DoNotUse<(String), Void>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
             return cuckoo_manager.verify(
-    """
-    validate(pan: String)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(pan: String)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchant() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchant()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchant()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func getCardBrand() -> Cuckoo.__DoNotUse<(), CardBrandModel?> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    getCardBrand() -> CardBrandModel?
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                getCardBrand() -> CardBrandModel?
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class PanValidationFlowStub: PanValidationFlow {
 
- class PanValidationFlowStub: PanValidationFlow {
-    
-
-    
-
-    
-    
-    
-    
-     override func validate(pan: String)   {
+    override func validate(pan: String) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func notifyMerchant()   {
+
+    override func notifyMerchant() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     override func getCardBrand() -> CardBrandModel?  {
+
+    override func getCardBrand() -> CardBrandModel? {
         return DefaultValueRegistry.defaultValue(for: (CardBrandModel?).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationStateHandler.swift
@@ -1,275 +1,229 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockPanValidationStateHandler: PanValidationStateHandler, Cuckoo.ProtocolMock {
 
+    typealias MocksType = PanValidationStateHandler
 
+    typealias Stubbing = __StubbingProxy_PanValidationStateHandler
+    typealias Verification = __VerificationProxy_PanValidationStateHandler
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
 
-
- class MockPanValidationStateHandler: PanValidationStateHandler, Cuckoo.ProtocolMock {
-    
-     typealias MocksType = PanValidationStateHandler
-    
-     typealias Stubbing = __StubbingProxy_PanValidationStateHandler
-     typealias Verification = __VerificationProxy_PanValidationStateHandler
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
-
-    
     private var __defaultImplStub: PanValidationStateHandler?
 
-     func enableDefaultImplementation(_ stub: PanValidationStateHandler) {
+    func enableDefaultImplementation(_ stub: PanValidationStateHandler) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    func handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?) {
 
-    
-
-    
-    
-    
-    
-     func handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)  {
-        
-    return cuckoo_manager.call(
-    """
-    handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
-    """,
+        return cuckoo_manager.call(
+            """
+            handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
+            """,
             parameters: (isValid, cardBrand),
             escapingParameters: (isValid, cardBrand),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.handlePanValidation(isValid: isValid, cardBrand: cardBrand))
-        
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.handlePanValidation(
+                isValid: isValid, cardBrand: cardBrand))
+
     }
-    
-    
-    
-    
-    
-     func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
-    """,
+
+    func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool {
+
+        return cuckoo_manager.call(
+            """
+            isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
+            """,
             parameters: (cardBrand),
             escapingParameters: (cardBrand),
             superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.isCardBrandDifferentFrom(cardBrand: cardBrand))
-        
-    }
-    
-    
-    
-    
-    
-     func notifyMerchantOfPanValidationState()  {
-        
-    return cuckoo_manager.call(
-    """
-    notifyMerchantOfPanValidationState()
-    """,
-            parameters: (),
-            escapingParameters: (),
-            superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.notifyMerchantOfPanValidationState())
-        
-    }
-    
-    
-    
-    
-    
-     func getCardBrand() -> CardBrandModel? {
-        
-    return cuckoo_manager.call(
-    """
-    getCardBrand() -> CardBrandModel?
-    """,
-            parameters: (),
-            escapingParameters: (),
-            superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.getCardBrand())
-        
-    }
-    
-    
 
-     struct __StubbingProxy_PanValidationStateHandler: Cuckoo.StubbingProxy {
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.isCardBrandDifferentFrom(cardBrand: cardBrand))
+
+    }
+
+    func notifyMerchantOfPanValidationState() {
+
+        return cuckoo_manager.call(
+            """
+            notifyMerchantOfPanValidationState()
+            """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.notifyMerchantOfPanValidationState())
+
+    }
+
+    func getCardBrand() -> CardBrandModel? {
+
+        return cuckoo_manager.call(
+            """
+            getCardBrand() -> CardBrandModel?
+            """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall(),
+            defaultCall: __defaultImplStub!.getCardBrand())
+
+    }
+
+    struct __StubbingProxy_PanValidationStateHandler: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func handlePanValidation<M1: Cuckoo.Matchable, M2: Cuckoo.OptionalMatchable>(isValid: M1, cardBrand: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool, CardBrandModel?)> where M1.MatchedType == Bool, M2.OptionalMatchedType == CardBrandModel {
-            let matchers: [Cuckoo.ParameterMatcher<(Bool, CardBrandModel?)>] = [wrap(matchable: isValid) { $0.0 }, wrap(matchable: cardBrand) { $0.1 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationStateHandler.self, method:
-    """
-    handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
-    """, parameterMatchers: matchers))
+
+        func handlePanValidation<M1: Cuckoo.Matchable, M2: Cuckoo.OptionalMatchable>(
+            isValid: M1, cardBrand: M2
+        ) -> Cuckoo.ProtocolStubNoReturnFunction<(Bool, CardBrandModel?)>
+        where M1.MatchedType == Bool, M2.OptionalMatchedType == CardBrandModel {
+            let matchers: [Cuckoo.ParameterMatcher<(Bool, CardBrandModel?)>] = [
+                wrap(matchable: isValid) { $0.0 }, wrap(matchable: cardBrand) { $0.1 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationStateHandler.self,
+                    method:
+                        """
+                        handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func isCardBrandDifferentFrom<M1: Cuckoo.OptionalMatchable>(cardBrand: M1) -> Cuckoo.ProtocolStubFunction<(CardBrandModel?), Bool> where M1.OptionalMatchedType == CardBrandModel {
-            let matchers: [Cuckoo.ParameterMatcher<(CardBrandModel?)>] = [wrap(matchable: cardBrand) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationStateHandler.self, method:
-    """
-    isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
-    """, parameterMatchers: matchers))
+
+        func isCardBrandDifferentFrom<M1: Cuckoo.OptionalMatchable>(cardBrand: M1)
+            -> Cuckoo.ProtocolStubFunction<(CardBrandModel?), Bool>
+        where M1.OptionalMatchedType == CardBrandModel {
+            let matchers: [Cuckoo.ParameterMatcher<(CardBrandModel?)>] = [
+                wrap(matchable: cardBrand) { $0 }
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationStateHandler.self,
+                    method:
+                        """
+                        isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func notifyMerchantOfPanValidationState() -> Cuckoo.ProtocolStubNoReturnFunction<()> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationStateHandler.self, method:
-    """
-    notifyMerchantOfPanValidationState()
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationStateHandler.self,
+                    method:
+                        """
+                        notifyMerchantOfPanValidationState()
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
+
         func getCardBrand() -> Cuckoo.ProtocolStubFunction<(), CardBrandModel?> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidationStateHandler.self, method:
-    """
-    getCardBrand() -> CardBrandModel?
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationStateHandler.self,
+                    method:
+                        """
+                        getCardBrand() -> CardBrandModel?
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_PanValidationStateHandler: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_PanValidationStateHandler: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func handlePanValidation<M1: Cuckoo.Matchable, M2: Cuckoo.OptionalMatchable>(isValid: M1, cardBrand: M2) -> Cuckoo.__DoNotUse<(Bool, CardBrandModel?), Void> where M1.MatchedType == Bool, M2.OptionalMatchedType == CardBrandModel {
-            let matchers: [Cuckoo.ParameterMatcher<(Bool, CardBrandModel?)>] = [wrap(matchable: isValid) { $0.0 }, wrap(matchable: cardBrand) { $0.1 }]
+        func handlePanValidation<M1: Cuckoo.Matchable, M2: Cuckoo.OptionalMatchable>(
+            isValid: M1, cardBrand: M2
+        ) -> Cuckoo.__DoNotUse<(Bool, CardBrandModel?), Void>
+        where M1.MatchedType == Bool, M2.OptionalMatchedType == CardBrandModel {
+            let matchers: [Cuckoo.ParameterMatcher<(Bool, CardBrandModel?)>] = [
+                wrap(matchable: isValid) { $0.0 }, wrap(matchable: cardBrand) { $0.1 },
+            ]
             return cuckoo_manager.verify(
-    """
-    handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func isCardBrandDifferentFrom<M1: Cuckoo.OptionalMatchable>(cardBrand: M1) -> Cuckoo.__DoNotUse<(CardBrandModel?), Bool> where M1.OptionalMatchedType == CardBrandModel {
-            let matchers: [Cuckoo.ParameterMatcher<(CardBrandModel?)>] = [wrap(matchable: cardBrand) { $0 }]
+        func isCardBrandDifferentFrom<M1: Cuckoo.OptionalMatchable>(cardBrand: M1)
+            -> Cuckoo.__DoNotUse<(CardBrandModel?), Bool>
+        where M1.OptionalMatchedType == CardBrandModel {
+            let matchers: [Cuckoo.ParameterMatcher<(CardBrandModel?)>] = [
+                wrap(matchable: cardBrand) { $0 }
+            ]
             return cuckoo_manager.verify(
-    """
-    isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func notifyMerchantOfPanValidationState() -> Cuckoo.__DoNotUse<(), Void> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    notifyMerchantOfPanValidationState()
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                notifyMerchantOfPanValidationState()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
         func getCardBrand() -> Cuckoo.__DoNotUse<(), CardBrandModel?> {
             let matchers: [Cuckoo.ParameterMatcher<Void>] = []
             return cuckoo_manager.verify(
-    """
-    getCardBrand() -> CardBrandModel?
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                getCardBrand() -> CardBrandModel?
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class PanValidationStateHandlerStub: PanValidationStateHandler {
 
- class PanValidationStateHandlerStub: PanValidationStateHandler {
-    
-
-    
-
-    
-    
-    
-    
-     func handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?)   {
+    func handlePanValidation(isValid: Bool, cardBrand: CardBrandModel?) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool  {
+
+    func isCardBrandDifferentFrom(cardBrand: CardBrandModel?) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
-    
-    
-    
-     func notifyMerchantOfPanValidationState()   {
+
+    func notifyMerchantOfPanValidationState() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
-    
-    
-    
-    
-    
-     func getCardBrand() -> CardBrandModel?  {
+
+    func getCardBrand() -> CardBrandModel? {
         return DefaultValueRegistry.defaultValue(for: (CardBrandModel?).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidator.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidator.swift
@@ -1,173 +1,137 @@
 import Cuckoo
+
 @testable import AccessCheckoutSDK
 
+class MockPanValidator: PanValidator, Cuckoo.ClassMock {
 
+    typealias MocksType = PanValidator
 
+    typealias Stubbing = __StubbingProxy_PanValidator
+    typealias Verification = __VerificationProxy_PanValidator
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
-
- class MockPanValidator: PanValidator, Cuckoo.ClassMock {
-    
-     typealias MocksType = PanValidator
-    
-     typealias Stubbing = __StubbingProxy_PanValidator
-     typealias Verification = __VerificationProxy_PanValidator
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: PanValidator?
 
-     func enableDefaultImplementation(_ stub: PanValidator) {
+    func enableDefaultImplementation(_ stub: PanValidator) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func validate(pan: String) -> PanValidationResult {
 
-    
-
-    
-    
-    
-    
-     override func validate(pan: String) -> PanValidationResult {
-        
-    return cuckoo_manager.call(
-    """
-    validate(pan: String) -> PanValidationResult
-    """,
+        return cuckoo_manager.call(
+            """
+            validate(pan: String) -> PanValidationResult
+            """,
             parameters: (pan),
             escapingParameters: (pan),
             superclassCall:
-                
-                super.validate(pan: pan)
-                ,
+
+                super.validate(pan: pan),
             defaultCall: __defaultImplStub!.validate(pan: pan))
-        
+
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ pan: String) -> Bool {
-        
-    return cuckoo_manager.call(
-    """
-    canValidate(_: String) -> Bool
-    """,
+
+    override func canValidate(_ pan: String) -> Bool {
+
+        return cuckoo_manager.call(
+            """
+            canValidate(_: String) -> Bool
+            """,
             parameters: (pan),
             escapingParameters: (pan),
             superclassCall:
-                
-                super.canValidate(pan)
-                ,
-            defaultCall: __defaultImplStub!.canValidate(pan))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_PanValidator: Cuckoo.StubbingProxy {
+                super.canValidate(pan),
+            defaultCall: __defaultImplStub!.canValidate(pan))
+
+    }
+
+    struct __StubbingProxy_PanValidator: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.ClassStubFunction<(String), PanValidationResult> where M1.MatchedType == String {
+
+        func validate<M1: Cuckoo.Matchable>(pan: M1)
+            -> Cuckoo.ClassStubFunction<(String), PanValidationResult>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidator.self, method:
-    """
-    validate(pan: String) -> PanValidationResult
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidator.self,
+                    method:
+                        """
+                        validate(pan: String) -> PanValidationResult
+                        """, parameterMatchers: matchers))
         }
-        
-        
-        
-        
-        func canValidate<M1: Cuckoo.Matchable>(_ pan: M1) -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String {
+
+        func canValidate<M1: Cuckoo.Matchable>(_ pan: M1)
+            -> Cuckoo.ClassStubFunction<(String), Bool> where M1.MatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockPanValidator.self, method:
-    """
-    canValidate(_: String) -> Bool
-    """, parameterMatchers: matchers))
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidator.self,
+                    method:
+                        """
+                        canValidate(_: String) -> Bool
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_PanValidator: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_PanValidator: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.__DoNotUse<(String), PanValidationResult> where M1.MatchedType == String {
+        func validate<M1: Cuckoo.Matchable>(pan: M1)
+            -> Cuckoo.__DoNotUse<(String), PanValidationResult> where M1.MatchedType == String
+        {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
             return cuckoo_manager.verify(
-    """
-    validate(pan: String) -> PanValidationResult
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                validate(pan: String) -> PanValidationResult
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
-        
-        
+
         @discardableResult
-        func canValidate<M1: Cuckoo.Matchable>(_ pan: M1) -> Cuckoo.__DoNotUse<(String), Bool> where M1.MatchedType == String {
+        func canValidate<M1: Cuckoo.Matchable>(_ pan: M1) -> Cuckoo.__DoNotUse<(String), Bool>
+        where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
             return cuckoo_manager.verify(
-    """
-    canValidate(_: String) -> Bool
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                canValidate(_: String) -> Bool
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class PanValidatorStub: PanValidator {
 
- class PanValidatorStub: PanValidator {
-    
-
-    
-
-    
-    
-    
-    
-     override func validate(pan: String) -> PanValidationResult  {
+    override func validate(pan: String) -> PanValidationResult {
         return DefaultValueRegistry.defaultValue(for: (PanValidationResult).self)
     }
-    
-    
-    
-    
-    
-     override func canValidate(_ pan: String) -> Bool  {
+
+    override func canValidate(_ pan: String) -> Bool {
         return DefaultValueRegistry.defaultValue(for: (Bool).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockSingleLinkDiscoveryFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockSingleLinkDiscoveryFactory.swift
@@ -1,124 +1,100 @@
 import Cuckoo
-@testable import AccessCheckoutSDK
-
 import Foundation
 
+@testable import AccessCheckoutSDK
 
+class MockSingleLinkDiscoveryFactory: SingleLinkDiscoveryFactory, Cuckoo.ClassMock {
 
+    typealias MocksType = SingleLinkDiscoveryFactory
 
+    typealias Stubbing = __StubbingProxy_SingleLinkDiscoveryFactory
+    typealias Verification = __VerificationProxy_SingleLinkDiscoveryFactory
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
- class MockSingleLinkDiscoveryFactory: SingleLinkDiscoveryFactory, Cuckoo.ClassMock {
-    
-     typealias MocksType = SingleLinkDiscoveryFactory
-    
-     typealias Stubbing = __StubbingProxy_SingleLinkDiscoveryFactory
-     typealias Verification = __VerificationProxy_SingleLinkDiscoveryFactory
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: SingleLinkDiscoveryFactory?
 
-     func enableDefaultImplementation(_ stub: SingleLinkDiscoveryFactory) {
+    func enableDefaultImplementation(_ stub: SingleLinkDiscoveryFactory) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery {
 
-    
-
-    
-    
-    
-    
-     override func create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery {
-        
-    return cuckoo_manager.call(
-    """
-    create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
-    """,
+        return cuckoo_manager.call(
+            """
+            create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
+            """,
             parameters: (toFindLink, usingRequest),
             escapingParameters: (toFindLink, usingRequest),
             superclassCall:
-                
-                super.create(toFindLink: toFindLink, usingRequest: usingRequest)
-                ,
-            defaultCall: __defaultImplStub!.create(toFindLink: toFindLink, usingRequest: usingRequest))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_SingleLinkDiscoveryFactory: Cuckoo.StubbingProxy {
+                super.create(toFindLink: toFindLink, usingRequest: usingRequest),
+            defaultCall: __defaultImplStub!.create(
+                toFindLink: toFindLink, usingRequest: usingRequest))
+
+    }
+
+    struct __StubbingProxy_SingleLinkDiscoveryFactory: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func create<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(toFindLink: M1, usingRequest: M2) -> Cuckoo.ClassStubFunction<(String, URLRequest), SingleLinkDiscovery> where M1.MatchedType == String, M2.MatchedType == URLRequest {
-            let matchers: [Cuckoo.ParameterMatcher<(String, URLRequest)>] = [wrap(matchable: toFindLink) { $0.0 }, wrap(matchable: usingRequest) { $0.1 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockSingleLinkDiscoveryFactory.self, method:
-    """
-    create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
-    """, parameterMatchers: matchers))
+
+        func create<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(toFindLink: M1, usingRequest: M2)
+            -> Cuckoo.ClassStubFunction<(String, URLRequest), SingleLinkDiscovery>
+        where M1.MatchedType == String, M2.MatchedType == URLRequest {
+            let matchers: [Cuckoo.ParameterMatcher<(String, URLRequest)>] = [
+                wrap(matchable: toFindLink) { $0.0 }, wrap(matchable: usingRequest) { $0.1 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockSingleLinkDiscoveryFactory.self,
+                    method:
+                        """
+                        create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_SingleLinkDiscoveryFactory: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_SingleLinkDiscoveryFactory: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func create<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(toFindLink: M1, usingRequest: M2) -> Cuckoo.__DoNotUse<(String, URLRequest), SingleLinkDiscovery> where M1.MatchedType == String, M2.MatchedType == URLRequest {
-            let matchers: [Cuckoo.ParameterMatcher<(String, URLRequest)>] = [wrap(matchable: toFindLink) { $0.0 }, wrap(matchable: usingRequest) { $0.1 }]
+        func create<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(toFindLink: M1, usingRequest: M2)
+            -> Cuckoo.__DoNotUse<(String, URLRequest), SingleLinkDiscovery>
+        where M1.MatchedType == String, M2.MatchedType == URLRequest {
+            let matchers: [Cuckoo.ParameterMatcher<(String, URLRequest)>] = [
+                wrap(matchable: toFindLink) { $0.0 }, wrap(matchable: usingRequest) { $0.1 },
+            ]
             return cuckoo_manager.verify(
-    """
-    create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class SingleLinkDiscoveryFactoryStub: SingleLinkDiscoveryFactory {
 
- class SingleLinkDiscoveryFactoryStub: SingleLinkDiscoveryFactory {
-    
-
-    
-
-    
-    
-    
-    
-     override func create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery  {
+    override func create(toFindLink: String, usingRequest: URLRequest) -> SingleLinkDiscovery {
         return DefaultValueRegistry.defaultValue(for: (SingleLinkDiscovery).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockTextChangeHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockTextChangeHandler.swift
@@ -1,124 +1,111 @@
 import Cuckoo
-@testable import AccessCheckoutSDK
-
 import Foundation
 
+@testable import AccessCheckoutSDK
 
+class MockTextChangeHandler: TextChangeHandler, Cuckoo.ClassMock {
 
+    typealias MocksType = TextChangeHandler
 
+    typealias Stubbing = __StubbingProxy_TextChangeHandler
+    typealias Verification = __VerificationProxy_TextChangeHandler
 
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
 
- class MockTextChangeHandler: TextChangeHandler, Cuckoo.ClassMock {
-    
-     typealias MocksType = TextChangeHandler
-    
-     typealias Stubbing = __StubbingProxy_TextChangeHandler
-     typealias Verification = __VerificationProxy_TextChangeHandler
-
-     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
-
-    
     private var __defaultImplStub: TextChangeHandler?
 
-     func enableDefaultImplementation(_ stub: TextChangeHandler) {
+    func enableDefaultImplementation(_ stub: TextChangeHandler) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }
-    
 
-    
+    override func change(
+        originalText: String?, textChange: String, usingSelection selection: NSRange
+    ) -> String {
 
-    
-
-    
-    
-    
-    
-     override func change(originalText: String?, textChange: String, usingSelection selection: NSRange) -> String {
-        
-    return cuckoo_manager.call(
-    """
-    change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
-    """,
+        return cuckoo_manager.call(
+            """
+            change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
+            """,
             parameters: (originalText, textChange, selection),
             escapingParameters: (originalText, textChange, selection),
             superclassCall:
-                
-                super.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-                ,
-            defaultCall: __defaultImplStub!.change(originalText: originalText, textChange: textChange, usingSelection: selection))
-        
-    }
-    
-    
 
-     struct __StubbingProxy_TextChangeHandler: Cuckoo.StubbingProxy {
+                super.change(
+                    originalText: originalText, textChange: textChange, usingSelection: selection),
+            defaultCall: __defaultImplStub!.change(
+                originalText: originalText, textChange: textChange, usingSelection: selection))
+
+    }
+
+    struct __StubbingProxy_TextChangeHandler: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
-    
-         init(manager: Cuckoo.MockManager) {
+
+        init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
         }
-        
-        
-        
-        
-        func change<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(originalText: M1, textChange: M2, usingSelection selection: M3) -> Cuckoo.ClassStubFunction<(String?, String, NSRange), String> where M1.OptionalMatchedType == String, M2.MatchedType == String, M3.MatchedType == NSRange {
-            let matchers: [Cuckoo.ParameterMatcher<(String?, String, NSRange)>] = [wrap(matchable: originalText) { $0.0 }, wrap(matchable: textChange) { $0.1 }, wrap(matchable: selection) { $0.2 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockTextChangeHandler.self, method:
-    """
-    change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
-    """, parameterMatchers: matchers))
+
+        func change<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(
+            originalText: M1, textChange: M2, usingSelection selection: M3
+        ) -> Cuckoo.ClassStubFunction<(String?, String, NSRange), String>
+        where M1.OptionalMatchedType == String, M2.MatchedType == String, M3.MatchedType == NSRange
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(String?, String, NSRange)>] = [
+                wrap(matchable: originalText) { $0.0 }, wrap(matchable: textChange) { $0.1 },
+                wrap(matchable: selection) { $0.2 },
+            ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockTextChangeHandler.self,
+                    method:
+                        """
+                        change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
+                        """, parameterMatchers: matchers))
         }
-        
-        
+
     }
 
-     struct __VerificationProxy_TextChangeHandler: Cuckoo.VerificationProxy {
+    struct __VerificationProxy_TextChangeHandler: Cuckoo.VerificationProxy {
         private let cuckoo_manager: Cuckoo.MockManager
         private let callMatcher: Cuckoo.CallMatcher
         private let sourceLocation: Cuckoo.SourceLocation
-    
-         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
             self.cuckoo_manager = manager
             self.callMatcher = callMatcher
             self.sourceLocation = sourceLocation
         }
-    
-        
-    
-        
-        
-        
+
         @discardableResult
-        func change<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(originalText: M1, textChange: M2, usingSelection selection: M3) -> Cuckoo.__DoNotUse<(String?, String, NSRange), String> where M1.OptionalMatchedType == String, M2.MatchedType == String, M3.MatchedType == NSRange {
-            let matchers: [Cuckoo.ParameterMatcher<(String?, String, NSRange)>] = [wrap(matchable: originalText) { $0.0 }, wrap(matchable: textChange) { $0.1 }, wrap(matchable: selection) { $0.2 }]
+        func change<M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(
+            originalText: M1, textChange: M2, usingSelection selection: M3
+        ) -> Cuckoo.__DoNotUse<(String?, String, NSRange), String>
+        where M1.OptionalMatchedType == String, M2.MatchedType == String, M3.MatchedType == NSRange
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(String?, String, NSRange)>] = [
+                wrap(matchable: originalText) { $0.0 }, wrap(matchable: textChange) { $0.1 },
+                wrap(matchable: selection) { $0.2 },
+            ]
             return cuckoo_manager.verify(
-    """
-    change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+                """
+                change(originalText: String?, textChange: String, usingSelection: NSRange) -> String
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
         }
-        
-        
+
     }
 }
 
+class TextChangeHandlerStub: TextChangeHandler {
 
- class TextChangeHandlerStub: TextChangeHandler {
-    
-
-    
-
-    
-    
-    
-    
-     override func change(originalText: String?, textChange: String, usingSelection selection: NSRange) -> String  {
+    override func change(
+        originalText: String?, textChange: String, usingSelection selection: NSRange
+    ) -> String {
         return DefaultValueRegistry.defaultValue(for: (String).self)
     }
-    
-    
+
 }
-
-
-
-

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/PaymentsCvcRetrieveSessionHandlerMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/PaymentsCvcRetrieveSessionHandlerMock.swift
@@ -7,7 +7,10 @@ class PaymentsCvcRetrieveSessionHandlerMock: RetrieveCvcSessionHandler {
         super.init(apiClient: SessionsApiClientMock(sessionToReturn: ""))
     }
 
-    override func handle(_ checkoutId: String, _ baseUrl: String, _ cardDetails: CardDetails, completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
+    override func handle(
+        _ checkoutId: String, _ baseUrl: String, _ cardDetails: CardDetails,
+        completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void
+    ) {
         retrieveSessionCalled = true
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
@@ -15,7 +15,10 @@ class RestClientMock<T: Decodable>: RestClient {
         self.error = error
     }
 
-    override func send<T: Decodable>(urlSession: URLSession, request: URLRequest, responseType: T.Type, completionHandler: @escaping (Result<T, AccessCheckoutError>) -> Void) {
+    override func send<T: Decodable>(
+        urlSession: URLSession, request: URLRequest, responseType: T.Type,
+        completionHandler: @escaping (Result<T, AccessCheckoutError>) -> Void
+    ) {
         sendMethodCalled = true
         requestSent = request
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RetrieveCardSessionHandlerMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RetrieveCardSessionHandlerMock.swift
@@ -7,7 +7,10 @@ class RetrieveCardSessionHandlerMock: RetrieveCardSessionHandler {
         super.init(apiClient: CardSessionsApiClientMock(sessionToReturn: ""))
     }
 
-    override func handle(_ checkoutId: String, _ baseUrl: String, _ cardDetails: CardDetails, completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
+    override func handle(
+        _ checkoutId: String, _ baseUrl: String, _ cardDetails: CardDetails,
+        completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void
+    ) {
         retrieveSessionCalled = true
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SessionsApiClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SessionsApiClientMock.swift
@@ -4,20 +4,23 @@ class SessionsApiClientMock: CvcSessionsApiClient {
     var createSessionCalled: Bool = false
     var sessionToReturn: String?
     var error: AccessCheckoutError?
-    
+
     init(sessionToReturn: String?) {
         self.sessionToReturn = sessionToReturn
         super.init()
     }
-    
+
     init(error: AccessCheckoutError?) {
         self.error = error
         super.init()
     }
-    
-    override func createSession(baseUrl: String, checkoutId: String, cvc: String, completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
+
+    override func createSession(
+        baseUrl: String, checkoutId: String, cvc: String,
+        completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void
+    ) {
         createSessionCalled = true
-        
+
         if let sessionToReturn = sessionToReturn {
             completionHandler(.success(sessionToReturn))
         } else if let error = error {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SessionsApiDiscoveryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SessionsApiDiscoveryMock.swift
@@ -3,19 +3,22 @@
 class SessionsApiDiscoveryMock: CvcSessionsApiDiscovery {
     private var url: String?
     private var error: AccessCheckoutError?
-    
-    override func discover(baseUrl: String, completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void) {
+
+    override func discover(
+        baseUrl: String,
+        completionHandler: @escaping (Swift.Result<String, AccessCheckoutError>) -> Void
+    ) {
         if let url = url {
             completionHandler(.success(url))
         } else if let error = error {
             completionHandler(.failure(error))
         }
     }
-    
+
     func willComplete(with url: String) {
         self.url = url
     }
-    
+
     func willComplete(with error: AccessCheckoutError) {
         self.error = error
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SingleLinkDiscoveryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/SingleLinkDiscoveryMock.swift
@@ -3,23 +3,25 @@
 class SingleLinkDiscoveryMock: SingleLinkDiscovery {
     private var url: String?
     private var error: AccessCheckoutError?
-    
+
     init() {
         super.init(linkToFind: "", urlRequest: URLRequest(url: URL(string: "http://localhost")!))
     }
-    
-    override func discover(completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
+
+    override func discover(
+        completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void
+    ) {
         if let url = url {
             completionHandler(.success(url))
         } else if let error = error {
             completionHandler(.failure(error))
         }
     }
-    
+
     func willComplete(with url: String) {
         self.url = url
     }
-    
+
     func willComplete(with error: AccessCheckoutError) {
         self.error = error
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/UITextFieldMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/UITextFieldMock.swift
@@ -9,10 +9,10 @@ class UITextFieldMock: UITextField {
     public private(set) var textRangeCalled: Bool = false
     public private(set) var addTargetCalled: Bool = false
     public private(set) var removeTargetCalled: Bool = false
-    
+
     public private(set) var sendActionsCalled: Bool = false
     public private(set) var sendActionsEvents: UIControl.Event?
-    
+
     private var _beginningOfDocument: UITextPosition?
     override var beginningOfDocument: UITextPosition {
         if let mockValue = _beginningOfDocument {
@@ -25,7 +25,7 @@ class UITextFieldMock: UITextField {
     public func setBeginningOfDocument(_ uiTextPosition: UITextPosition) {
         self._beginningOfDocument = uiTextPosition
     }
-    
+
     private var _endOfDocument: UITextPosition?
     override var endOfDocument: UITextPosition {
         if let mockValue = _endOfDocument {
@@ -38,47 +38,51 @@ class UITextFieldMock: UITextField {
     public func setEndOfDocument(_ uiTextPosition: UITextPosition) {
         self._endOfDocument = uiTextPosition
     }
-    
+
     private var _selectedTextRange: UITextRange?
     override var selectedTextRange: UITextRange? {
         set { _selectedTextRange = newValue }
         get { _selectedTextRange }
     }
-    
+
     override public func becomeFirstResponder() -> Bool {
         self.becomeFirstResponderCalled = true
         return true
     }
-   
+
     override public func resignFirstResponder() -> Bool {
         self.resignFirstResponderCalled = true
         return true
     }
-    
+
     override public func offset(from: UITextPosition, to: UITextPosition) -> Int {
         offsetCalled = true
         return 0
     }
-    
+
     override public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
         positionCalled = true
         return nil
     }
-    
+
     override public func textRange(from: UITextPosition, to: UITextPosition) -> UITextRange? {
         textRangeCalled = true
         return nil
     }
-    
-    override public func addTarget(_ target: Any?, action: Selector, for controlEvents: UIControl.Event) {
+
+    override public func addTarget(
+        _ target: Any?, action: Selector, for controlEvents: UIControl.Event
+    ) {
         addTargetCalled = true
     }
-    
-    override public func removeTarget(_ target: Any?, action: Selector?, for controlEvents: UIControl.Event) {
+
+    override public func removeTarget(
+        _ target: Any?, action: Selector?, for controlEvents: UIControl.Event
+    ) {
         removeTargetCalled = true
     }
-    
-    override public func sendActions(for controlEvents:UIControl.Event) {
+
+    override public func sendActions(for controlEvents: UIControl.Event) {
         sendActionsCalled = true
         sendActionsEvents = controlEvents
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/URLSessionDataTaskMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/URLSessionDataTaskMock.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class URLSessionDataTaskMock : URLSessionDataTask{
+class URLSessionDataTaskMock: URLSessionDataTask {
     private(set) var resumeCalled = false
 
     override func resume() {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/URLSessionMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/URLSessionMock.swift
@@ -1,17 +1,19 @@
 import Foundation
 
-class URLSessionMock : URLSession {
-    private let urlSessionDataTask:URLSessionDataTask
+class URLSessionMock: URLSession {
+    private let urlSessionDataTask: URLSessionDataTask
     private(set) var dataTaskCalled = false
-    private var forRequest:URLRequest
+    private var forRequest: URLRequest
 
-    init (forRequest: URLRequest, usingDataTask:URLSessionDataTask){
+    init(forRequest: URLRequest, usingDataTask: URLSessionDataTask) {
         self.forRequest = forRequest
         self.urlSessionDataTask = usingDataTask
     }
 
-    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-        if(request == forRequest){
+    override func dataTask(
+        with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
+        if request == forRequest {
             self.dataTaskCalled = true
             return urlSessionDataTask
         } else {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionURLRequestFactoryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionURLRequestFactoryTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardSessionsSessionURLRequestFactoryTests: XCTestCase {
     private let pan: String = "a-pan"
@@ -13,17 +14,20 @@ class CardSessionsSessionURLRequestFactoryTests: XCTestCase {
     private let expectedMethod = "POST"
 
     func testCreatesACardSessionRequest() {
-        let expectedHeaderFields = ["Accept": ApiHeaders.sessionsHeaderValue,
-                                    "Content-Type": ApiHeaders.sessionsHeaderValue,
-                                    "X-WP-SDK": "access-checkout-ios/\(sdkVersion)"]
+        let expectedHeaderFields = [
+            "Accept": ApiHeaders.sessionsHeaderValue,
+            "Content-Type": ApiHeaders.sessionsHeaderValue,
+            "X-WP-SDK": "access-checkout-ios/\(sdkVersion)",
+        ]
         let expectedURL = URLRequest(url: URL(string: "some-url")!)
 
-        let request = urlRequestFactory.create(url: "some-url",
-                                               checkoutId: checkoutId,
-                                               pan: pan,
-                                               expiryMonth: expiryMonth,
-                                               expiryYear: expiryYear,
-                                               cvc: cvc)
+        let request = urlRequestFactory.create(
+            url: "some-url",
+            checkoutId: checkoutId,
+            pan: pan,
+            expiryMonth: expiryMonth,
+            expiryYear: expiryYear,
+            cvc: cvc)
 
         XCTAssertEqual(expectedURL.url, request.url)
         XCTAssertEqual(expectedMethod, request.httpMethod)
@@ -34,33 +38,38 @@ class CardSessionsSessionURLRequestFactoryTests: XCTestCase {
         let body = String(decoding: request.httpBody!, as: UTF8.self)
         XCTAssertTrue(body.contains("\"identity\":\"a-checkout-id\""))
         XCTAssertTrue(body.contains("\"cardNumber\":\"a-pan\""))
-        XCTAssertTrue(body.contains("\"cardExpiryDate\":{\"month\":12,\"year\":24}")
-            || body.contains("\"cardExpiryDate\":{\"year\":24,\"month\":12}"))
+        XCTAssertTrue(
+            body.contains("\"cardExpiryDate\":{\"month\":12,\"year\":24}")
+                || body.contains("\"cardExpiryDate\":{\"year\":24,\"month\":12}"))
         XCTAssertTrue(body.contains("\"cvc\":\"123\""))
     }
 
     func testHttpMethodIsPost() {
-        let request = urlRequestFactory.create(url: "some-url",
-                                               checkoutId: checkoutId,
-                                               pan: pan,
-                                               expiryMonth: expiryMonth,
-                                               expiryYear: expiryYear,
-                                               cvc: cvc)
+        let request = urlRequestFactory.create(
+            url: "some-url",
+            checkoutId: checkoutId,
+            pan: pan,
+            expiryMonth: expiryMonth,
+            expiryYear: expiryYear,
+            cvc: cvc)
 
         XCTAssertEqual(expectedMethod, request.httpMethod)
     }
 
     func testHeadersAreSetCorrectly() {
-        let expectedHeaderFields = ["Accept": ApiHeaders.sessionsHeaderValue,
-                                    "Content-Type": ApiHeaders.sessionsHeaderValue,
-                                    "X-WP-SDK": "access-checkout-ios/\(sdkVersion)"]
+        let expectedHeaderFields = [
+            "Accept": ApiHeaders.sessionsHeaderValue,
+            "Content-Type": ApiHeaders.sessionsHeaderValue,
+            "X-WP-SDK": "access-checkout-ios/\(sdkVersion)",
+        ]
 
-        let request = urlRequestFactory.create(url: "some-url",
-                                               checkoutId: checkoutId,
-                                               pan: pan,
-                                               expiryMonth: expiryMonth,
-                                               expiryYear: expiryYear,
-                                               cvc: cvc)
+        let request = urlRequestFactory.create(
+            url: "some-url",
+            checkoutId: checkoutId,
+            pan: pan,
+            expiryMonth: expiryMonth,
+            expiryYear: expiryYear,
+            cvc: cvc)
 
         XCTAssertEqual(expectedHeaderFields, request.allHTTPHeaderFields)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiClientTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardSessionsApiClientTests: XCTestCase {
     private let baseUrl = "http://localhost"
@@ -7,28 +8,34 @@ class CardSessionsApiClientTests: XCTestCase {
     private let expiryMonth: UInt = 12
     private let expiryYear: UInt = 24
     private let cvc = "123"
-    
+
     private let mockDiscovery = CardSessionsApiDiscoveryMock()
     private let mockURLRequestFactory = CardSessionURLRequestFactoryMock()
-    
+
     private let expectedSession = "a-session"
     private let expectedDiscoveredUrl = "http://and-end-point"
-    
+
     private let urlRequestFactoryResult = URLRequest(url: URL(string: "a-url")!)
     private var expectationToFulfill: XCTestExpectation?
-    
+
     override func setUp() {
         mockURLRequestFactory.willReturn(urlRequestFactoryResult)
         expectationToFulfill = expectation(description: "")
     }
-    
+
     func testDiscoversApiAndCreatesSession() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
-        let mockRestClient = RestClientMock(replyWith: successResponse(withSession: expectedSession))
-        
-        let client = CardSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
-        client.createSession(baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, cvc: cvc) { result in
+        let mockRestClient = RestClientMock(
+            replyWith: successResponse(withSession: expectedSession))
+
+        let client = CardSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
+        client.createSession(
+            baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth,
+            expiryYear: expiryYear, cvc: cvc
+        ) { result in
             switch result {
             case .success(let session):
                 XCTAssertEqual(self.expectedSession, session)
@@ -43,18 +50,24 @@ class CardSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsDiscoveryErrorWhenApiDiscoveryFails() {
         let expectedError = StubUtils.createError(errorName: "some error", message: "some message")
         mockDiscovery.willComplete(with: expectedError)
-        let mockRestClient = RestClientMock(replyWith: successResponse(withSession: expectedSession))
-        
-        let client = CardSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
-        client.createSession(baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, cvc: cvc) { result in
+        let mockRestClient = RestClientMock(
+            replyWith: successResponse(withSession: expectedSession))
+
+        let client = CardSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
+        client.createSession(
+            baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth,
+            expiryYear: expiryYear, cvc: cvc
+        ) { result in
             switch result {
             case .success:
                 XCTFail("Creation of session should have failed")
@@ -63,18 +76,25 @@ class CardSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsSessionNotFound_whenExpectedSessionIsNotInResponse() {
-        let expectedError = StubUtils.createError(errorName: "sessionLinkNotFound", message: "Failed to find link \(ApiLinks.cvcSessions.result) in response")
+        let expectedError = StubUtils.createError(
+            errorName: "sessionLinkNotFound",
+            message: "Failed to find link \(ApiLinks.cvcSessions.result) in response")
         let mockRestClient = RestClientMock(replyWith: responseWithoutExpectedLink())
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
-        
-        let client = CardSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
-        client.createSession(baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, cvc: cvc) { result in
+
+        let client = CardSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
+        client.createSession(
+            baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth,
+            expiryYear: expiryYear, cvc: cvc
+        ) { result in
             switch result {
             case .success:
                 XCTFail("Creation of session should have failed")
@@ -83,18 +103,23 @@ class CardSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsServiceError_whenServiceErrorsOut() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
         let expectedError = StubUtils.createError(errorName: "some error", message: "some message")
         let mockRestClient = RestClientMock<String>(errorWith: expectedError)
-        
-        let client = CardSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
-        client.createSession(baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, cvc: cvc) { result in
+
+        let client = CardSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
+        client.createSession(
+            baseUrl: baseUrl, checkoutId: "", pan: pan, expiryMonth: expiryMonth,
+            expiryYear: expiryYear, cvc: cvc
+        ) { result in
             switch result {
             case .success:
                 XCTFail("Creation of session should have failed")
@@ -103,10 +128,10 @@ class CardSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     private func successResponse(withSession: String) -> ApiResponse {
         let responseAsString =
             """
@@ -118,11 +143,11 @@ class CardSessionsApiClientTests: XCTestCase {
                     }
                 }
             """
-        
+
         let responseAsData = responseAsString.data(using: .utf8)!
         return try! JSONDecoder().decode(ApiResponse.self, from: responseAsData)
     }
-    
+
     private func responseWithoutExpectedLink() -> ApiResponse {
         let responseAsString =
             """
@@ -134,7 +159,7 @@ class CardSessionsApiClientTests: XCTestCase {
                     }
                 }
             """
-        
+
         let responseAsData = responseAsString.data(using: .utf8)!
         return try! JSONDecoder().decode(ApiResponse.self, from: responseAsData)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiDiscoveryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiDiscoveryTests.swift
@@ -1,120 +1,138 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardSessionsApiDiscoveryTests: XCTestCase {
     let discoveryFactory = MockSingleLinkDiscoveryFactory()
     let mockDiscoveryService = SingleLinkDiscoveryMock()
     let mockDiscoveryEndPoint = SingleLinkDiscoveryMock()
-    
+
     override func setUp() {
-        when(discoveryFactory.getStubbingProxy().create(toFindLink: ApiLinks.cardSessions.service, usingRequest: any())).thenReturn(mockDiscoveryService)
-        when(discoveryFactory.getStubbingProxy().create(toFindLink: ApiLinks.cardSessions.endpoint, usingRequest: any())).thenReturn(mockDiscoveryEndPoint)
+        when(
+            discoveryFactory.getStubbingProxy().create(
+                toFindLink: ApiLinks.cardSessions.service, usingRequest: any())
+        ).thenReturn(mockDiscoveryService)
+        when(
+            discoveryFactory.getStubbingProxy().create(
+                toFindLink: ApiLinks.cardSessions.endpoint, usingRequest: any())
+        ).thenReturn(mockDiscoveryEndPoint)
     }
-    
+
     func testDiscoversSessionsServiceAndCardSessionEndPoint() {
         let expectationToFulfill = expectation(description: "")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         mockDiscoveryService.willComplete(with: "http://localhost/a-service")
-        
-        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(url: "http://localhost/a-service")
+
+        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(
+            url: "http://localhost/a-service")
         mockDiscoveryEndPoint.willComplete(with: "http://localhost/an-end-point")
-        
+
         let discovery = CardSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success(let link):
-                    XCTAssertEqual("http://localhost/an-end-point", link)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(2)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
-                    
-                    XCTAssertEqual(ApiLinks.cardSessions.endpoint, argumentCaptorLinks.allValues[1])
-                    XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
-                case .failure:
-                    XCTFail("Discovery should not have failed")
+            case .success(let link):
+                XCTAssertEqual("http://localhost/an-end-point", link)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(2)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+
+                XCTAssertEqual(ApiLinks.cardSessions.endpoint, argumentCaptorLinks.allValues[1])
+                XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
+            case .failure:
+                XCTFail("Discovery should not have failed")
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testFailsToDiscoverIfServiceIsNotDiscoveredSuccessfully() {
         let expectationToFulfill = expectation(description: "")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         mockDiscoveryService.willComplete(with: expectedError)
         mockDiscoveryEndPoint.willComplete(with: "http://localhost/an-end-point")
-        
+
         let discovery = CardSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(1)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(1)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testFailsToDiscoverIfEndpointIsNotDiscoveredSuccessfully() {
         let expectationToFulfill = expectation(description: "")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         mockDiscoveryService.willComplete(with: "http://localhost/a-service")
-        
-        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(url: "http://localhost/a-service")
+
+        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(
+            url: "http://localhost/a-service")
         mockDiscoveryEndPoint.willComplete(with: expectedError)
-        
+
         let discovery = CardSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(2)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
-                    
-                    XCTAssertEqual(ApiLinks.cardSessions.endpoint, argumentCaptorLinks.allValues[1])
-                    XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(2)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cardSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+
+                XCTAssertEqual(ApiLinks.cardSessions.endpoint, argumentCaptorLinks.allValues[1])
+                XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func createExpectedRequestToFindService(url: String) -> URLRequest {
         return URLRequest(url: URL(string: url)!)
     }
-    
+
     func createExpectedRequestToFindEndPoint(url: String) -> URLRequest {
         var urlRequest = URLRequest(url: URL(string: url)!)
         urlRequest.addValue(ApiHeaders.sessionsHeaderValue, forHTTPHeaderField: "content-type")

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionURLRequestFactoryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionURLRequestFactoryTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcSessionURLRequestFactoryTests: XCTestCase {
     private let urlRequestFactory = CvcSessionURLRequestFactory()
@@ -10,29 +11,38 @@ class CvcSessionURLRequestFactoryTests: XCTestCase {
 
     func testCreatesACvcSessionRequest() {
         let expectedHttpBody: Data = expectedBodyAsString.data(using: .utf8)!
-        let expectedHeaderFields = ["Accept": ApiHeaders.sessionsHeaderValue,
-                                    "Content-Type": ApiHeaders.sessionsHeaderValue,
-                                    "X-WP-SDK": "access-checkout-ios/\(sdkVersion)"]
+        let expectedHeaderFields = [
+            "Accept": ApiHeaders.sessionsHeaderValue,
+            "Content-Type": ApiHeaders.sessionsHeaderValue,
+            "X-WP-SDK": "access-checkout-ios/\(sdkVersion)",
+        ]
         var expectedRequest = URLRequest(url: URL(string: "some-url")!)
         expectedRequest.httpBody = expectedHttpBody
         expectedRequest.httpMethod = expectedMethod
         expectedRequest.allHTTPHeaderFields = expectedHeaderFields
 
-        let request = urlRequestFactory.create(url: "some-url", cvc: cvc, checkoutId: "some-identity")
+        let request = urlRequestFactory.create(
+            url: "some-url", cvc: cvc, checkoutId: "some-identity")
 
         XCTAssertEqual(request, expectedRequest)
     }
 
     func testHttpMethodIsPost() {
-        let request = urlRequestFactory.create(url: "some-url", cvc: cvc, checkoutId: "some-identity")
+        let request = urlRequestFactory.create(
+            url: "some-url", cvc: cvc, checkoutId: "some-identity")
 
         XCTAssertEqual(request.httpMethod, expectedMethod)
     }
 
     func testHeadersAreSetCorrectly() {
-        let expectedHeaderFields = ["Accept": ApiHeaders.sessionsHeaderValue, "Content-Type": ApiHeaders.sessionsHeaderValue, "X-WP-SDK": "access-checkout-ios/\(sdkVersion)"]
+        let expectedHeaderFields = [
+            "Accept": ApiHeaders.sessionsHeaderValue,
+            "Content-Type": ApiHeaders.sessionsHeaderValue,
+            "X-WP-SDK": "access-checkout-ios/\(sdkVersion)",
+        ]
 
-        let request = urlRequestFactory.create(url: "some-url", cvc: cvc, checkoutId: "some-identity")
+        let request = urlRequestFactory.create(
+            url: "some-url", cvc: cvc, checkoutId: "some-identity")
 
         XCTAssertEqual(request.allHTTPHeaderFields, expectedHeaderFields)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiClientTests.swift
@@ -1,53 +1,61 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcSessionsApiClientTests: XCTestCase {
     private let baseUrl = "http://localhost"
     private let cvc = "123"
-    
+
     private let mockDiscovery = SessionsApiDiscoveryMock()
     private let mockURLRequestFactory = PaymentsCvcSessionURLRequestFactoryMock()
-    
+
     private let expectedSession = "a-session"
     private let expectedDiscoveredUrl = "http://and-end-point"
-    
+
     private let urlRequestFactoryResult = URLRequest(url: URL(string: "a-url")!)
     private var expectationToFulfill: XCTestExpectation?
-    
+
     override func setUp() {
         mockURLRequestFactory.willReturn(urlRequestFactoryResult)
         expectationToFulfill = expectation(description: "")
     }
-    
+
     func testDiscoversApiAndCreatesSession() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
-        let mockRestClient = RestClientMock(replyWith: successResponse(withSession: expectedSession))
-        
-        let client = CvcSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
+        let mockRestClient = RestClientMock(
+            replyWith: successResponse(withSession: expectedSession))
+
+        let client = CvcSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
         client.createSession(baseUrl: baseUrl, checkoutId: "", cvc: cvc) { result in
             switch result {
             case .success(let session):
                 XCTAssertEqual(self.expectedSession, session)
                 XCTAssertEqual(self.urlRequestFactoryResult, mockRestClient.requestSent)
                 XCTAssertEqual(self.cvc, self.mockURLRequestFactory.cvcPassed)
-                XCTAssertEqual(self.expectedDiscoveredUrl, self.mockURLRequestFactory.urlStringPassed)
+                XCTAssertEqual(
+                    self.expectedDiscoveredUrl, self.mockURLRequestFactory.urlStringPassed)
             case .failure:
                 XCTFail("Creation of session shoul have succeeded")
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsDiscoveryErrorWhenApiDiscoveryFails() {
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
         mockDiscovery.willComplete(with: expectedError)
-        let mockRestClient = RestClientMock(replyWith: successResponse(withSession: expectedSession))
-        
-        let client = CvcSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
+        let mockRestClient = RestClientMock(
+            replyWith: successResponse(withSession: expectedSession))
+
+        let client = CvcSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
         client.createSession(baseUrl: baseUrl, checkoutId: "", cvc: cvc) { result in
             switch result {
             case .success:
@@ -57,17 +65,21 @@ class CvcSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsSessionNotFound_whenExpectedSessionIsNotInResponse() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
         let mockRestClient = RestClientMock(replyWith: responseWithoutExpectedLink())
-        let expectedError = StubUtils.createError(errorName: "sessionLinkNotFound", message: "Failed to find link \(ApiLinks.cvcSessions.result) in response")
-        
-        let client = CvcSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
+        let expectedError = StubUtils.createError(
+            errorName: "sessionLinkNotFound",
+            message: "Failed to find link \(ApiLinks.cvcSessions.result) in response")
+
+        let client = CvcSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
         client.createSession(baseUrl: baseUrl, checkoutId: "", cvc: cvc) { result in
             switch result {
             case .success:
@@ -77,17 +89,19 @@ class CvcSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     func testReturnsServiceError_whenServiceErrorsOut() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
         let mockRestClient = RestClientMock<String>(errorWith: expectedError)
-        
-        let client = CvcSessionsApiClient(discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory, restClient: mockRestClient)
-        
+
+        let client = CvcSessionsApiClient(
+            discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,
+            restClient: mockRestClient)
+
         client.createSession(baseUrl: baseUrl, checkoutId: "", cvc: cvc) { result in
             switch result {
             case .success:
@@ -97,10 +111,10 @@ class CvcSessionsApiClientTests: XCTestCase {
             }
             self.expectationToFulfill!.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill!], timeout: 1)
     }
-    
+
     private func successResponse(withSession: String) -> ApiResponse {
         let responseAsString =
             """
@@ -112,11 +126,11 @@ class CvcSessionsApiClientTests: XCTestCase {
                     }
                 }
             """
-        
+
         let responseAsData = responseAsString.data(using: .utf8)!
         return try! JSONDecoder().decode(ApiResponse.self, from: responseAsData)
     }
-    
+
     private func responseWithoutExpectedLink() -> ApiResponse {
         let responseAsString =
             """
@@ -128,7 +142,7 @@ class CvcSessionsApiClientTests: XCTestCase {
                     }
                 }
             """
-        
+
         let responseAsData = responseAsString.data(using: .utf8)!
         return try! JSONDecoder().decode(ApiResponse.self, from: responseAsData)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiDiscoveryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiDiscoveryTests.swift
@@ -1,120 +1,138 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcSessionsApiDiscoveryTests: XCTestCase {
     let discoveryFactory = MockSingleLinkDiscoveryFactory()
     let mockDiscoveryService = SingleLinkDiscoveryMock()
     let mockDiscoveryEndPoint = SingleLinkDiscoveryMock()
-    
+
     override func setUp() {
-        when(discoveryFactory.getStubbingProxy().create(toFindLink: ApiLinks.cvcSessions.service, usingRequest: any())).thenReturn(mockDiscoveryService)
-        when(discoveryFactory.getStubbingProxy().create(toFindLink: ApiLinks.cvcSessions.endpoint, usingRequest: any())).thenReturn(mockDiscoveryEndPoint)
+        when(
+            discoveryFactory.getStubbingProxy().create(
+                toFindLink: ApiLinks.cvcSessions.service, usingRequest: any())
+        ).thenReturn(mockDiscoveryService)
+        when(
+            discoveryFactory.getStubbingProxy().create(
+                toFindLink: ApiLinks.cvcSessions.endpoint, usingRequest: any())
+        ).thenReturn(mockDiscoveryEndPoint)
     }
-    
+
     func testDiscoversSessionsServiceAndPaymentsCvcSessionEndPoint() {
         let expectationToFulfill = expectation(description: "")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         mockDiscoveryService.willComplete(with: "http://localhost/a-service")
-        
-        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(url: "http://localhost/a-service")
+
+        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(
+            url: "http://localhost/a-service")
         mockDiscoveryEndPoint.willComplete(with: "http://localhost/an-end-point")
-        
+
         let discovery = CvcSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success(let link):
-                    XCTAssertEqual("http://localhost/an-end-point", link)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(2)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
-                    
-                    XCTAssertEqual(ApiLinks.cvcSessions.endpoint, argumentCaptorLinks.allValues[1])
-                    XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
-                case .failure:
-                    XCTFail("Discovery should not have failed")
+            case .success(let link):
+                XCTAssertEqual("http://localhost/an-end-point", link)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(2)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+
+                XCTAssertEqual(ApiLinks.cvcSessions.endpoint, argumentCaptorLinks.allValues[1])
+                XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
+            case .failure:
+                XCTFail("Discovery should not have failed")
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testFailsToDiscoverIfServiceIsNotDiscoveredSuccessfully() {
         let expectationToFulfill = expectation(description: "")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
         mockDiscoveryService.willComplete(with: expectedError)
         mockDiscoveryEndPoint.willComplete(with: "http://localhost/an-end-point")
-        
+
         let discovery = CvcSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(1)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(1)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testFailsToDiscoverIfEndpointIsNotDiscoveredSuccessfully() {
         let expectationToFulfill = expectation(description: "")
-        
-        let expectedRequestToFindService = createExpectedRequestToFindService(url: "http://localhost")
+
+        let expectedRequestToFindService = createExpectedRequestToFindService(
+            url: "http://localhost")
         mockDiscoveryService.willComplete(with: "http://localhost/a-service")
-        
-        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(url: "http://localhost/a-service")
+
+        let expectedRequestToFindEndPoint = createExpectedRequestToFindEndPoint(
+            url: "http://localhost/a-service")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
         mockDiscoveryEndPoint.willComplete(with: expectedError)
-        
+
         let discovery = CvcSessionsApiDiscovery(discoveryFactory: discoveryFactory)
-        
+
         discovery.discover(baseUrl: "http://localhost") { result in
             switch result {
-                case .success:
-                    XCTFail("Discovery should have failed")
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    
-                    let argumentCaptorLinks = ArgumentCaptor<String>()
-                    let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
-                    verify(self.discoveryFactory, times(2)).create(toFindLink: argumentCaptorLinks.capture(), usingRequest: argumentCaptorRequests.capture())
-                    
-                    XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
-                    XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
-                    
-                    XCTAssertEqual(ApiLinks.cvcSessions.endpoint, argumentCaptorLinks.allValues[1])
-                    XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
+            case .success:
+                XCTFail("Discovery should have failed")
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+
+                let argumentCaptorLinks = ArgumentCaptor<String>()
+                let argumentCaptorRequests = ArgumentCaptor<URLRequest>()
+                verify(self.discoveryFactory, times(2)).create(
+                    toFindLink: argumentCaptorLinks.capture(),
+                    usingRequest: argumentCaptorRequests.capture())
+
+                XCTAssertEqual(ApiLinks.cvcSessions.service, argumentCaptorLinks.allValues[0])
+                XCTAssertEqual(expectedRequestToFindService, argumentCaptorRequests.allValues[0])
+
+                XCTAssertEqual(ApiLinks.cvcSessions.endpoint, argumentCaptorLinks.allValues[1])
+                XCTAssertEqual(expectedRequestToFindEndPoint, argumentCaptorRequests.allValues[1])
             }
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func createExpectedRequestToFindService(url: String) -> URLRequest {
         return URLRequest(url: URL(string: url)!)
     }
-    
+
     func createExpectedRequestToFindEndPoint(url: String) -> URLRequest {
         var urlRequest = URLRequest(url: URL(string: url)!)
         urlRequest.addValue(ApiHeaders.sessionsHeaderValue, forHTTPHeaderField: "content-type")

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/CardDetailsForSessionTypeValidatorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/CardDetailsForSessionTypeValidatorTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardDetailsForSessionTypeValidatorTests: XCTestCase {
     let validator = CardDetailsForSessionTypeValidator()
@@ -12,7 +13,8 @@ class CardDetailsForSessionTypeValidatorTests: XCTestCase {
             .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
             .build()
 
-        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) { error in
+        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) {
+            error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
@@ -25,7 +27,8 @@ class CardDetailsForSessionTypeValidatorTests: XCTestCase {
             .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
             .build()
 
-        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) { error in
+        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) {
+            error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
@@ -38,7 +41,8 @@ class CardDetailsForSessionTypeValidatorTests: XCTestCase {
             .expiryDate(UIUtils.createAccessCheckoutUITextField(withText: "12/20"))
             .build()
 
-        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) { error in
+        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) {
+            error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }
@@ -48,7 +52,8 @@ class CardDetailsForSessionTypeValidatorTests: XCTestCase {
         let sessionType = SessionType.cvc
         let cardDetails = try CardDetailsBuilder().build()
 
-        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) { error in
+        XCTAssertThrowsError(try validator.validate(cardDetails: cardDetails, for: sessionType)) {
+            error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
         }
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveCardSessionHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveCardSessionHandlerTests.swift
@@ -1,15 +1,18 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class RetrieveCardSessionHandlerTests: XCTestCase {
     func testCanHandleCardSession() {
-        let sessionHandler = RetrieveCardSessionHandler(apiClient: CardSessionsApiClientMock(sessionToReturn: ""))
+        let sessionHandler = RetrieveCardSessionHandler(
+            apiClient: CardSessionsApiClientMock(sessionToReturn: ""))
 
         XCTAssertTrue(sessionHandler.canHandle(sessionType: SessionType.card))
     }
 
     func testCannotHandlePaymentsCvcSession() {
-        let sessionHandler = RetrieveCardSessionHandler(apiClient: CardSessionsApiClientMock(sessionToReturn: ""))
+        let sessionHandler = RetrieveCardSessionHandler(
+            apiClient: CardSessionsApiClientMock(sessionToReturn: ""))
 
         XCTAssertFalse(sessionHandler.canHandle(sessionType: SessionType.cvc))
     }
@@ -26,11 +29,11 @@ class RetrieveCardSessionHandlerTests: XCTestCase {
 
         sessionHandler.handle("a-checkout-id", "some-url", cardDetails) { result in
             switch result {
-                case .success(let session):
-                    XCTAssertEqual("expected-session", session)
-                    expectationToFulfill.fulfill()
-                case .failure:
-                    XCTFail("should not have failed to retrieve a session")
+            case .success(let session):
+                XCTAssertEqual("expected-session", session)
+                expectationToFulfill.fulfill()
+            case .failure:
+                XCTFail("should not have failed to retrieve a session")
             }
         }
 
@@ -50,12 +53,12 @@ class RetrieveCardSessionHandlerTests: XCTestCase {
 
         sessionHandler.handle("a-checkout-id", "some-url", cardDetails) { result in
             switch result {
-                case .success:
-                    XCTFail("should have failed to retrieve a session")
-                    expectationToFulfill.fulfill()
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    expectationToFulfill.fulfill()
+            case .success:
+                XCTFail("should have failed to retrieve a session")
+                expectationToFulfill.fulfill()
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+                expectationToFulfill.fulfill()
             }
         }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveCvcSessionHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveCvcSessionHandlerTests.swift
@@ -1,15 +1,18 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class RetrieveCvcSessionHandlerTests: XCTestCase {
     func testCannotHandleCardSession() {
-        let sessionHandler = RetrieveCvcSessionHandler(apiClient: SessionsApiClientMock(sessionToReturn: ""))
+        let sessionHandler = RetrieveCvcSessionHandler(
+            apiClient: SessionsApiClientMock(sessionToReturn: ""))
 
         XCTAssertFalse(sessionHandler.canHandle(sessionType: SessionType.card))
     }
 
     func testCanHandlePaymentsCvcSession() {
-        let sessionHandler = RetrieveCvcSessionHandler(apiClient: SessionsApiClientMock(sessionToReturn: ""))
+        let sessionHandler = RetrieveCvcSessionHandler(
+            apiClient: SessionsApiClientMock(sessionToReturn: ""))
 
         XCTAssertTrue(sessionHandler.canHandle(sessionType: SessionType.cvc))
     }
@@ -24,11 +27,11 @@ class RetrieveCvcSessionHandlerTests: XCTestCase {
 
         sessionHandler.handle("a-checkout-id", "some-url", cardDetails) { result in
             switch result {
-                case .success(let session):
-                    XCTAssertEqual("expected-session", session)
-                    expectationToFulfill.fulfill()
-                case .failure:
-                    XCTFail("should not have failed to retrieve a session")
+            case .success(let session):
+                XCTAssertEqual("expected-session", session)
+                expectationToFulfill.fulfill()
+            case .failure:
+                XCTFail("should not have failed to retrieve a session")
             }
         }
 
@@ -46,12 +49,12 @@ class RetrieveCvcSessionHandlerTests: XCTestCase {
 
         sessionHandler.handle("a-checkout-id", "some-url", cardDetails) { result in
             switch result {
-                case .success:
-                    XCTFail("should have failed to retrieve a session")
-                    expectationToFulfill.fulfill()
-                case .failure(let error):
-                    XCTAssertEqual(expectedError, error)
-                    expectationToFulfill.fulfill()
+            case .success:
+                XCTFail("should have failed to retrieve a session")
+                expectationToFulfill.fulfill()
+            case .failure(let error):
+                XCTAssertEqual(expectedError, error)
+                expectationToFulfill.fulfill()
             }
         }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionHandlerDispatcherTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionHandlerDispatcherTests.swift
@@ -1,32 +1,37 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class RetrieveSessionHandlerDispatcherTests: XCTestCase {
     let checkoutId = "123"
     let baseUrl = "some-url"
-    
+
     let cardDetails = try! CardDetailsBuilder()
         .cvc(UIUtils.createAccessCheckoutUITextField(withText: "123"))
         .build()
-    
+
     let paymentsCvcSessionHandler = PaymentsCvcRetrieveSessionHandlerMock()
     let cardSessionHandler = RetrieveCardSessionHandlerMock()
-    
+
     func testDispatchesToRetrieveACardSession() {
-        let dispatcher = RetrieveSessionHandlerDispatcher(retrieveSessionHandlers: [paymentsCvcSessionHandler, cardSessionHandler])
-        
+        let dispatcher = RetrieveSessionHandlerDispatcher(retrieveSessionHandlers: [
+            paymentsCvcSessionHandler, cardSessionHandler,
+        ])
+
         dispatcher.dispatch(checkoutId, baseUrl, cardDetails, SessionType.card) { _ in }
-        
+
         XCTAssertTrue(cardSessionHandler.retrieveSessionCalled)
         XCTAssertFalse(paymentsCvcSessionHandler.retrieveSessionCalled)
     }
-    
+
     func testDispatchesToRetrieveAPaymentsCvcSession() {
-        let dispatcher = RetrieveSessionHandlerDispatcher(retrieveSessionHandlers: [paymentsCvcSessionHandler, cardSessionHandler])
-        
+        let dispatcher = RetrieveSessionHandlerDispatcher(retrieveSessionHandlers: [
+            paymentsCvcSessionHandler, cardSessionHandler,
+        ])
+
         dispatcher.dispatch(checkoutId, baseUrl, cardDetails, SessionType.cvc) { _ in }
-        
+
         XCTAssertFalse(cardSessionHandler.retrieveSessionCalled)
         XCTAssertTrue(paymentsCvcSessionHandler.retrieveSessionCalled)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionResultsHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/workflow/RetrieveSessionResultsHandlerTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class RetrieveSessionResultsCollatorTests: XCTestCase {
     func testCompletesWithAllResultsWhenAllSuccessfulResultsReceived() {
@@ -15,16 +16,16 @@ class RetrieveSessionResultsCollatorTests: XCTestCase {
             case .failure(let error):
                 XCTFail("Expected successful result but got error \(error)")
             }
-            
+
             expectationToFulfill.fulfill()
         }
-        
+
         handler.handle(cardSession, for: SessionType.card)
         handler.handle(paymentsCvcSession, for: SessionType.cvc)
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testCompletesWithAnErrorWhenOneOfTheResultsIsAFailure() {
         let expectationToFulfill = expectation(description: "")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
@@ -37,20 +38,21 @@ class RetrieveSessionResultsCollatorTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(expectedError, error)
             }
-            
+
             expectationToFulfill.fulfill()
         }
-        
+
         handler.handle(cardSession, for: SessionType.card)
         handler.handle(paymentsCvcSession, for: SessionType.cvc)
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
-    
+
     func testCompletesWithFirstErrorWhenAllResultsAreAFailure() {
         let expectationToFulfill = expectation(description: "")
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
-        let otherError = StubUtils.createError(errorName: "another error", message: "another message")
+        let otherError = StubUtils.createError(
+            errorName: "another error", message: "another message")
         let cardSession: Result<String, AccessCheckoutError> = .failure(expectedError)
         let paymentsCvcSession: Result<String, AccessCheckoutError> = .failure(otherError)
         let handler = RetrieveSessionResultsHandler(numberOfExpectedResults: 2) { result in
@@ -60,13 +62,13 @@ class RetrieveSessionResultsCollatorTests: XCTestCase {
             case .failure(let error):
                 XCTAssertEqual(expectedError, error)
             }
-            
+
             expectationToFulfill.fulfill()
         }
-        
+
         handler.handle(cardSession, for: SessionType.card)
         handler.handle(paymentsCvcSession, for: SessionType.cvc)
-        
+
         wait(for: [expectationToFulfill], timeout: 1)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
@@ -1,130 +1,155 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AcceptanceTestSuite: XCTestCase {
     let panTextField = AccessCheckoutUITextField()
     let expiryDateTextField = AccessCheckoutUITextField()
     let cvcTextField = AccessCheckoutUITextField()
-    
-    func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedCardBrands: [String] = []) -> MockAccessCheckoutCardValidationDelegate {
-        return initialiseCardValidation(cardBrands: cardBrands, acceptedBrands: acceptedCardBrands, panTextField, expiryDateTextField, cvcTextField)
-    }
-    
-    func initialiseCardValidation() -> MockAccessCheckoutCardValidationDelegate {
-        return initialiseCardValidation(cardBrands: [TestFixtures.visaBrand(), TestFixtures.maestroBrand()], acceptedBrands: [], panTextField, expiryDateTextField, cvcTextField)
-    }
-    
-    func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedBrands: [String],
-                                  _ panAccessCheckoutTextField: AccessCheckoutUITextField,
-                                  _ expiryDateAccessCheckoutTextField:AccessCheckoutUITextField,
-                                  _ cvcAccessCheckoutTextField: AccessCheckoutUITextField) -> MockAccessCheckoutCardValidationDelegate
+
+    func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedCardBrands: [String] = [])
+        -> MockAccessCheckoutCardValidationDelegate
     {
+        return initialiseCardValidation(
+            cardBrands: cardBrands, acceptedBrands: acceptedCardBrands, panTextField,
+            expiryDateTextField, cvcTextField)
+    }
+
+    func initialiseCardValidation() -> MockAccessCheckoutCardValidationDelegate {
+        return initialiseCardValidation(
+            cardBrands: [TestFixtures.visaBrand(), TestFixtures.maestroBrand()], acceptedBrands: [],
+            panTextField, expiryDateTextField, cvcTextField)
+    }
+
+    func initialiseCardValidation(
+        cardBrands: [CardBrandModel], acceptedBrands: [String],
+        _ panAccessCheckoutTextField: AccessCheckoutUITextField,
+        _ expiryDateAccessCheckoutTextField: AccessCheckoutUITextField,
+        _ cvcAccessCheckoutTextField: AccessCheckoutUITextField
+    ) -> MockAccessCheckoutCardValidationDelegate {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().expiryDateValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().cardBrandChanged(cardBrand: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
-        
-        let cardBrandsConfiguration = createConfiguration(brands: cardBrands, acceptedBrands: acceptedBrands)
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any(), acceptedCardBrands: any()).thenDoNothing()
+
+        let cardBrandsConfiguration = createConfiguration(
+            brands: cardBrands, acceptedBrands: acceptedBrands)
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock())
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(
+            baseUrl: any(), acceptedCardBrands: any()
+        ).thenDoNothing()
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
-        
-        let validationConfiguration = try! CardValidationConfig.builder().pan(panAccessCheckoutTextField)
-            .expiryDate(expiryDateAccessCheckoutTextField)
-            .cvc(cvcAccessCheckoutTextField)
-            .accessBaseUrl("a-url")
-            .validationDelegate(merchantDelegate)
-            .acceptedCardBrands(acceptedBrands)
-            .build()
-        
+
+        let validationConfiguration = try! CardValidationConfig.builder().pan(
+            panAccessCheckoutTextField
+        )
+        .expiryDate(expiryDateAccessCheckoutTextField)
+        .cvc(cvcAccessCheckoutTextField)
+        .accessBaseUrl("a-url")
+        .validationDelegate(merchantDelegate)
+        .acceptedCardBrands(acceptedBrands)
+        .build()
+
         let validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
-        
+
         validationInitialiser.initialise(validationConfiguration)
-        
+
         return merchantDelegate
     }
-    
+
     func initialiseCvcOnlyValidation() -> MockAccessCheckoutCvcOnlyValidationDelegate {
-        let cardBrandsConfiguration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any(), acceptedCardBrands: any()).thenDoNothing()
+        let cardBrandsConfiguration = CardBrandsConfiguration(
+            allCardBrands: [], acceptedCardBrands: [])
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock())
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(
+            baseUrl: any(), acceptedCardBrands: any()
+        ).thenDoNothing()
         configurationProvider.getStubbingProxy().get().thenReturn(cardBrandsConfiguration)
-        
+
         let merchantDelegate = MockAccessCheckoutCvcOnlyValidationDelegate()
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
-        
+
         let validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)
         let validationConfiguration = try! CvcOnlyValidationConfig.builder()
             .cvc(cvcTextField)
             .validationDelegate(merchantDelegate)
             .build()
         validationInitialiser.initialise(validationConfiguration)
-        
+
         return merchantDelegate
     }
-    
+
     func editPan(text: String) {
         panTextField.text = text
         (panTextField.delegate as! Presenter).textFieldEditingChanged(panTextField.uiTextField)
     }
-    
+
     func clearPan() {
         editPan(text: "")
     }
-    
+
     func removeFocusFromPan() {
         (panTextField.delegate!).textFieldDidEndEditing!(panTextField.uiTextField)
     }
-    
+
     func canEnterPan(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
-        
-        return (panTextField.delegate!).textField!(panTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return (panTextField.delegate!).textField!(
+            panTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
-    
+
     func editExpiryDate(text: String) {
         expiryDateTextField.text = text
-        (expiryDateTextField.delegate as! Presenter).textFieldEditingChanged(expiryDateTextField.uiTextField)
+        (expiryDateTextField.delegate as! Presenter).textFieldEditingChanged(
+            expiryDateTextField.uiTextField)
     }
-    
+
     func removeFocusFromExpiryDate() {
         (expiryDateTextField.delegate!).textFieldDidEndEditing!(expiryDateTextField.uiTextField)
     }
-    
+
     func clearExpiryDate() {
         editExpiryDate(text: "")
     }
-    
+
     func canEnterExpiryDate(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
-        
-        return (expiryDateTextField.delegate!).textField!(expiryDateTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return (expiryDateTextField.delegate!).textField!(
+            expiryDateTextField.uiTextField, shouldChangeCharactersIn: range,
+            replacementString: text)
     }
-    
+
     func editCvc(text: String) {
         cvcTextField.text = text
         (cvcTextField.delegate as! Presenter).textFieldEditingChanged(cvcTextField.uiTextField)
     }
-    
+
     func clearCvc() {
         editCvc(text: "")
     }
-    
+
     func removeFocusFromCvc() {
         (cvcTextField.delegate!).textFieldDidEndEditing!(cvcTextField.uiTextField)
     }
-    
+
     func canEnterCvc(_ text: String) -> Bool {
         let range = NSRange(location: 0, length: 0)
-        
-        return (cvcTextField.delegate!).textField!(cvcTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return (cvcTextField.delegate!).textField!(
+            cvcTextField.uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
-    
-    private func createConfiguration(brands: [CardBrandModel], acceptedBrands: [String]) -> CardBrandsConfiguration {
+
+    private func createConfiguration(brands: [CardBrandModel], acceptedBrands: [String])
+        -> CardBrandsConfiguration
+    {
         return CardBrandsConfiguration(allCardBrands: brands, acceptedCardBrands: acceptedBrands)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/CuckooExtension.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/CuckooExtension.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
+
+@testable import AccessCheckoutSDK
 
 extension CardBrand: Matchable, OptionalMatchable {}
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/PresenterTestSuite.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/PresenterTestSuite.swift
@@ -1,27 +1,35 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PresenterTestSuite: XCTestCase {
     let panTextField = UITextField()
     let expiryDateTextField = UITextField()
     let cvcTextField = UITextField()
-    
-    func enterPanInUITextField(presenter: PanViewPresenter, uiTextField: UITextField, _ text: String) {
+
+    func enterPanInUITextField(
+        presenter: PanViewPresenter, uiTextField: UITextField, _ text: String
+    ) {
         let range = NSRange(location: 0, length: 0)
-        
+
         presenter.textField(uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
-    
-    func canEnterExpiryDate(presenter: ExpiryDateViewPresenter, uiTextField: UITextField, _ text: String) -> Bool {
+
+    func canEnterExpiryDate(
+        presenter: ExpiryDateViewPresenter, uiTextField: UITextField, _ text: String
+    ) -> Bool {
         let range = NSRange(location: 0, length: 0)
-        
-        return presenter.textField(uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return presenter.textField(
+            uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
-    
-    func canEnterCvc(presenter: CvcViewPresenter, uiTextField: UITextField, _ text: String) -> Bool {
+
+    func canEnterCvc(presenter: CvcViewPresenter, uiTextField: UITextField, _ text: String) -> Bool
+    {
         let range = NSRange(location: 0, length: 0)
-        
-        return presenter.textField(uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return presenter.textField(
+            uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
@@ -1,82 +1,85 @@
-@testable import AccessCheckoutSDK
 import Swifter
+
+@testable import AccessCheckoutSDK
 
 struct ServiceStubs {
     init() {
-        self.port = UInt16.random(in: 7000 ..< 8000)
+        self.port = UInt16.random(in: 7000..<8000)
         self.httpServer = .init()
         self.baseUrl = "http://localhost:\(port)"
     }
-    
+
     let baseUrl: String
-    
+
     private let port: UInt16
     private let httpServer: HttpServer
-    
+
     private let sessionsServicePath = "/sessions"
     private let sessionsServiceCardSessionPath = "/sessions/card"
     private let sessionsServicePaymentsCvcSessionPath = "/sessions/paymentsCvc"
-    
+
     func get200(path: String, jsonResponse: String) -> ServiceStubs {
         let jsonData = try! toJSON(jsonResponse)
         httpServer.GET[path] = { _ in .ok(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func get200(path: String, textResponse: String) -> ServiceStubs {
         httpServer.GET[path] = { _ in .ok(.text(textResponse)) }
         return self
     }
-    
+
     func get400(path: String, jsonResponse: String) -> ServiceStubs {
         let jsonData = try! toJSON(jsonResponse)
         httpServer.GET[path] = { _ in .badRequest(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func get400(path: String, textResponse: String) -> ServiceStubs {
         httpServer.GET[path] = { _ in .badRequest(.text(textResponse)) }
         return self
     }
-    
+
     func failed400(path: String, error: AccessCheckoutError) -> ServiceStubs {
         let jsonData = try! toJSON(toJSONString(error))
         httpServer.GET[path] = { _ in .badRequest(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func post200(path: String, jsonResponse: String) -> ServiceStubs {
         let jsonData = try! toJSON(jsonResponse)
         httpServer.POST[path] = { _ in .ok(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func post400(path: String, error: AccessCheckoutError) -> ServiceStubs {
         let jsonData = try! toJSON(toJSONString(error))
         httpServer.POST[path] = { _ in .badRequest(.json(jsonData as AnyObject)) }
         return self
     }
-    
+
     func servicesRootDiscoverySuccess() -> ServiceStubs {
         return get200(path: "", jsonResponse: successfulDiscoveryResponse())
     }
-    
+
     func cardSessionSuccess(session: String) -> ServiceStubs {
-        return post200(path: sessionsServiceCardSessionPath, jsonResponse: successfulCardSessionResponse(session: session))
+        return post200(
+            path: sessionsServiceCardSessionPath,
+            jsonResponse: successfulCardSessionResponse(session: session))
     }
-    
+
     func cardSessionFailure(error: AccessCheckoutError) -> ServiceStubs {
         return post400(path: sessionsServiceCardSessionPath, error: error)
     }
-    
+
     func sessionsEndPointsDiscoverySuccess() -> ServiceStubs {
         return get200(path: sessionsServicePath, jsonResponse: successfulDiscoveryResponse())
     }
-    
+
     func sessionsEndPointDiscoveryFailure(error: AccessCheckoutError) -> ServiceStubs {
         return failed400(path: sessionsServicePath, error: error)
     }
-    
+
     func sessionsPaymentsCvcSessionSuccess(session: String) -> ServiceStubs {
         let jsonResponse = successfulPaymentsCvcSessionResponse(session: session)
         return post200(path: sessionsServicePaymentsCvcSessionPath, jsonResponse: jsonResponse)
@@ -85,61 +88,61 @@ struct ServiceStubs {
     func sessionsPaymentsCvcSessionFailure(error: AccessCheckoutError) -> ServiceStubs {
         return post400(path: sessionsServicePaymentsCvcSessionPath, error: error)
     }
-    
+
     func start() {
         try! httpServer.start(port)
     }
-    
+
     func stop() {
         httpServer.stop()
     }
-    
+
     private func successfulDiscoveryResponse() -> String {
         return """
-        {
-            "_links": {
-                "service:sessions": {
-                    "href": "\(baseUrl)\(sessionsServicePath)"
-                },
-                "sessions:card": {
-                    "href": "\(baseUrl)\(sessionsServiceCardSessionPath)"
-                },
-                "sessions:paymentsCvc": {
-                    "href": "\(baseUrl)\(sessionsServicePaymentsCvcSessionPath)"
+            {
+                "_links": {
+                    "service:sessions": {
+                        "href": "\(baseUrl)\(sessionsServicePath)"
+                    },
+                    "sessions:card": {
+                        "href": "\(baseUrl)\(sessionsServiceCardSessionPath)"
+                    },
+                    "sessions:paymentsCvc": {
+                        "href": "\(baseUrl)\(sessionsServicePaymentsCvcSessionPath)"
+                    }
                 }
             }
-        }
-        """
+            """
     }
-    
+
     private func successfulCardSessionResponse(session: String) -> String {
         return """
-        {
-            "_links": {
-                "sessions:session": {
-                    "href": "\(session)"
+            {
+                "_links": {
+                    "sessions:session": {
+                        "href": "\(session)"
+                    }
                 }
             }
-        }
-        """
+            """
     }
-    
+
     private func successfulPaymentsCvcSessionResponse(session: String) -> String {
         return """
-        {
-            "_links": {
-                "sessions:session": {
-                    "href": "\(session)"
+            {
+                "_links": {
+                    "sessions:session": {
+                        "href": "\(session)"
+                    }
                 }
             }
-        }
-        """
+            """
     }
 
     private func toJSONString(_ error: AccessCheckoutError) -> String {
         return String(data: try! JSONEncoder().encode(error), encoding: .utf8)!
     }
-    
+
     private func toJSON(_ content: String) throws -> Any? {
         let data = content.data(using: .utf8)
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
@@ -1,60 +1,67 @@
-@testable import AccessCheckoutSDK
 import Swifter
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class StubUtils {
     static func createError(errorName: String, message: String) -> AccessCheckoutError {
         let json = """
-        {
-            "errorName": "\(errorName)",
-            "message": "\(message)"
-        }
-        """
-        
+            {
+                "errorName": "\(errorName)",
+                "message": "\(message)"
+            }
+            """
+
         let jsonAsData = json.data(using: .utf8)!
         return try! JSONDecoder().decode(AccessCheckoutError.self, from: jsonAsData)
     }
-    
+
     static func parseAccessCheckoutError(json: String) -> AccessCheckoutError {
         let jsonAsData = json.data(using: .utf8)!
         return try! JSONDecoder().decode(AccessCheckoutError.self, from: jsonAsData)
     }
-    
-    static func createApiValidationError(errorName: String, message: String, jsonPath: String) -> AccessCheckoutError.AccessCheckoutValidationError {
+
+    static func createApiValidationError(errorName: String, message: String, jsonPath: String)
+        -> AccessCheckoutError.AccessCheckoutValidationError
+    {
         let json = """
-        {
-            "errorName": "\(errorName)",
-            "message": "\(message)",
-            "jsonPath": "\(jsonPath)"
-        }
-        """
-        
-        let jsonAsData = json.data(using: .utf8)!
-        return try! JSONDecoder().decode(AccessCheckoutError.AccessCheckoutValidationError.self, from: jsonAsData)
-    }
-    
-    static func createApiError(errorName: String, message: String, validationErrors: [AccessCheckoutError.AccessCheckoutValidationError]) -> AccessCheckoutError {
-        var validationErrorsJson = [String]()
-        
-        for error in validationErrors {
-            let jsonError = """
             {
-                "errorName": "\(error.errorName)",
-                "message": "\(error.message)",
-                "jsonPath": "\(error.jsonPath)"
+                "errorName": "\(errorName)",
+                "message": "\(message)",
+                "jsonPath": "\(jsonPath)"
             }
             """
+
+        let jsonAsData = json.data(using: .utf8)!
+        return try! JSONDecoder().decode(
+            AccessCheckoutError.AccessCheckoutValidationError.self, from: jsonAsData)
+    }
+
+    static func createApiError(
+        errorName: String, message: String,
+        validationErrors: [AccessCheckoutError.AccessCheckoutValidationError]
+    ) -> AccessCheckoutError {
+        var validationErrorsJson = [String]()
+
+        for error in validationErrors {
+            let jsonError = """
+                {
+                    "errorName": "\(error.errorName)",
+                    "message": "\(error.message)",
+                    "jsonPath": "\(error.jsonPath)"
+                }
+                """
             validationErrorsJson.append(jsonError)
         }
-        
+
         let json = """
-        {
-            "errorName": "\(errorName)",
-            "message": "\(message)",
-            "validationErrors" : [\(validationErrorsJson.joined(separator: ","))]
-        }
-        """
-        
+            {
+                "errorName": "\(errorName)",
+                "message": "\(message)",
+                "validationErrors" : [\(validationErrorsJson.joined(separator: ","))]
+            }
+            """
+
         let jsonAsData = json.data(using: .utf8)!
         return try! JSONDecoder().decode(AccessCheckoutError.self, from: jsonAsData)
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/TestFixtures.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/TestFixtures.swift
@@ -1,6 +1,6 @@
-@testable import AccessCheckoutSDK
-
 import Foundation
+
+@testable import AccessCheckoutSDK
 
 final class TestFixtures {
     static let validVisaPan1 = "4111111111111111"
@@ -18,17 +18,19 @@ final class TestFixtures {
 
     static let validMasterCardPan = "5500000000000004"
 
-    static func createCardBrandModel(name: String, panPattern: String, panValidLengths: [Int], cvcValidLength: Int) -> CardBrandModel {
+    static func createCardBrandModel(
+        name: String, panPattern: String, panValidLengths: [Int], cvcValidLength: Int
+    ) -> CardBrandModel {
         let panValidLengthsString = panValidLengths.map { String($0) }.joined(separator: ",")
 
         let json = """
-        {
-            "name": "\(name)",
-            "pattern": "\(panPattern.replacingOccurrences(of: "\\", with: "\\\\"))",
-            "panLengths": [\(panValidLengthsString)],
-            "cvvLength": \(cvcValidLength)
-        }
-        """
+            {
+                "name": "\(name)",
+                "pattern": "\(panPattern.replacingOccurrences(of: "\\", with: "\\\\"))",
+                "panLengths": [\(panValidLengthsString)],
+                "cvvLength": \(cvcValidLength)
+            }
+            """
         let decoder = JSONDecoder()
         let jsonData = json.data(using: .utf8)
         let cardBrandDto = try! decoder.decode(CardBrandDto.self, from: jsonData!)
@@ -37,24 +39,28 @@ final class TestFixtures {
     }
 
     static func visaBrand() -> CardBrandModel {
-        return createCardBrandModel(name: "visa",
-                                    panPattern: "^(?!^493698\\d*$)4\\d*$",
-                                    panValidLengths: [16, 18, 19],
-                                    cvcValidLength: 3)
+        return createCardBrandModel(
+            name: "visa",
+            panPattern: "^(?!^493698\\d*$)4\\d*$",
+            panValidLengths: [16, 18, 19],
+            cvcValidLength: 3)
     }
 
     static func maestroBrand() -> CardBrandModel {
-        return createCardBrandModel(name: "maestro",
-                                    panPattern: "^(493698|(50[0-5][0-9]{2}|506[0-5][0-9]|5066[0-9])|(5067[7-9]|506[89][0-9]|50[78][0-9]{2})|5[6-9]|63|67)\\d*$",
-                                    panValidLengths: [12, 13, 14, 15, 16, 17, 18, 19],
-                                    cvcValidLength: 3)
+        return createCardBrandModel(
+            name: "maestro",
+            panPattern:
+                "^(493698|(50[0-5][0-9]{2}|506[0-5][0-9]|5066[0-9])|(5067[7-9]|506[89][0-9]|50[78][0-9]{2})|5[6-9]|63|67)\\d*$",
+            panValidLengths: [12, 13, 14, 15, 16, 17, 18, 19],
+            cvcValidLength: 3)
     }
 
     static func amexBrand() -> CardBrandModel {
-        return createCardBrandModel(name: "amex",
-                                    panPattern: "^3[47]\\d*$",
-                                    panValidLengths: [15],
-                                    cvcValidLength: 4)
+        return createCardBrandModel(
+            name: "amex",
+            panPattern: "^3[47]\\d*$",
+            panValidLengths: [15],
+            cvcValidLength: 4)
     }
 
     static func unknownBrand() -> CardBrandModel? {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/UIUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/UIUtils.swift
@@ -1,8 +1,10 @@
-@testable import AccessCheckoutSDK
 import UIKit
 
+@testable import AccessCheckoutSDK
+
 struct UIUtils {
-    static func createAccessCheckoutUITextField(withText text: String) -> AccessCheckoutUITextField {
+    static func createAccessCheckoutUITextField(withText text: String) -> AccessCheckoutUITextField
+    {
         let uiTextField = UITextField()
         uiTextField.text = text
         return AccessCheckoutUITextField(uiTextField)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/CardBrandDtoTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/CardBrandDtoTests.swift
@@ -1,56 +1,57 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutSDKTests: XCTestCase {
     func testIsDeserialisedSuccessfully() throws {
         let json = """
-        {
-            "name": "visa",
-            "pattern": "a-pattern",
-            "panLengths": [
-                16,
-                18,
-                19
-            ],
-            "cvvLength": 3,
-            "images": [
-                {
-                    "type": "image/png",
-                    "url": "png-url"
-                },
-                {
-                    "type": "image/svg+xml",
-                    "url": "svg-url"
-                }
-            ]
-        }
-        """
+            {
+                "name": "visa",
+                "pattern": "a-pattern",
+                "panLengths": [
+                    16,
+                    18,
+                    19
+                ],
+                "cvvLength": 3,
+                "images": [
+                    {
+                        "type": "image/png",
+                        "url": "png-url"
+                    },
+                    {
+                        "type": "image/svg+xml",
+                        "url": "svg-url"
+                    }
+                ]
+            }
+            """
         let decoder = JSONDecoder()
         let jsonData = json.data(using: .utf8)
-        
+
         let result = try decoder.decode(CardBrandDto.self, from: jsonData!)
-        
+
         XCTAssertEqual("visa", result.name)
         XCTAssertEqual("a-pattern", result.pattern)
         XCTAssertEqual([16, 18, 19], result.panLengths)
         XCTAssertEqual(3, result.cvcLength)
-        
+
         XCTAssertEqual(result.images[0].type, "image/png")
         XCTAssertEqual(result.images[0].url, "png-url")
-        
+
         XCTAssertEqual(result.images[1].type, "image/svg+xml")
         XCTAssertEqual(result.images[1].url, "svg-url")
     }
-    
+
     func testIsDeserialisedSuccessfullyWhenFieldsAreMissing() throws {
         let json = """
-        { }
-        """
+            { }
+            """
         let decoder = JSONDecoder()
         let jsonData = json.data(using: .utf8)
-        
+
         let result = try decoder.decode(CardBrandDto.self, from: jsonData!)
-        
+
         XCTAssertEqual("", result.name)
         XCTAssertEqual("", result.pattern)
         XCTAssertEqual([], result.panLengths)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/CardBrandDtoTransformerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/CardBrandDtoTransformerTests.swift
@@ -1,35 +1,40 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardBrandDtoTransformerTests: XCTestCase {
     func testTransformsToCardBrand() throws {
-        let expectedImages = [CardBrandImageModel(type: "image/png", url: "png-url"), CardBrandImageModel(type: "image/svg+xml", url: "svg-url")]
-        let expectedPanValidationRule = ValidationRule(matcher: "a-pattern", validLengths: [16, 18, 19])
+        let expectedImages = [
+            CardBrandImageModel(type: "image/png", url: "png-url"),
+            CardBrandImageModel(type: "image/svg+xml", url: "svg-url"),
+        ]
+        let expectedPanValidationRule = ValidationRule(
+            matcher: "a-pattern", validLengths: [16, 18, 19])
         let expectedCvcValidationRule = ValidationRule(matcher: "^\\d*$", validLengths: [3])
         let transformer = CardBrandDtoTransformer()
         let decoder = JSONDecoder()
         let json = """
-        {
-            "name": "a-name",
-            "pattern": "a-pattern",
-            "panLengths": [
-                16,
-                18,
-                19
-            ],
-            "cvvLength": 3,
-            "images": [
-                {
-                    "type": "image/png",
-                    "url": "png-url"
-                },
-                {
-                    "type": "image/svg+xml",
-                    "url": "svg-url"
-                }
-            ]
-        }
-        """
+            {
+                "name": "a-name",
+                "pattern": "a-pattern",
+                "panLengths": [
+                    16,
+                    18,
+                    19
+                ],
+                "cvvLength": 3,
+                "images": [
+                    {
+                        "type": "image/png",
+                        "url": "png-url"
+                    },
+                    {
+                        "type": "image/svg+xml",
+                        "url": "svg-url"
+                    }
+                ]
+            }
+            """
         let dto = try decoder.decode(CardBrandDto.self, from: json.data(using: .utf8)!)
 
         let result = transformer.transform(dto)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CardValidationStateHandlerTests.swift
@@ -1,27 +1,30 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardValidationStateHandlerTests: XCTestCase {
     let visaBrand = CardBrandModel(
         name: "visa",
         images: [],
-        panValidationRule: ValidationRule(matcher: "^(?!^493698\\d*$)4\\d*$", validLengths: [16, 18, 19]),
+        panValidationRule: ValidationRule(
+            matcher: "^(?!^493698\\d*$)4\\d*$", validLengths: [16, 18, 19]),
         cvcValidationRule: ValidationRule(matcher: nil, validLengths: [3])
     )
-    
+
     let maestroBrand = CardBrandModel(
         name: "maestro",
         images: [],
         panValidationRule: ValidationRule(
-            matcher: "^(493698|(50[0-5][0-9]{2}|506[0-5][0-9]|5066[0-9])|(5067[7-9]|506[89][0-9]|50[78][0-9]{2})|5[6-9]|63|67)\\d*$",
+            matcher:
+                "^(493698|(50[0-5][0-9]{2}|506[0-5][0-9]|5066[0-9])|(5067[7-9]|506[89][0-9]|50[78][0-9]{2})|5[6-9]|63|67)\\d*$",
             validLengths: [12, 13, 14, 15, 16, 17, 18, 19]
         ),
         cvcValidationRule: ValidationRule(matcher: nil, validLengths: [3])
     )
-    
+
     private let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
-    
+
     override func setUp() {
         merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().cardBrandChanged(cardBrand: any()).thenDoNothing()
@@ -29,41 +32,49 @@ class CardValidationStateHandlerTests: XCTestCase {
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
     }
-    
+
     // MARK: PanValidationStateHandler
-    
-    func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromFalse() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
-        
+
+    func
+        testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromFalse()
+    {
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false)
+
         validationStateHandler.handlePanValidation(isValid: false, cardBrand: nil)
-        
+
         verify(merchantDelegate, never()).panValidChanged(isValid: any())
     }
-    
-    func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromTrue() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
-        
+
+    func
+        testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenPanValidationDoesNotChangeFromTrue()
+    {
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: true)
+
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
-        
+
         verify(merchantDelegate, never()).panValidChanged(isValid: any())
     }
-    
+
     func testHandlePanValidation_shouldNotifyMerchantDelegateWhenPanValidationChangesToFalse() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: true)
+
         validationStateHandler.handlePanValidation(isValid: false, cardBrand: nil)
-        
+
         verify(merchantDelegate).panValidChanged(isValid: false)
     }
-    
+
     func testHandlePanValidation_shouldNotifyMerchantDelegateWhenPanValidationChangesToTrue() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false)
+
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
-        
+
         verify(merchantDelegate).panValidChanged(isValid: true)
     }
-    
+
     func testHandlePanValidation_shouldNotifyMerchantDelegateWhenCardBrandChanges() {
         let expectedCardBrand = createCardBrand(from: visaBrand)
         let validationStateHandler = CardValidationStateHandler(
@@ -71,268 +82,306 @@ class CardValidationStateHandlerTests: XCTestCase {
             panValidationState: true,
             cardBrand: nil
         )
-        
+
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: visaBrand)
-        
+
         verify(merchantDelegate).cardBrandChanged(cardBrand: expectedCardBrand)
     }
-    
+
     func testHandlePanValidation_shouldNotNotifyMerchantDelegateWhenCardBrandDoesNotChange() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: visaBrand
         )
-        
+
         validationStateHandler.handlePanValidation(isValid: false, cardBrand: visaBrand)
-        
+
         verify(merchantDelegate, never()).cardBrandChanged(cardBrand: any())
     }
-    
-    func testIsCardBrandDifferentFrom_shouldReturnFalseWhenCardBrandInStateIsSameAsCardBrandInParameter() {
+
+    func
+        testIsCardBrandDifferentFrom_shouldReturnFalseWhenCardBrandInStateIsSameAsCardBrandInParameter()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: visaBrand
         )
-        
+
         XCTAssertFalse(validationStateHandler.isCardBrandDifferentFrom(cardBrand: visaBrand))
     }
-    
-    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNilAndCardBrandInParameterIsNot() {
+
+    func
+        testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNilAndCardBrandInParameterIsNot()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: nil
         )
-        
+
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: visaBrand))
     }
-    
-    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsDifferentFromCardBrandInParameter() {
+
+    func
+        testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsDifferentFromCardBrandInParameter()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: visaBrand
         )
-        
+
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: maestroBrand))
     }
-    
-    func testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNotNilAndCardBrandInParameterIs() {
+
+    func
+        testIsCardBrandDifferentFrom_shouldReturnTrueWhenCardBrandInStateIsNotNilAndCardBrandInParameterIs()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: visaBrand
         )
-        
+
         XCTAssertTrue(validationStateHandler.isCardBrandDifferentFrom(cardBrand: nil))
     }
-    
+
     func testIsCardBrandDifferentFrom_shouldReturnFalseWhenCardBrandRemainsNil() {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             panValidationState: false,
             cardBrand: nil
         )
-        
+
         XCTAssertFalse(validationStateHandler.isCardBrandDifferentFrom(cardBrand: nil))
     }
-    
+
     func testNotifyMerchantOfPanValidationState_notifiesMerchantOfValidPan() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: true)
+
         validationStateHandler.notifyMerchantOfPanValidationState()
-        
+
         verify(merchantDelegate).panValidChanged(isValid: true)
     }
-    
-    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfValidPanOnlyOnceWhenCalledMultipleTimes() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: true)
-        
+
+    func
+        testNotifyMerchantOfPanValidationState_notifiesMerchantOfValidPanOnlyOnceWhenCalledMultipleTimes()
+    {
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: true)
+
         validationStateHandler.notifyMerchantOfPanValidationState()
         validationStateHandler.notifyMerchantOfPanValidationState()
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: true)
     }
-    
+
     func testNotifyMerchantOfPanValidationState_notifiesMerchantOfInvalidPan() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false)
+
         validationStateHandler.notifyMerchantOfPanValidationState()
-        
+
         verify(merchantDelegate).panValidChanged(isValid: false)
     }
-    
-    func testNotifyMerchantOfPanValidationState_notifiesMerchantOfInvalidPanOnlyOnceWhenCalledMultipleTimes() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false)
-        
+
+    func
+        testNotifyMerchantOfPanValidationState_notifiesMerchantOfInvalidPanOnlyOnceWhenCalledMultipleTimes()
+    {
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false)
+
         validationStateHandler.notifyMerchantOfPanValidationState()
         validationStateHandler.notifyMerchantOfPanValidationState()
-        
+
         verify(merchantDelegate, times(1)).panValidChanged(isValid: false)
     }
-    
-    
+
     func testGetCardBrand_shouldReturnCardBrandIfKnownBrand() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: visaBrand)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: visaBrand)
+
         XCTAssertEqual(validationStateHandler.getCardBrand(), visaBrand)
     }
-    
+
     func testGetCardBrand_shouldReturnNilCardBrandIfUnknownBrand() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: nil)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, panValidationState: false, cardBrand: nil)
+
         XCTAssertEqual(validationStateHandler.getCardBrand(), nil)
     }
-    
+
     // MARK: ExpiryDateValidationStateHandler
-    
-    func testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromFalse() {
+
+    func
+        testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromFalse()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: false
         )
-        
+
         validationStateHandler.handleExpiryDateValidation(isValid: false)
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }
-    
-    func testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromTrue() {
+
+    func
+        testHandleExpiryDateValidation_shouldNotNotifyMerchantDelegateWhenExpiryValidationStateDoesNotChangeFromTrue()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: true
         )
-        
+
         validationStateHandler.handleExpiryDateValidation(isValid: true)
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }
-    
-    func testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromFalse() {
+
+    func
+        testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromFalse()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: false
         )
-        
+
         validationStateHandler.handleExpiryDateValidation(isValid: true)
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
     }
-    
-    func testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromTrue() {
+
+    func
+        testHandleExpiryDateValidation_shouldNotifyMerchantDelegateWhenExpiryValidationStateChangesFromTrue()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             expiryDateValidationState: true
         )
-        
+
         validationStateHandler.handleExpiryDateValidation(isValid: false)
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
-    
+
     func testNotifyMerchantOfExpiryDateValidationState_notifiesMerchantOfValidExpiryDate() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, expiryDateValidationState: true)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, expiryDateValidationState: true)
+
         validationStateHandler.notifyMerchantOfExpiryDateValidationState()
-        
+
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
     }
-    
+
     func testNotifyMerchantOfExpiryDateValidationState_notifiesMerchantOfInvalidExpiryDate() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, expiryDateValidationState: false)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, expiryDateValidationState: false)
+
         validationStateHandler.notifyMerchantOfExpiryDateValidationState()
-        
+
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
-    
+
     // MARK: CvcValidationStateHandler
-    
-    func testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse() {
+
+    func
+        testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: false
         )
-        
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
-    func testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue() {
+
+    func
+        testHandleCvcValidation_shouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: true
         )
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
-    func testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse() {
+
+    func
+        testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: false
         )
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
-    
-    func testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue() {
+
+    func testHandleCvcValidation_shouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue()
+    {
         let validationStateHandler = CardValidationStateHandler(
             merchantDelegate: merchantDelegate,
             cvcValidationState: true
         )
-        
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
+
     func testNotifyMerchantOfCvcValidationState_notifiesMerchantOfValidCvc() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, cvcValidationState: true)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, cvcValidationState: true)
+
         validationStateHandler.notifyMerchantOfCvcValidationState()
-        
+
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
-    
+
     func testNotifyMerchantOfCvcValidationState_notifiesMerchantOfInvalidCvc() {
-        let validationStateHandler = CardValidationStateHandler(merchantDelegate: merchantDelegate, cvcValidationState: false)
-        
+        let validationStateHandler = CardValidationStateHandler(
+            merchantDelegate: merchantDelegate, cvcValidationState: false)
+
         validationStateHandler.notifyMerchantOfCvcValidationState()
-        
+
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
+
     // MARK: Tests for notification that all fields are valid
-    
+
     func testShouldNotifyMerchantDelegateWhenAllFieldsAreValid() {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
         validationStateHandler.handleExpiryDateValidation(isValid: true)
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate).validationSuccess()
     }
-    
-    func testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAFieldIsChangedToAnotherValidValue() {
+
+    func
+        testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAFieldIsChangedToAnotherValidValue()
+    {
         let validationStateHandler = CardValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handlePanValidation(isValid: true, cardBrand: nil)
         validationStateHandler.handleExpiryDateValidation(isValid: true)
         validationStateHandler.handleCvcValidation(isValid: true)
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
-    
+
     private func createCardBrand(from cardBrandModel: CardBrandModel) -> CardBrand? {
         var images = [CardBrandImage]()
-        
+
         for imageToConvert in cardBrandModel.images {
             let image = CardBrandImage(type: imageToConvert.type, url: imageToConvert.url)
             images.append(image)
         }
-        
+
         return CardBrand(name: cardBrandModel.name, images: images)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CvvOnlyValidationStateHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/CvvOnlyValidationStateHandlerTests.swift
@@ -1,67 +1,74 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class CvcOnlyValidationStateHandlerTests: XCTestCase {
     private let merchantDelegate = MockAccessCheckoutCvcOnlyValidationDelegate()
-    
+
     override func setUp() {
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().validationSuccess().thenDoNothing()
     }
-    
+
     func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromFalse() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvvValidationState: false)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate, cvvValidationState: false)
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
+
     func testShouldNotNotifyMerchantDelegateWhenCvcValidationStateDoesNotChangeFromTrue() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvvValidationState: true)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate, cvvValidationState: true)
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate, never()).cvcValidChanged(isValid: any())
     }
-    
+
     func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromFalse() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvvValidationState: false)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate, cvvValidationState: false)
+
         validationStateHandler.handleCvcValidation(isValid: true)
         verify(merchantDelegate).cvcValidChanged(isValid: true)
     }
-    
+
     func testShouldNotifyMerchantDelegateWhenCvcValidationStateChangesFromTrue() {
-        let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate, cvvValidationState: true)
-        
+        let validationStateHandler = CvcOnlyValidationStateHandler(
+            merchantDelegate, cvvValidationState: true)
+
         validationStateHandler.handleCvcValidation(isValid: false)
         verify(merchantDelegate).cvcValidChanged(isValid: false)
     }
-    
+
     func testNotifyMerchantOfCvcValidationStateSetsNotificationState() {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.notifyMerchantOfCvcValidationState()
-        
+
         XCTAssertTrue(validationStateHandler.alreadyNotifiedMerchantOfCvcValidationState)
     }
-    
+
     // MARK: Tests for notification that all fields are valid
-    
+
     func testShouldNotifyMerchantDelegateWhenAllFieldsAreValid() {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate).validationSuccess()
     }
-    
-    func testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAndCvcIsChangedToAnotherValidValue() {
+
+    func
+        testShouldNotifyMerchantDelegateOnlyOnceWhenAllFieldsAreValidAndCvcIsChangedToAnotherValidValue()
+    {
         let validationStateHandler = CvcOnlyValidationStateHandler(merchantDelegate)
-        
+
         validationStateHandler.handleCvcValidation(isValid: true)
         validationStateHandler.handleCvcValidation(isValid: true)
-        
+
         verify(merchantDelegate, times(1)).validationSuccess()
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandModelTransformerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandModelTransformerTests.swift
@@ -1,20 +1,24 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardBrandModelTransformerTests: XCTestCase {
     func testTransformsIntoACardBrand() {
-        let model = CardBrandModel(name: "a card brand",
-                                   images: [
-                                       CardBrandImageModel(type: "type 1", url: "url 1"),
-                                       CardBrandImageModel(type: "type 2", url: "url 2")
-                                   ],
-                                   panValidationRule: ValidationRule(matcher: "pan matcher", validLengths: [1, 2, 3]),
-                                   cvcValidationRule: ValidationRule(matcher: "cvc matcher", validLengths: [4]))
+        let model = CardBrandModel(
+            name: "a card brand",
+            images: [
+                CardBrandImageModel(type: "type 1", url: "url 1"),
+                CardBrandImageModel(type: "type 2", url: "url 2"),
+            ],
+            panValidationRule: ValidationRule(matcher: "pan matcher", validLengths: [1, 2, 3]),
+            cvcValidationRule: ValidationRule(matcher: "cvc matcher", validLengths: [4]))
 
-        let expected = CardBrand(name: "a card brand", images: [
-            CardBrandImage(type: "type 1", url: "url 1"),
-            CardBrandImage(type: "type 2", url: "url 2")
-        ])
+        let expected = CardBrand(
+            name: "a card brand",
+            images: [
+                CardBrandImage(type: "type 1", url: "url 1"),
+                CardBrandImage(type: "type 2", url: "url 2"),
+            ])
         let transformer = CardBrandModelTransformer()
 
         let result = transformer.transform(model)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationFactoryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationFactoryTests.swift
@@ -1,106 +1,130 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
 
+@testable import AccessCheckoutSDK
+
 class CardBrandsConfigurationFactoryTests: XCTestCase {
     private var serviceStubs: ServiceStubs?
-    
+
     override func setUp() {
         serviceStubs = ServiceStubs()
     }
-    
+
     override func tearDown() {
         serviceStubs?.stop()
     }
-    
+
     private let successfulResponse = """
-    [{
-        "name": "visa",
-        "pattern": "a-pattern",
-        "panLengths": [3],
-        "cvvLength": 3,
-        "images": []
-    
-    }]
-    """
+        [{
+            "name": "visa",
+            "pattern": "a-pattern",
+            "panLengths": [3],
+            "cvvLength": 3,
+            "images": []
+
+        }]
+        """
     private let factory = CardBrandsConfigurationFactory(RestClient(), CardBrandDtoTransformer())
-    
-    func testCreatesConfigurationWithBrandsAndAcceptedCardBrands_byRequestingRemoteConfigurationFileForBaseUrlWithoutTrailingSlash() throws {
+
+    func
+        testCreatesConfigurationWithBrandsAndAcceptedCardBrands_byRequestingRemoteConfigurationFileForBaseUrlWithoutTrailingSlash()
+        throws
+    {
         let expectationToFulfill = expectation(description: "")
-        
-        serviceStubs!.get200(path: "/access-checkout/cardTypes.json", jsonResponse: successfulResponse)
-            .start()
-        
-        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) { configuration in
+
+        serviceStubs!.get200(
+            path: "/access-checkout/cardTypes.json", jsonResponse: successfulResponse
+        )
+        .start()
+
+        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) {
+            configuration in
             XCTAssertEqual(1, configuration.allCardBrands.count)
             XCTAssertEqual("visa", configuration.allCardBrands[0].name)
-            
+
             XCTAssertEqual(["amex", "jcb"], configuration.acceptedCardBrands)
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
-    func testCreatesConfigurationWithBrandsAndAcceptedCardBrands_byRequestingRemoteConfigurationFileForBaseUrlWithTrailingSlash() throws {
+
+    func
+        testCreatesConfigurationWithBrandsAndAcceptedCardBrands_byRequestingRemoteConfigurationFileForBaseUrlWithTrailingSlash()
+        throws
+    {
         let expectationToFulfill = expectation(description: "")
-        serviceStubs!.get200(path: "/access-checkout/cardTypes.json", jsonResponse: successfulResponse)
-            .start()
-        
-        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) { configuration in
+        serviceStubs!.get200(
+            path: "/access-checkout/cardTypes.json", jsonResponse: successfulResponse
+        )
+        .start()
+
+        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) {
+            configuration in
             XCTAssertEqual(1, configuration.allCardBrands.count)
             XCTAssertEqual("visa", configuration.allCardBrands[0].name)
-            
+
             XCTAssertEqual(["amex", "jcb"], configuration.acceptedCardBrands)
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
-    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenInvalidUrlIsPassed() throws {
+
+    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenInvalidUrlIsPassed() throws
+    {
         let expectationToFulfill = expectation(description: "")
-        
-        factory.create(baseUrl: "some invalid URL", acceptedCardBrands: ["amex", "jcb"]) { configuration in
+
+        factory.create(baseUrl: "some invalid URL", acceptedCardBrands: ["amex", "jcb"]) {
+            configuration in
             XCTAssertTrue(configuration.allCardBrands.isEmpty)
             XCTAssertEqual(["amex", "jcb"], configuration.acceptedCardBrands)
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 2)
     }
-    
-    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenFailingToConnectToUrl() throws {
+
+    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenFailingToConnectToUrl()
+        throws
+    {
         let expectationToFulfill = expectation(description: "")
-        
-        factory.create(baseUrl: "http://localhost:9000", acceptedCardBrands: ["amex", "jcb"]) { configuration in
+
+        factory.create(baseUrl: "http://localhost:9000", acceptedCardBrands: ["amex", "jcb"]) {
+            configuration in
             XCTAssertTrue(configuration.allCardBrands.isEmpty)
             XCTAssertEqual(["amex", "jcb"], configuration.acceptedCardBrands)
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 0.5)
     }
-    
-    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenReceivingErrorInResponse() throws {
+
+    func testCreatesConfigurationWithEmptyBrandsAndAcceptedCardBrandsWhenReceivingErrorInResponse()
+        throws
+    {
         let expectationToFulfill = expectation(description: "")
-        serviceStubs!.get400(path: "/access-checkout/cardTypes.json", textResponse: "some invalid response")
-            .start()
-        
-        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) { configuration in
+        serviceStubs!.get400(
+            path: "/access-checkout/cardTypes.json", textResponse: "some invalid response"
+        )
+        .start()
+
+        factory.create(baseUrl: serviceStubs!.baseUrl, acceptedCardBrands: ["amex", "jcb"]) {
+            configuration in
             XCTAssertTrue(configuration.allCardBrands.isEmpty)
             XCTAssertEqual(["amex", "jcb"], configuration.acceptedCardBrands)
             expectationToFulfill.fulfill()
         }
-        
+
         wait(for: [expectationToFulfill], timeout: 5)
     }
-    
+
     func createsAnEmptyConfiguration() {
-        let expectedConfiguration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
+        let expectedConfiguration = CardBrandsConfiguration(
+            allCardBrands: [], acceptedCardBrands: [])
+
         let result = factory.emptyConfiguration()
-        
+
         XCTAssertEqual(expectedConfiguration, result)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationProviderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationProviderTests.swift
@@ -1,44 +1,51 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardBrandsConfigurationProviderTests: XCTestCase {
     let factory = CardBrandsConfigurationFactoryMock()
     var configurationProvider: CardBrandsConfigurationProvider?
-    
+
     override func setUp() {
         configurationProvider = CardBrandsConfigurationProvider(factory)
     }
-    
+
     func testReturnsEmptyConfigurationWhenRemoteConfigurationIsNotNeeded() {
-        let expectedConfiguration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
+        let expectedConfiguration = CardBrandsConfiguration(
+            allCardBrands: [], acceptedCardBrands: [])
+
         let result = configurationProvider!.get()
-        
+
         XCTAssertEqual(expectedConfiguration, result)
     }
-    
+
     func testReturnsEmptyConfigurationWhenRemoteConfigurationHasBeenRequestedButNotYetProcessed() {
-        let expectedConfiguration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
-        configurationProvider!.retrieveRemoteConfiguration(baseUrl: "a-url", acceptedCardBrands: ["amex", "visa"])
+        let expectedConfiguration = CardBrandsConfiguration(
+            allCardBrands: [], acceptedCardBrands: [])
+
+        configurationProvider!.retrieveRemoteConfiguration(
+            baseUrl: "a-url", acceptedCardBrands: ["amex", "visa"])
         let result = configurationProvider!.get()
-        
+
         XCTAssertTrue(factory.createCalled)
         XCTAssertEqual("a-url", factory.baseUrlPassed)
         XCTAssertEqual(["amex", "visa"], factory.acceptedBrandsPassed)
         XCTAssertEqual(expectedConfiguration, result)
     }
-    
+
     func testReturnsConfigurationWithBrandsWhenSuccessfullyProcessedRemoteConfiguration() {
-        let cardBrand = CardBrandModel(name: "a-brand", images: [],
-                                       panValidationRule: ValidationRule(matcher: "rule-1", validLengths: []),
-                                       cvcValidationRule: ValidationRule(matcher: "rule-2", validLengths: []))
-        let expectedConfiguration = CardBrandsConfiguration(allCardBrands: [cardBrand], acceptedCardBrands: ["amex", "visa"])
+        let cardBrand = CardBrandModel(
+            name: "a-brand", images: [],
+            panValidationRule: ValidationRule(matcher: "rule-1", validLengths: []),
+            cvcValidationRule: ValidationRule(matcher: "rule-2", validLengths: []))
+        let expectedConfiguration = CardBrandsConfiguration(
+            allCardBrands: [cardBrand], acceptedCardBrands: ["amex", "visa"])
         factory.willReturn(expectedConfiguration)
-        
-        configurationProvider!.retrieveRemoteConfiguration(baseUrl: "a-url", acceptedCardBrands: ["amex", "visa"])
+
+        configurationProvider!.retrieveRemoteConfiguration(
+            baseUrl: "a-url", acceptedCardBrands: ["amex", "visa"])
         let result = configurationProvider!.get()
-        
+
         XCTAssertTrue(factory.createCalled)
         XCTAssertEqual("a-url", factory.baseUrlPassed)
         XCTAssertEqual(["amex", "visa"], factory.acceptedBrandsPassed)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/CardBrandsConfigurationTests.swift
@@ -1,64 +1,71 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CardBrandsConfigurationTests: XCTestCase {
     func testReturnsCardBrandMatchingPan() {
         let cardBrandStartingWith3 = createCardBrand(panMatcherPattern: "^3\\d*?")
         let cardBrandStartingWith4 = createCardBrand(panMatcherPattern: "^4\\d*?")
-        let configuration = CardBrandsConfiguration(allCardBrands: [cardBrandStartingWith3, cardBrandStartingWith4], acceptedCardBrands: [])
-        
+        let configuration = CardBrandsConfiguration(
+            allCardBrands: [cardBrandStartingWith3, cardBrandStartingWith4], acceptedCardBrands: [])
+
         let resultForPanStartingWith3 = configuration.cardBrand(forPan: "3321")
         let resultForPanStartingWith4 = configuration.cardBrand(forPan: "4321")
-        
+
         XCTAssertEqual(cardBrandStartingWith3, resultForPanStartingWith3)
         XCTAssertEqual(cardBrandStartingWith4, resultForPanStartingWith4)
     }
-    
+
     func testReturnsNoCardBrandIfNoCardBrandsConfigured() {
         let configuration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
+
         let result = configuration.cardBrand(forPan: "1234")
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testReturnsNoCardBrandIfNoMatchingValidationRuleFound() {
         let cardBrand = createCardBrand(panMatcherPattern: "^3\\d*?")
-        let configuration = CardBrandsConfiguration(allCardBrands: [cardBrand], acceptedCardBrands: [])
-        
+        let configuration = CardBrandsConfiguration(
+            allCardBrands: [cardBrand], acceptedCardBrands: [])
+
         let result = configuration.cardBrand(forPan: "1234")
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testReturnsPanValidationRuleCorrespondingToCardBrand() {
         let expectedPanValidationRule = ValidationRule(matcher: "1234", validLengths: [1, 2])
         let cardBrand = createCardBrand(panValidationRule: expectedPanValidationRule)
         let configuration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
+
         let result = configuration.panValidationRule(using: cardBrand)
-        
+
         XCTAssertEqual(expectedPanValidationRule, result)
     }
-    
+
     func testReturnsDefaultPanValidationRuleIfCardBrandIsNil() {
         let configuration = CardBrandsConfiguration(allCardBrands: [], acceptedCardBrands: [])
-        
+
         let result = configuration.panValidationRule(using: nil)
-        
+
         XCTAssertEqual(ValidationRulesDefaults.instance().pan, result)
     }
-    
+
     private func createCardBrand(panMatcherPattern: String) -> CardBrandModel {
         let panValidationRule = ValidationRule(matcher: panMatcherPattern, validLengths: [])
         let cvcValidationRule = ValidationRule(matcher: nil, validLengths: [])
-        
-        return CardBrandModel(name: "", images: [], panValidationRule: panValidationRule, cvcValidationRule: cvcValidationRule)
+
+        return CardBrandModel(
+            name: "", images: [], panValidationRule: panValidationRule,
+            cvcValidationRule: cvcValidationRule)
     }
-    
+
     private func createCardBrand(panValidationRule: ValidationRule) -> CardBrandModel {
         let cvcValidationRule = ValidationRule(matcher: nil, validLengths: [])
-        
-        return CardBrandModel(name: "", images: [], panValidationRule: panValidationRule, cvcValidationRule: cvcValidationRule)
+
+        return CardBrandModel(
+            name: "", images: [], panValidationRule: panValidationRule,
+            cvcValidationRule: cvcValidationRule)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/ValidationRuleTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/ValidationRuleTests.swift
@@ -1,106 +1,108 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ValidationRuleTests: XCTestCase {
     // MARK: validate()
-    
+
     func testValidateReturnsFalseIfTextIsEmpty() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [16, 18])
-        
+
         XCTAssertFalse(validationRule.validate(text: ""))
     }
-    
+
     func testValidateReturnsFalseIfTextDoesNotMatchRegex() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [16, 18])
-        
+
         XCTAssertFalse(validationRule.validate(text: "abc"))
     }
-    
+
     func testValidateReturnsTrueIfTextMatchesRegexAndValidLengthsIsEmpty() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [])
-        
+
         XCTAssertTrue(validationRule.validate(text: "123"))
     }
-    
+
     func testValidateReturnsTrueIfTextMatchesRegexAndIsEqualToAValidLength() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [16, 18])
-        
+
         XCTAssertTrue(validationRule.validate(text: "4111111111111111"))
     }
-    
+
     func testValidateReturnsFalseIfTextMatchesRegexAndIsShorterThanAValidLength() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [16, 18])
-        
+
         XCTAssertFalse(validationRule.validate(text: "41111111"))
     }
-    
+
     func testValidateReturnsFalseIfMatcherIsEmptyAndTextIsEqualToAValidLength() {
         let validationRule = ValidationRule(matcher: "", validLengths: [3])
-        
+
         XCTAssertFalse(validationRule.validate(text: "123"))
     }
-    
+
     func testValidateReturnsFalseIfMatcherIsNilAndTextIsShorterThanAValidLength() {
         let validationRule = ValidationRule(matcher: nil, validLengths: [3, 4])
-        
+
         XCTAssertFalse(validationRule.validate(text: "12"))
     }
-    
+
     func testValidateReturnsTrueIfMatcherIsNilAndTextIsEqualToAValidLength() {
         let validationRule = ValidationRule(matcher: nil, validLengths: [3, 4])
-        
+
         XCTAssertTrue(validationRule.validate(text: "123"))
     }
-    
+
     // MARK: textIsMatched()
-    
-    func testTextIsMatchedReturnsTrueWhenTextIsMatchedByMatcherButNotAsLongAsOneOfTheValidLengths() {
+
+    func testTextIsMatchedReturnsTrueWhenTextIsMatchedByMatcherButNotAsLongAsOneOfTheValidLengths()
+    {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [3])
-        
+
         XCTAssertTrue(validationRule.textIsMatched("12"))
     }
-    
+
     func testTextIsMatchedReturnsFalseWhenTextIsNotMatchedByMatcher() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [3])
-        
+
         XCTAssertFalse(validationRule.textIsMatched("abc"))
     }
-    
+
     func testTextIsMatchedReturnsTrueWhenThereIsNoMatcher() {
         let validationRule = ValidationRule(matcher: nil, validLengths: [3])
-        
+
         XCTAssertTrue(validationRule.textIsMatched("12"))
     }
-    
+
     func testTextIsMatchedReturnsFalseWhenMatcherIsEmptyAndTextIsNotEmpty() {
         let validationRule = ValidationRule(matcher: "", validLengths: [3])
-        
+
         XCTAssertFalse(validationRule.textIsMatched("123"))
     }
-    
+
     // MARK: textIsShorterOrAsLongAsMaxLength()
-    
+
     func testTextIsShorterOrAsLongAsMaxLengthReturnsTrueWhenTextIsShorter() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [4, 5])
-        
+
         XCTAssertTrue(validationRule.textIsShorterOrAsLongAsMaxLength("123"))
     }
-    
+
     func testTextIsShorterOrAsLongAsMaxLengthReturnsTrueWhenTextIsAsLongAsMaxLength() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [2, 3])
-        
+
         XCTAssertTrue(validationRule.textIsShorterOrAsLongAsMaxLength("123"))
     }
-    
+
     func testTextIsShorterOrAsLongAsMaxLengthReturnsFalseWhenTextIsLongerThanMaxLength() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [3])
-        
+
         XCTAssertFalse(validationRule.textIsShorterOrAsLongAsMaxLength("1234"))
     }
-    
+
     func testTextIsShorterOrAsLongAsMaxLengthReturnsTrueWhenValidLengthsIsEmpty() {
         let validationRule = ValidationRule(matcher: "^\\d*$", validLengths: [])
-        
+
         XCTAssertTrue(validationRule.textIsShorterOrAsLongAsMaxLength("1234"))
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/ValidationRulesDefaultsTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/configuration/ValidationRulesDefaultsTests.swift
@@ -1,24 +1,25 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ValidationRulesDefaultsTests: XCTestCase {
     let defaults = ValidationRulesDefaults.instance()
-    
+
     func testPanValidationRule() {
         XCTAssertEqual("^\\d{0,19}$", defaults.pan.matcher)
         XCTAssertEqual([12, 13, 14, 15, 16, 17, 18, 19], defaults.pan.validLengths)
     }
-    
+
     func testCvcValidationRule() {
         XCTAssertEqual("^\\d{0,4}$", defaults.cvc.matcher)
         XCTAssertEqual([3, 4], defaults.cvc.validLengths)
     }
-    
+
     func testExpiryDateValidationRule() {
         XCTAssertEqual("^((0[1-9])|(1[0-2]))\\/(\\d{2})$", defaults.expiryDate.matcher)
         XCTAssertEqual([5], defaults.expiryDate.validLengths)
     }
-    
+
     func testExpiryDateInputValidationRule() {
         XCTAssertEqual("^(\\d{0,4})?\\/?(\\d{0,4})?$", defaults.expiryDateInput.matcher)
         XCTAssertEqual([5], defaults.expiryDateInput.validLengths)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/cvc/CvcValidationFlowTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/cvc/CvcValidationFlowTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcValidationFlowTests: XCTestCase {
     private let cvcValidationStateHandler = MockCvcValidationStateHandler()
@@ -14,16 +15,20 @@ class CvcValidationFlowTests: XCTestCase {
     )
 
     override func setUp() {
-        cvcValidationStateHandler.getStubbingProxy().handleCvcValidation(isValid: any()).thenDoNothing()
-        cvcValidationStateHandler.getStubbingProxy().notifyMerchantOfCvcValidationState().thenDoNothing()
+        cvcValidationStateHandler.getStubbingProxy().handleCvcValidation(isValid: any())
+            .thenDoNothing()
+        cvcValidationStateHandler.getStubbingProxy().notifyMerchantOfCvcValidationState()
+            .thenDoNothing()
     }
 
-    func testValidateValidatesCvcWithStoredValidationRuleAndCallsValidationStateHandlerWithResult() {
+    func testValidateValidatesCvcWithStoredValidationRuleAndCallsValidationStateHandlerWithResult()
+    {
         let expectedResult = false
         let cvcValidator = createMockCvcValidator(thatReturns: expectedResult)
-        let cvcValidationFlow = CvcValidationFlow(cvcValidator: cvcValidator,
-                                                  cvcValidationStateHandler: cvcValidationStateHandler,
-                                                  validationRule: cvcValidationRule)
+        let cvcValidationFlow = CvcValidationFlow(
+            cvcValidator: cvcValidator,
+            cvcValidationStateHandler: cvcValidationStateHandler,
+            validationRule: cvcValidationRule)
 
         cvcValidationFlow.validate(cvc: "123")
 
@@ -45,7 +50,8 @@ class CvcValidationFlowTests: XCTestCase {
 
         cvcValidationFlow.validate(cvc: "123")
 
-        verify(cvcValidator).validate(cvc: "123", validationRule: ValidationRulesDefaults.instance().cvc)
+        verify(cvcValidator).validate(
+            cvc: "123", validationRule: ValidationRulesDefaults.instance().cvc)
     }
 
     func testUpdateValidationRuleStoresValidationRule() {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/cvc/CvcValidatorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/cvc/CvcValidatorTests.swift
@@ -1,5 +1,6 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcValidatorTests: XCTestCase {
     private let validator = CvcValidator()
@@ -34,19 +35,22 @@ class CvcValidatorTests: XCTestCase {
     func testValidateReturnsFalseIfCvcIsThreeDigitsWithAmexPan() {
         let cardBrandWith4Digits = createCardBrand(cvcLength: 4)
 
-        XCTAssertFalse(validator.validate(cvc: "123", validationRule: cardBrandWith4Digits.cvcValidationRule))
+        XCTAssertFalse(
+            validator.validate(cvc: "123", validationRule: cardBrandWith4Digits.cvcValidationRule))
     }
 
     func testValidateReturnstrueIfCvcIsThreeDigitsWithVisaPan() {
         let cardBrandWith3Digits = createCardBrand(cvcLength: 3)
 
-        XCTAssertTrue(validator.validate(cvc: "123", validationRule: cardBrandWith3Digits.cvcValidationRule))
+        XCTAssertTrue(
+            validator.validate(cvc: "123", validationRule: cardBrandWith3Digits.cvcValidationRule))
     }
 
     func testValidateReturnsTrueIfCvcIsFourDigitsWithAmexPan() {
         let cardBrandWith4Digits = createCardBrand(cvcLength: 4)
 
-        XCTAssertTrue(validator.validate(cvc: "1234", validationRule: cardBrandWith4Digits.cvcValidationRule))
+        XCTAssertTrue(
+            validator.validate(cvc: "1234", validationRule: cardBrandWith4Digits.cvcValidationRule))
     }
 
     func testValidateReturnsFalseIfCvcIsLongerThanFourDigitsWithEmptyPan() {
@@ -56,7 +60,9 @@ class CvcValidatorTests: XCTestCase {
     func testValidateReturnsFalseIfCvcIsLongerThanFourDigitsWithAmexPan() {
         let cardBrandWith4Digits = createCardBrand(cvcLength: 4)
 
-        XCTAssertFalse(validator.validate(cvc: "12345", validationRule: cardBrandWith4Digits.cvcValidationRule))
+        XCTAssertFalse(
+            validator.validate(cvc: "12345", validationRule: cardBrandWith4Digits.cvcValidationRule)
+        )
     }
 
     // MARK: canValidate()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidationFlowTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidationFlowTests.swift
@@ -1,49 +1,55 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ExpiryDateValidationFlowTests: XCTestCase {
     func testShouldCallExpiryDateValidatorThenCallStateHandlerWithResult() {
         let expectedResult = false
-        
+
         let expiryDateValidationStateHandler = MockExpiryDateValidationStateHandler()
-        expiryDateValidationStateHandler.getStubbingProxy().handleExpiryDateValidation(isValid: any()).thenDoNothing()
+        expiryDateValidationStateHandler.getStubbingProxy().handleExpiryDateValidation(
+            isValid: any()
+        ).thenDoNothing()
         let expiryDateValidator = MockExpiryDateValidator()
         expiryDateValidator.getStubbingProxy().validate(any()).thenReturn(expectedResult)
-        
-        let expiryDateValidationFlow = ExpiryDateValidationFlow(expiryDateValidator, expiryDateValidationStateHandler)
-        
+
+        let expiryDateValidationFlow = ExpiryDateValidationFlow(
+            expiryDateValidator, expiryDateValidationStateHandler)
+
         expiryDateValidationFlow.validate(expiryDate: "12/34")
-        
+
         verify(expiryDateValidator).validate("12/34")
         verify(expiryDateValidationStateHandler).handleExpiryDateValidation(isValid: expectedResult)
     }
-    
+
     func testCanNotifyMerchant() {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().expiryDateValidChanged(isValid: any()).thenDoNothing()
         let expiryDateValidator = ExpiryDateValidator()
         let expiryDateValidationStateHandler = CardValidationStateHandler(merchantDelegate)
-        let expiryDateValidationFlow = ExpiryDateValidationFlow(expiryDateValidator, expiryDateValidationStateHandler)
-        
+        let expiryDateValidationFlow = ExpiryDateValidationFlow(
+            expiryDateValidator, expiryDateValidationStateHandler)
+
         expiryDateValidationFlow.notifyMerchant()
-        
+
         verify(merchantDelegate).expiryDateValidChanged(isValid: false)
     }
-    
+
     func testCannotNotifyMerchantIfAlreadyNotified() {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().expiryDateValidChanged(isValid: any()).thenDoNothing()
         let expiryDateValidator = ExpiryDateValidator()
         let expiryDateValidationStateHandler = CardValidationStateHandler(merchantDelegate)
-        let expiryDateValidationFlow = ExpiryDateValidationFlow(expiryDateValidator, expiryDateValidationStateHandler)
-        
+        let expiryDateValidationFlow = ExpiryDateValidationFlow(
+            expiryDateValidator, expiryDateValidationStateHandler)
+
         expiryDateValidationStateHandler.handleExpiryDateValidation(isValid: true)
         verify(merchantDelegate).expiryDateValidChanged(isValid: true)
         clearInvocations(merchantDelegate)
-        
+
         expiryDateValidationFlow.notifyMerchant()
-        
+
         verify(merchantDelegate, never()).expiryDateValidChanged(isValid: any())
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidatorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/expiryDate/ExpiryDateValidatorTests.swift
@@ -1,115 +1,118 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ExpiryDateValidatorTests: XCTestCase {
     private let expiryDateValidator = ExpiryDateValidator()
     private let targetDate = Date()
-    
+
     // MARK: validate()
-    
+
     func testValidateReturnsFalseIfEmpty() {
         XCTAssertFalse(expiryDateValidator.validate(""))
     }
-    
+
     func testValidateReturnsFalseIfMonthIsEmpty() {
         XCTAssertFalse(expiryDateValidator.validate("/34"))
     }
-    
+
     func testValidateReturnsFalseIfYearIsEmpty() {
         XCTAssertFalse(expiryDateValidator.validate("10/"))
     }
-    
+
     func testValidateReturnsFalseIfMonthIsNotANumber() {
         XCTAssertFalse(expiryDateValidator.validate("aa/34"))
     }
-    
+
     func testValidateReturnsFalseIfMonthIsGreaterThan13() {
         XCTAssertFalse(expiryDateValidator.validate("13/34"))
     }
-    
+
     func testValidateReturnsFalseIfYearIsNotANumber() {
         XCTAssertFalse(expiryDateValidator.validate("11/aa"))
     }
-    
+
     func testValidateReturnsFalseIfMonthIsOneDigit() {
         XCTAssertFalse(expiryDateValidator.validate("1/34"))
     }
-    
+
     func testValidateReturnsFalseIfYearIsOneDigit() {
         XCTAssertFalse(expiryDateValidator.validate("12/3"))
     }
-    
+
     func testValidateReturnsFalseIfDateIsInThePast() {
         XCTAssertFalse(expiryDateValidator.validate("03/20"))
     }
-    
+
     func testValidateReturnsTrueIfDateIsCurrentMonthOfCurrentYear() {
         XCTAssertTrue(expiryDateValidator.validate(expiryDateOfCurrentMonthAndYear()))
     }
-    
+
     func testValidateReturnsTrueIfDateIsInTheFuture() {
         XCTAssertTrue(expiryDateValidator.validate("03/34"))
     }
-    
+
     // MARK: canValidate
-    
+
     func testCanValidateReturnsFalseIfTextIsNonNumericalCharacters() {
         XCTAssertFalse(expiryDateValidator.canValidate("ab"))
         XCTAssertFalse(expiryDateValidator.canValidate("?&"))
-        
+
         XCTAssertFalse(expiryDateValidator.canValidate("abcd"))
         XCTAssertFalse(expiryDateValidator.canValidate("?&*%"))
-        
+
         XCTAssertFalse(expiryDateValidator.canValidate("ab/cd"))
         XCTAssertFalse(expiryDateValidator.canValidate("?&/*%"))
     }
-    
+
     func testCanValidateReturnsTrueIfTextIsDigitsOnlyAndUpTo4CharactersLong() {
         XCTAssertTrue(expiryDateValidator.canValidate("9"))
         XCTAssertTrue(expiryDateValidator.canValidate("99"))
         XCTAssertTrue(expiryDateValidator.canValidate("999"))
         XCTAssertTrue(expiryDateValidator.canValidate("9999"))
     }
-    
+
     func testCanValidateReturnsTrueIfTextIsDigitsOnlyAnd5CharactersLong() {
         XCTAssertTrue(expiryDateValidator.canValidate("99999"))
     }
-    
+
     func testCanValidateReturnsFalseIfTextIsDigitsOnlyAndLongerThan5Characters() {
         XCTAssertFalse(expiryDateValidator.canValidate("999999"))
     }
-    
-    func testCanValidateReturnsTrueIfTextContainsASlashAndAnyNumberOfDigitsOnEachSideAndUpTo5CharactersLong() {
+
+    func
+        testCanValidateReturnsTrueIfTextContainsASlashAndAnyNumberOfDigitsOnEachSideAndUpTo5CharactersLong()
+    {
         XCTAssertTrue(expiryDateValidator.canValidate("/"))
         XCTAssertTrue(expiryDateValidator.canValidate("9/"))
         XCTAssertTrue(expiryDateValidator.canValidate("9/9"))
         XCTAssertTrue(expiryDateValidator.canValidate("9/99"))
         XCTAssertTrue(expiryDateValidator.canValidate("9/999"))
-        
+
         XCTAssertTrue(expiryDateValidator.canValidate("99/"))
         XCTAssertTrue(expiryDateValidator.canValidate("99/9"))
         XCTAssertTrue(expiryDateValidator.canValidate("99/99"))
-        
+
         XCTAssertTrue(expiryDateValidator.canValidate("999/"))
         XCTAssertTrue(expiryDateValidator.canValidate("999/9"))
-        
+
         XCTAssertTrue(expiryDateValidator.canValidate("/9"))
         XCTAssertTrue(expiryDateValidator.canValidate("/99"))
         XCTAssertTrue(expiryDateValidator.canValidate("/999"))
-        
+
         XCTAssertTrue(expiryDateValidator.canValidate("9999/"))
         XCTAssertTrue(expiryDateValidator.canValidate("/9999"))
     }
-    
+
     func testCanValidateReturnsTrueIfTextIsAValidExpiryDate() {
         XCTAssertTrue(expiryDateValidator.canValidate("12/34"))
     }
-    
+
     private func expiryDateOfCurrentMonthAndYear() -> String {
         let date = Date()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM/yy"
-        
+
         return dateFormatter.string(from: date)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidatorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidatorTests.swift
@@ -1,232 +1,250 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanValidatorTests: XCTestCase {
     private let amexBrand = TestFixtures.maestroBrand()
     private let maestroBrand = TestFixtures.maestroBrand()
     private let visaBrand = TestFixtures.visaBrand()
-    
+
     private let validVisaPan = TestFixtures.validVisaPan1
     private let validVisaPanWithSpaces = TestFixtures.validVisaPan1WithSpaces
-    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures.validVisaPanAsLongAsMaxLengthAllowed
-    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures.validVisaPanAsLongAsMaxLengthAllowedWithSpaces
+    private let validVisaPanAsLongAsMaxLengthAllowed = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowed
+    private let validVisaPanAsLongAsMaxLengthAllowedWithSpaces = TestFixtures
+        .validVisaPanAsLongAsMaxLengthAllowedWithSpaces
 
     private let visaPanTooLong = TestFixtures.visaPanTooLong
     private let startOfVisaPan = "4111"
-    
-    private let configurationProvider = MockCardBrandsConfigurationProvider(CardBrandsConfigurationFactoryMock())
+
+    private let configurationProvider = MockCardBrandsConfigurationProvider(
+        CardBrandsConfigurationFactoryMock())
     private var panValidator: PanValidator?
-    
+
     override func setUp() {
         panValidator = PanValidator(configurationProvider)
     }
-    
+
     // MARK: validate()
-    
+
     func testValidate_returnsFalseAndCardBrand_whenKnownBrandPanIsShorterThanMinValidLength() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: startOfVisaPan)
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
+
     func testValidate_returnsFalseAndNilCardBrand_whenUnknownBrandPanIsShorterThanMinValidLength() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: "1234")
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertNil(result.cardBrand)
     }
-    
+
     func testValidate_returnsFalseAndCardBrand_whenKnownBrandPanHasInvalidLuhnAndValidLength() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: "4444444444444444444")
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
+
     func testValidate_returnsTrueAndCardBrand_whenKnownBrandPanHasValidLuhnAndValidLength() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: validVisaPan)
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
+
     func testValidate_returnsTrueAndNilCardBrand_whenUnknownBrandPanHasValidLuhnAndValidLength() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: "8888888888888888")
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertNil(result.cardBrand)
     }
-    
-    func testValidate_returnsTrueAndNilCardBrand_whenUnknownBrandPanHasValidLuhnAndValidLength_andSpaces() {
+
+    func
+        testValidate_returnsTrueAndNilCardBrand_whenUnknownBrandPanHasValidLuhnAndValidLength_andSpaces()
+    {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.validate(pan: "8888 88888 88 88888")
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertNil(result.cardBrand)
     }
-    
+
     func testValidate_returnsFirstVisaThenMaestro_whenVisaAndMaestroPatternsAreEntered() {
         givenConfigurationHas(brands: [visaBrand, maestroBrand])
-        
+
         var result = panValidator!.validate(pan: "49369")
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
-        
+
         result = panValidator!.validate(pan: "493698")
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "maestro")
     }
-    
+
     func testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andAcceptedBrandsIsEmpty() {
         givenConfigurationHas(brands: [amexBrand, visaBrand], acceptedBrands: [])
-        
+
         let result = panValidator!.validate(pan: validVisaPan)
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
-    func testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions() {
+
+    func
+        testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions()
+    {
         givenConfigurationHas(brands: [amexBrand, visaBrand], acceptedBrands: ["amex", "visa"])
-        
+
         let result = panValidator!.validate(pan: validVisaPan)
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
-    func testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions_andThereAreSpaces() {
+
+    func
+        testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions_andThereAreSpaces()
+    {
         givenConfigurationHas(brands: [amexBrand, visaBrand], acceptedBrands: ["amex", "visa"])
-        
+
         let result = panValidator!.validate(pan: validVisaPanWithSpaces)
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
-    func testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions_independentlyOfCase() {
+
+    func
+        testValidate_returnsTrueAndCardBrand_whenKnownBrandPanIsValid_andBrandIsPartOfMerchantRestrictions_independentlyOfCase()
+    {
         givenConfigurationHas(brands: [visaBrand], acceptedBrands: ["VisA"])
-        
+
         let result = panValidator!.validate(pan: validVisaPan)
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
-    func testValidate_returnsFalseAndCardBrand_whenKnownBrandPanIsValid_andBrandIsNOTPartOfMerchantRestrictions() {
-        givenConfigurationHas(brands: [amexBrand, maestroBrand, visaBrand], acceptedBrands: ["amex", "maestro"])
-        
+
+    func
+        testValidate_returnsFalseAndCardBrand_whenKnownBrandPanIsValid_andBrandIsNOTPartOfMerchantRestrictions()
+    {
+        givenConfigurationHas(
+            brands: [amexBrand, maestroBrand, visaBrand], acceptedBrands: ["amex", "maestro"])
+
         let result = panValidator!.validate(pan: validVisaPan)
-        
+
         XCTAssertFalse(result.isValid)
         XCTAssertEqual(result.cardBrand?.name, "visa")
     }
-    
-    func testValidate_returnsTrue_whenUnknownBrandPanIsValid_andConfigHasRestrictionOnAcceptedBrands() {
+
+    func
+        testValidate_returnsTrue_whenUnknownBrandPanIsValid_andConfigHasRestrictionOnAcceptedBrands()
+    {
         givenConfigurationHas(brands: [visaBrand], acceptedBrands: ["visa"])
-        
+
         let result = panValidator!.validate(pan: "8888888888888888")
-        
+
         XCTAssertTrue(result.isValid)
         XCTAssertNil(result.cardBrand)
     }
-    
+
     // MARK: canValidate()
-    
+
     func testCanValidateAllowsPanMatchingPatternAndShorterThanMaxLengthForABrand() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.canValidate("49369")
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateAllowsPanAsLongAsMaxLengthForABrand() {
         givenConfigurationHas(brands: [visaBrand])
         let panWith19Digits = validVisaPanAsLongAsMaxLengthAllowed
-        
+
         let result = panValidator!.canValidate(panWith19Digits)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateAllowsPanAsLongAsMaxLengthForABrandWithSpaces() {
         givenConfigurationHas(brands: [visaBrand])
         let panWith19DigitsPlusSpaces = validVisaPanAsLongAsMaxLengthAllowedWithSpaces
-        
+
         let result = panValidator!.canValidate(panWith19DigitsPlusSpaces)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateDoesNotAllowPanLongerThanMaxLengthForABrand() {
         givenConfigurationHas(brands: [visaBrand])
         let panWith20Digits = visaPanTooLong
-        
+
         let result = panValidator!.canValidate(panWith20Digits)
-        
+
         XCTAssertFalse(result)
     }
-    
+
     func testCanValidateAllowsPanMatchingPatternAndShorterThanMaxLengthForUnknownBrand() {
         givenConfigurationHas(brands: [])
-        
+
         let result = panValidator!.canValidate("12345")
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateAllowsPanAsLongAsMaxLengthForUnknownBrand() {
         givenConfigurationHas(brands: [])
         let panWith19Digits = "1234567890123456789"
-        
+
         let result = panValidator!.canValidate(panWith19Digits)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateAllowsPanAsLongAsMaxLengthWithSpacesTrimmedForUnknownBrand() {
         givenConfigurationHas(brands: [])
         let panWith19Digits = "1234 5678 0123 4567 89"
-        
+
         let result = panValidator!.canValidate(panWith19Digits)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanValidateDoesNotAllowPanLongerThanMaxLengthForUnknownBrand() {
         givenConfigurationHas(brands: [])
         let panWith20Digits = "12345678901234567890"
-        
+
         let result = panValidator!.canValidate(panWith20Digits)
-        
+
         XCTAssertFalse(result)
     }
-    
+
     func testCanValidateDoesNotAllowPanThatDoesNotMatchAnyBrandAndDoesNotMatchDefaultPattern() {
         givenConfigurationHas(brands: [visaBrand])
-        
+
         let result = panValidator!.canValidate("abc")
-        
+
         XCTAssertFalse(result)
     }
-    
+
     private func givenConfigurationHas(brands: [CardBrandModel], acceptedBrands: [String] = []) {
-        configurationProvider.getStubbingProxy().get().thenReturn(CardBrandsConfiguration(allCardBrands: brands, acceptedCardBrands: acceptedBrands))
+        configurationProvider.getStubbingProxy().get().thenReturn(
+            CardBrandsConfiguration(allCardBrands: brands, acceptedCardBrands: acceptedBrands))
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -6,19 +6,19 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
     // MARK: constructors tests
     func testCGRectConstructorInitialiasesTextFieldWithDefaultStyles() {
         let textField = AccessCheckoutUITextField(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        
+
         // UITextField is initialised in subview
         XCTAssertNotNil(textField.subviews[0])
-        
+
         // Styles set on the view itself
         XCTAssertEqual(5, textField.layer.cornerRadius)
         XCTAssertTrue(colorsAreEqual(UIColor(cgColor: textField.layer.borderColor!), AccessCheckoutUITextField.defaults.borderColor))
         XCTAssertEqual(1, textField.layer.borderWidth)
-        
+
         // Styles set on the uiTextField
         XCTAssertEqual(UIKeyboardType.asciiCapableNumberPad.rawValue, textField.uiTextField.keyboardType.rawValue)
     }
-    
+
     func testDefaultConstructorInitialiasesTextFieldWithDefaultStyles() {
         let textField = AccessCheckoutUITextField(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
         // UITextField is initialised in subview
@@ -27,14 +27,14 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(5, textField.layer.cornerRadius)
         XCTAssertTrue(colorsAreEqual(UIColor(cgColor: textField.layer.borderColor!), AccessCheckoutUITextField.defaults.borderColor))
         XCTAssertEqual(1, textField.layer.borderWidth)
-        
+
         // Styles set on the uiTextField
         XCTAssertEqual(UIKeyboardType.asciiCapableNumberPad.rawValue, textField.uiTextField.keyboardType.rawValue)
     }
-    
+
     func testCGRectConstructorPositionsInternalTextFieldUsingConstraints() {
         let textField = AccessCheckoutUITextField(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
-        
+
         XCTAssertEqual(4, textField.constraints.count)
 
         assertConstraints(textField,
@@ -43,10 +43,10 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
                           leading: AccessCheckoutUITextField.defaults.horizontalPadding,
                           trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
     }
-    
+
     func testDefaultConstructorPositionsInternalTextFieldUsingConstraints() {
         let textField = AccessCheckoutUITextField()
-        
+
         XCTAssertEqual(4, textField.constraints.count)
 
         assertConstraints(textField,
@@ -55,7 +55,7 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
                           leading: AccessCheckoutUITextField.defaults.horizontalPadding,
                           trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
     }
-    
+
     // MARK: default styles values
 
     func testDefaultStylesValues() {
@@ -69,9 +69,9 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(AccessCheckoutUITextField.defaults.keyboardAppearance, .default)
         XCTAssertEqual(AccessCheckoutUITextField.defaults.horizontalPadding, 6)
     }
-    
+
     // MARK: interface builder support
-    
+
     func testPrepareForInterfaceBuilderSetsStyles() {
         let textField = AccessCheckoutUITextField(frame: CGRect())
         textField.cornerRadius = 10
@@ -80,534 +80,559 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         textField.keyboardType = .namePhonePad
         textField.placeholder = "some placeholder"
         textField.textColor = UIColor.yellow
-        
+
         textField.prepareForInterfaceBuilder()
-        
+
         // Styles set on the view itself
         XCTAssertEqual(10, textField.layer.cornerRadius)
         XCTAssertEqual(UIColor.green.cgColor, textField.layer.borderColor)
         XCTAssertEqual(2, textField.layer.borderWidth)
-        
+
         // Styles set on the uiTextField
         XCTAssertEqual(UIKeyboardType.namePhonePad.rawValue, textField.uiTextField.keyboardType.rawValue)
         XCTAssertEqual("some placeholder", textField.uiTextField.placeholder)
         XCTAssertEqual(UIColor.yellow, textField.uiTextField.textColor)
     }
-    
+
     // MARK: Accessibility properties tests
-    
+
     // isAccessibilityElement
     func testIsAccessibilityElementGetterAlwaysReturnsFalse() {
         let textField = createTextField()
         XCTAssertFalse(textField.isAccessibilityElement)
-        
+
         textField.isAccessibilityElement = true
         XCTAssertFalse(textField.isAccessibilityElement)
     }
-    
+
     func testIsAccessibilityElementSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         XCTAssertFalse(textField.uiTextField.isAccessibilityElement)
-        
+
         textField.isAccessibilityElement = true
         XCTAssertTrue(textField.uiTextField.isAccessibilityElement)
     }
-    
+
     // accessibilityHint
     func testAccessibilityHintGetterAlwaysReturnsNil() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityHint)
-        
+
         textField.accessibilityHint = "something"
         XCTAssertNil(textField.accessibilityHint)
     }
-    
+
     func testAccessibilityHintSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         XCTAssertNil(textField.uiTextField.accessibilityHint)
-        
+
         textField.accessibilityHint = "something"
         XCTAssertEqual("something", textField.uiTextField.accessibilityHint)
     }
-    
+
     // accessibilityIdentifier
     func testAccessibilityIdentifierGetterReturnsId() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityIdentifier)
-        
+
         textField.accessibilityIdentifier = "something"
         XCTAssertEqual("something", textField.accessibilityIdentifier)
     }
-    
+
     func testAccessibilityIdentifierSetterSetsIdAndUITextFieldIdUsingANamingConvention() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityIdentifier)
-        
+
         textField.accessibilityIdentifier = "something"
         XCTAssertEqual("something", textField.accessibilityIdentifier)
         XCTAssertEqual("something-UITextField", textField.uiTextField.accessibilityIdentifier)
     }
-    
+
     // accessibilityLabel
     func testAccessibilityLabelGetterAlwaysReturnsNil() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityLabel)
-        
+
         textField.accessibilityLabel = "something"
         XCTAssertNil(textField.accessibilityLabel)
     }
-    
+
     func testAccessibilityLabelSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         XCTAssertNil(textField.uiTextField.accessibilityLabel)
-        
+
         textField.accessibilityLabel = "something"
         XCTAssertEqual("something", textField.uiTextField.accessibilityLabel)
     }
-    
+
     // accessibilityLanguage
     func testAccessibilityLanguageGetterAlwaysReturnsNil() {
         let textField = createTextField()
         XCTAssertNil(textField.accessibilityLanguage)
-        
+
         textField.accessibilityLabel = "something"
         XCTAssertNil(textField.accessibilityLanguage)
     }
-    
+
     func testAccessibilityLanguageSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         XCTAssertNil(textField.uiTextField.accessibilityLanguage)
-        
+
         textField.accessibilityLanguage = "something"
         XCTAssertEqual("something", textField.uiTextField.accessibilityLanguage)
     }
-    
+
     // MARK: Padding properties tests
-    
+
     // horizontalPadding
     func testHorizontalPaddingModifiesTheLayoutAccordingly() {
         let textField = createTextField()
-        
+
         // Asserts padding is default padding to start with
         assertConstraints(textField,
                           top: AccessCheckoutUITextField.defaults.verticalPadding,
                           bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
                           leading: AccessCheckoutUITextField.defaults.horizontalPadding,
                           trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
-        
+
         textField.horizontalPadding = 20
-        
+
         assertConstraints(textField,
                           top: AccessCheckoutUITextField.defaults.verticalPadding,
                           bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
                           leading: 20,
                           trailing: -20)
     }
-    
+
     // MARK: Border properties tests
-    
+
     // cornerRadius
     func testCornerRadiusIs5ByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertEqual(5, textField.cornerRadius)
     }
-    
+
     func testCornerRadiusGetterReturnsValueSet() {
         let textField = createTextField()
         let expected: CGFloat = 3
-        
+
         textField.cornerRadius = expected
-        
+
         XCTAssertEqual(expected, textField.cornerRadius)
     }
-    
+
     func testCornerRadiusSetterSetsLayerProperty() {
         let textField = createTextField()
         let expected: CGFloat = 3
-        
+
         textField.cornerRadius = expected
-        
+
         XCTAssertEqual(expected, textField.layer.cornerRadius)
     }
-    
+
     // borderWidth
     func testBorderWidthIs0Point15ByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertEqual(1.0, textField.borderWidth)
     }
-    
+
     func testBorderWidthGetterReturnsValueSet() {
         let textField = createTextField()
         let expected: CGFloat = 3
-        
+
         textField.borderWidth = expected
-        
+
         XCTAssertEqual(expected, textField.borderWidth)
     }
-    
+
     func testBorderWidthSetterSetsLayerProperty() {
         let textField = createTextField()
         let expected: CGFloat = 3
-        
+
         textField.borderWidth = expected
-        
+
         XCTAssertEqual(expected, textField.layer.borderWidth)
     }
-    
+
     // borderColor
     func testBorderColorHasADefaultValue() {
         let textField = createTextField()
-        
+
         XCTAssertTrue(colorsAreEqual(textField.borderColor, AccessCheckoutUITextField.defaults.borderColor))
     }
-    
+
     func testBorderColorGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = UIColor.green
-        
+
         textField.borderColor = expected
-        
+
         XCTAssertEqual(expected, textField.borderColor)
     }
-    
+
     func testBorderColorSetterSetsLayerProperty() {
         let textField = createTextField()
         let expected = UIColor.green
-        
+
         textField.borderColor = expected
-        
+
         XCTAssertEqual(expected.cgColor, textField.layer.borderColor)
     }
-    
+
     // MARK: Text properties
-    
+
     // textColor
     func testTextColorIsNilByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertNil(textField.textColor)
     }
-    
+
     func testTextColorGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = UIColor.green
-        
+
         textField.textColor = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.textColor)
     }
-    
+
     func testTextColorSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = UIColor.green
-        
+
         textField.textColor = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.textColor)
     }
-    
+
     // font
     func testFontGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = UIFont.preferredFont(forTextStyle: .body)
-        
+
         textField.font = expected
-        
+
         XCTAssertEqual(expected, textField.font)
     }
-    
+
     func testFontSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = UIFont.boldSystemFont(ofSize: 3)
-        
+
         textField.font = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.font)
     }
-    
+
     // textAlignment
     func testTextAlignmentIsLeftByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertEqual(NSTextAlignment.left, textField.textAlignment)
     }
-    
+
     func testTextAlignmentGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = NSTextAlignment.right
-        
+
         textField.textAlignment = expected
-        
+
         XCTAssertEqual(expected, textField.textAlignment)
     }
-    
+
     func testTextAlignmentSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = NSTextAlignment.right
-        
+
         textField.textAlignment = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.textAlignment)
     }
-    
-    
+
+
     // MARK: Placeholder properties
-    
+
     // textAlignment
     func testPlacholderIsNilByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertNil(textField.placeholder)
     }
-    
+
     func testPlacholderGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = "something"
-        
+
         textField.placeholder = expected
-        
+
         XCTAssertEqual(expected, textField.placeholder)
     }
-    
+
     func testPlacholderSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = "something"
-        
+
         textField.placeholder = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.placeholder)
     }
-    
+
     // attributedPlacholder
     func testAttributedPlacholderIsNilByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertNil(textField.attributedPlaceholder)
     }
-    
+
     func testAttributedPlacholderGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = NSAttributedString(string: "something")
-        
+
         textField.attributedPlaceholder = expected
-        
+
         XCTAssertEqual(expected, textField.attributedPlaceholder)
     }
-    
+
     func testAttributedPlacholderSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = NSAttributedString(string: "something")
-        
+
         textField.attributedPlaceholder = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.attributedPlaceholder)
     }
-    
+
     // MARK: keyboard properties
-    
+
     // keyboardType
     func testKeyboardTypeIsDefaultByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertEqual(UIKeyboardType.asciiCapableNumberPad, textField.keyboardType)
     }
-    
+
     func testKeyboardTypeGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = UIKeyboardType.namePhonePad
-        
+
         textField.keyboardType = expected
-        
+
         XCTAssertEqual(expected, textField.keyboardType)
     }
-    
+
     func testKeyboardTypeSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = UIKeyboardType.namePhonePad
-        
+
         textField.keyboardType = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.keyboardType)
     }
-    
+
     // keyboardAppearance
     func testKeyboardAppearanceIsDefaultByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertEqual(UIKeyboardAppearance.default, textField.keyboardAppearance)
     }
-    
+
     func testKeyboardAppearanceGetterReturnsValueSet() {
         let textField = createTextField()
         let expected = UIKeyboardAppearance.dark
-        
+
         textField.keyboardAppearance = expected
-        
+
         XCTAssertEqual(expected, textField.keyboardAppearance)
     }
-    
+
     func testKeyboardAppearanceSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = UIKeyboardAppearance.dark
-        
+
         textField.keyboardAppearance = expected
-        
+
         XCTAssertEqual(expected, textField.uiTextField.keyboardAppearance)
     }
-    
+
     func testtextContentTypeByDefaultIsNil() {
         let textField = createTextField()
         XCTAssertEqual(nil , textField.uiTextField.textContentType)
     }
-    
+
     func testtextContentTypeSetterSetsUITextFieldProperty() {
         let textField = createTextField()
 
         textField.textContentType = UITextContentType.creditCardNumber
-    
+
         XCTAssertEqual(UITextContentType.creditCardNumber, textField.uiTextField.textContentType)
     }
-    
+
+    // inputAccessoryView (used to customise the keyboard displayed when the component receives the focus)
+    func testInputAccessoryViewIsNilByDefault() {
+        let textField = createTextField()
+
+        XCTAssertNil(textField.inputAccessoryView)
+    }
+
+    func testInputAccessoryViewGetterReturnsValueSet() {
+        let textField = createTextField()
+        let expected = UILabel()
+
+        textField.inputAccessoryView = expected
+
+        XCTAssertEqual(expected, textField.inputAccessoryView)
+    }
+
+    func testInputAccessoryViewSetterSetsUITextFieldProperty() {
+        let textField = createTextField()
+        let expected = UILabel()
+
+        textField.inputAccessoryView = expected
+
+        XCTAssertEqual(expected, textField.uiTextField.inputAccessoryView)
+    }
+
     // MARK: enabled properties
-    
+
     func testIsEnabledIsTrueByDefault() {
         let textField = createTextField()
-        
+
         XCTAssertTrue(textField.isEnabled)
     }
-    
+
     func testIsEnabledSetterSetsIsEnabledProperty() {
         let textField = createTextField()
-        
+
         textField.isEnabled = false
         XCTAssertFalse(textField.isEnabled)
     }
-    
+
     func testIsEnabled_whenToggled_changesBackgroundColor_whenBackgroundColorIsDefault() {
         let textField = createTextField()
         textField.backgroundColor = AccessCheckoutUITextField.defaults.backgroundColor
 
         textField.isEnabled = false
         XCTAssertTrue(colorsAreEqual(textField.backgroundColor, AccessCheckoutUITextField.defaults.disabledBackgroundColor))
-        
+
         textField.isEnabled = true
         XCTAssertTrue(colorsAreEqual(textField.backgroundColor, AccessCheckoutUITextField.defaults.backgroundColor))
     }
-    
+
     func testIsEnabled_whenToggled_doesNotChangeBackgroundColor_wWhenBackgroundColorIsNotDefault() {
         let textField = createTextField()
         textField.backgroundColor = UIColor.red
 
         textField.isEnabled = false
         XCTAssertTrue(colorsAreEqual(textField.backgroundColor, UIColor.red))
-        
+
         textField.isEnabled = true
         XCTAssertTrue(colorsAreEqual(textField.backgroundColor, UIColor.red))
-        
+
         textField.isEnabled = false
         XCTAssertTrue(colorsAreEqual(textField.backgroundColor, UIColor.red))
     }
-    
+
     // MARK: methods properties
-    
+
     func testClearClearsUITextFieldText_andDispatchesAnEditingChangedEvent() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
         textField.uiTextField.text = "something"
         XCTAssertEqual("something", textField.uiTextField.text)
-        
+
         textField.clear()
-        
+
         XCTAssertEqual("", textField.uiTextField.text)
         XCTAssertTrue(uiTextFieldMock.sendActionsCalled)
         XCTAssertEqual(.editingChanged, uiTextFieldMock.sendActionsEvents)
     }
-    
+
     func testBecomeFirstResponderDelegatesCallToUITextField() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         _ = textField.becomeFirstResponder()
-        
+
         XCTAssertTrue(uiTextFieldMock.becomeFirstResponderCalled)
     }
-    
+
     func testSetOnFocusChangedListenerAssignsValueToVariable() {
         let textField = AccessCheckoutUITextField()
-    
+
         XCTAssertNil(textField.externalOnFocusChangeListener)
 
         //Set
         textField.setOnFocusChangedListener{view, isFocused in
             //do something
         }
-        
+
         XCTAssertNotNil(textField.externalOnFocusChangeListener)
     }
-    
+
     func testSetOnFocusChangedListener() {
         let uiTextFieldMock = UITextFieldMock()
         let textField = AccessCheckoutUITextField(uiTextFieldMock)
-        
+
         _ = textField.resignFirstResponder()
-        
+
         XCTAssertTrue(uiTextFieldMock.resignFirstResponderCalled)
     }
-    
-    
+
+
     // MARK: Internal properties
-    
+
     // text
     func testTextGetterReturnsUITextFieldText() {
         let textField = createTextField()
         let expected = "something"
         XCTAssertEqual("", textField.uiTextField.text)
-        
+
         textField.uiTextField.text = expected
-        
+
         XCTAssertEqual(expected, textField.text)
     }
-    
+
     func testTextSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = "something"
-        
+
         textField.text = expected
-        
+
         XCTAssertEqual(expected, textField.text)
     }
-    
+
     // delegate
     func testDelegateGetterReturnsUITextFieldDelegate() {
         let textField = createTextField()
         let expected = UITextFieldDelegateMock()
         textField.uiTextField.delegate = expected
-        
+
         XCTAssertTrue(textField.delegate === expected)
     }
-    
+
     func testDelegateSetterSetsUITextFieldProperty() {
         let textField = createTextField()
         let expected = UITextFieldDelegateMock()
-        
+
         textField.delegate = expected
-        
+
         XCTAssertTrue(textField.delegate === expected)
     }
-    
+
     private func createTextField() -> AccessCheckoutUITextField {
         return AccessCheckoutUITextField()
     }
-    
+
     private func toUIColor(hexadecimal: Int) -> UIColor {
         let red = Double((hexadecimal & 0xFF0000) >> 16) / 255.0
         let green = Double((hexadecimal & 0xFF00) >> 8) / 255.0
         let blue = Double(hexadecimal & 0xFF) / 255.0
         return UIColor(red: CGFloat(red), green: CGFloat(green), blue: CGFloat(blue), alpha: 1.0)
     }
-    
+
     private func colorsAreEqual(_ color1: UIColor?, _ color2: UIColor?) -> Bool {
         if color1 == nil && color2 == nil {
             return true
@@ -616,25 +641,25 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         } else if color2 == nil {
             return false
         }
-        
+
         var lhsR: CGFloat = 0
         var lhsG: CGFloat = 0
         var lhsB: CGFloat = 0
         var lhsA: CGFloat = 0
         color1!.getRed(&lhsR, green: &lhsG, blue: &lhsB, alpha: &lhsA)
-        
+
         var rhsR: CGFloat = 0
         var rhsG: CGFloat = 0
         var rhsB: CGFloat = 0
         var rhsA: CGFloat = 0
         color2!.getRed(&rhsR, green: &rhsG, blue: &rhsB, alpha: &rhsA)
-        
+
         return lhsR == rhsR
             && lhsG == rhsG
             && lhsB == rhsB
             && lhsA == rhsA
     }
-    
+
     private func assertConstraints(_ textField:AccessCheckoutUITextField,
                                           top:CGFloat, bottom:CGFloat, leading:CGFloat, trailing:CGFloat) {
         XCTAssertEqual(4, textField.constraints.count)
@@ -645,21 +670,21 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(topConstraint.secondItem as? AccessCheckoutUITextField, textField)
         XCTAssertEqual(topConstraint.secondAnchor, textField.topAnchor)
         XCTAssertEqual(topConstraint.constant, top)
-        
+
         let bottomConstraint = textField.constraints[1]
         XCTAssertEqual(bottomConstraint.firstItem as? UITextField, textField.uiTextField)
         XCTAssertEqual(bottomConstraint.firstAnchor, textField.uiTextField.bottomAnchor)
         XCTAssertEqual(bottomConstraint.secondItem as? AccessCheckoutUITextField, textField)
         XCTAssertEqual(bottomConstraint.secondAnchor, textField.bottomAnchor)
         XCTAssertEqual(bottomConstraint.constant, bottom)
-        
+
         let leadingConstraint = textField.constraints[2]
         XCTAssertEqual(leadingConstraint.firstItem as? UITextField, textField.uiTextField)
         XCTAssertEqual(leadingConstraint.firstAnchor, textField.uiTextField.leadingAnchor)
         XCTAssertEqual(leadingConstraint.secondItem as? AccessCheckoutUITextField, textField)
         XCTAssertEqual(leadingConstraint.secondAnchor, textField.leadingAnchor)
         XCTAssertEqual(leadingConstraint.constant, leading)
-        
+
         let trailingConstraint = textField.constraints[3]
         XCTAssertEqual(trailingConstraint.firstItem as? UITextField, textField.uiTextField)
         XCTAssertEqual(trailingConstraint.firstAnchor, textField.uiTextField.trailingAnchor)
@@ -673,7 +698,7 @@ private class UITextFieldDelegateMock: NSObject {}
 
 extension UITextFieldDelegateMock: UITextFieldDelegate {
     public func textFieldDidEndEditing(_ textField: UITextField) {}
-    
+
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return false
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Foundation
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class AccessCheckoutUITextFieldTests: XCTestCase {
     // MARK: constructors tests
@@ -12,11 +13,16 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         // Styles set on the view itself
         XCTAssertEqual(5, textField.layer.cornerRadius)
-        XCTAssertTrue(colorsAreEqual(UIColor(cgColor: textField.layer.borderColor!), AccessCheckoutUITextField.defaults.borderColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                UIColor(cgColor: textField.layer.borderColor!),
+                AccessCheckoutUITextField.defaults.borderColor))
         XCTAssertEqual(1, textField.layer.borderWidth)
 
         // Styles set on the uiTextField
-        XCTAssertEqual(UIKeyboardType.asciiCapableNumberPad.rawValue, textField.uiTextField.keyboardType.rawValue)
+        XCTAssertEqual(
+            UIKeyboardType.asciiCapableNumberPad.rawValue,
+            textField.uiTextField.keyboardType.rawValue)
     }
 
     func testDefaultConstructorInitialiasesTextFieldWithDefaultStyles() {
@@ -25,11 +31,16 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertNotNil(textField.subviews[0])
         // Styles set on the view itself
         XCTAssertEqual(5, textField.layer.cornerRadius)
-        XCTAssertTrue(colorsAreEqual(UIColor(cgColor: textField.layer.borderColor!), AccessCheckoutUITextField.defaults.borderColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                UIColor(cgColor: textField.layer.borderColor!),
+                AccessCheckoutUITextField.defaults.borderColor))
         XCTAssertEqual(1, textField.layer.borderWidth)
 
         // Styles set on the uiTextField
-        XCTAssertEqual(UIKeyboardType.asciiCapableNumberPad.rawValue, textField.uiTextField.keyboardType.rawValue)
+        XCTAssertEqual(
+            UIKeyboardType.asciiCapableNumberPad.rawValue,
+            textField.uiTextField.keyboardType.rawValue)
     }
 
     func testCGRectConstructorPositionsInternalTextFieldUsingConstraints() {
@@ -37,11 +48,12 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         XCTAssertEqual(4, textField.constraints.count)
 
-        assertConstraints(textField,
-                          top: AccessCheckoutUITextField.defaults.verticalPadding,
-                          bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-                          leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-                          trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+        assertConstraints(
+            textField,
+            top: AccessCheckoutUITextField.defaults.verticalPadding,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
+            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
+            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
     }
 
     func testDefaultConstructorPositionsInternalTextFieldUsingConstraints() {
@@ -49,19 +61,25 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         XCTAssertEqual(4, textField.constraints.count)
 
-        assertConstraints(textField,
-                          top: AccessCheckoutUITextField.defaults.verticalPadding,
-                          bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-                          leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-                          trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+        assertConstraints(
+            textField,
+            top: AccessCheckoutUITextField.defaults.verticalPadding,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
+            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
+            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
     }
 
     // MARK: default styles values
 
     func testDefaultStylesValues() {
         XCTAssertTrue(colorsAreEqual(.white, AccessCheckoutUITextField.defaults.backgroundColor))
-        XCTAssertTrue(colorsAreEqual(toUIColor(hexadecimal: 0xFBFBFB), AccessCheckoutUITextField.defaults.disabledBackgroundColor))
-        XCTAssertTrue(colorsAreEqual(toUIColor(hexadecimal: 0xE9E9E9), AccessCheckoutUITextField.defaults.borderColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                toUIColor(hexadecimal: 0xFBFBFB),
+                AccessCheckoutUITextField.defaults.disabledBackgroundColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                toUIColor(hexadecimal: 0xE9E9E9), AccessCheckoutUITextField.defaults.borderColor))
         XCTAssertEqual(AccessCheckoutUITextField.defaults.borderWidth, 1)
         XCTAssertEqual(AccessCheckoutUITextField.defaults.cornerRadius, 5)
         XCTAssertEqual(AccessCheckoutUITextField.defaults.textAlignment, .left)
@@ -89,7 +107,8 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertEqual(2, textField.layer.borderWidth)
 
         // Styles set on the uiTextField
-        XCTAssertEqual(UIKeyboardType.namePhonePad.rawValue, textField.uiTextField.keyboardType.rawValue)
+        XCTAssertEqual(
+            UIKeyboardType.namePhonePad.rawValue, textField.uiTextField.keyboardType.rawValue)
         XCTAssertEqual("some placeholder", textField.uiTextField.placeholder)
         XCTAssertEqual(UIColor.yellow, textField.uiTextField.textColor)
     }
@@ -189,19 +208,21 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         let textField = createTextField()
 
         // Asserts padding is default padding to start with
-        assertConstraints(textField,
-                          top: AccessCheckoutUITextField.defaults.verticalPadding,
-                          bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-                          leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-                          trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+        assertConstraints(
+            textField,
+            top: AccessCheckoutUITextField.defaults.verticalPadding,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
+            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
+            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
 
         textField.horizontalPadding = 20
 
-        assertConstraints(textField,
-                          top: AccessCheckoutUITextField.defaults.verticalPadding,
-                          bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-                          leading: 20,
-                          trailing: -20)
+        assertConstraints(
+            textField,
+            top: AccessCheckoutUITextField.defaults.verticalPadding,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
+            leading: 20,
+            trailing: -20)
     }
 
     // MARK: Border properties tests
@@ -260,7 +281,8 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
     func testBorderColorHasADefaultValue() {
         let textField = createTextField()
 
-        XCTAssertTrue(colorsAreEqual(textField.borderColor, AccessCheckoutUITextField.defaults.borderColor))
+        XCTAssertTrue(
+            colorsAreEqual(textField.borderColor, AccessCheckoutUITextField.defaults.borderColor))
     }
 
     func testBorderColorGetterReturnsValueSet() {
@@ -351,7 +373,6 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         XCTAssertEqual(expected, textField.uiTextField.textAlignment)
     }
-
 
     // MARK: Placeholder properties
 
@@ -459,7 +480,7 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
     func testtextContentTypeByDefaultIsNil() {
         let textField = createTextField()
-        XCTAssertEqual(nil , textField.uiTextField.textContentType)
+        XCTAssertEqual(nil, textField.uiTextField.textContentType)
     }
 
     func testtextContentTypeSetterSetsUITextFieldProperty() {
@@ -515,10 +536,15 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         textField.backgroundColor = AccessCheckoutUITextField.defaults.backgroundColor
 
         textField.isEnabled = false
-        XCTAssertTrue(colorsAreEqual(textField.backgroundColor, AccessCheckoutUITextField.defaults.disabledBackgroundColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                textField.backgroundColor,
+                AccessCheckoutUITextField.defaults.disabledBackgroundColor))
 
         textField.isEnabled = true
-        XCTAssertTrue(colorsAreEqual(textField.backgroundColor, AccessCheckoutUITextField.defaults.backgroundColor))
+        XCTAssertTrue(
+            colorsAreEqual(
+                textField.backgroundColor, AccessCheckoutUITextField.defaults.backgroundColor))
     }
 
     func testIsEnabled_whenToggled_doesNotChangeBackgroundColor_wWhenBackgroundColorIsNotDefault() {
@@ -565,7 +591,7 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
         XCTAssertNil(textField.externalOnFocusChangeListener)
 
         //Set
-        textField.setOnFocusChangedListener{view, isFocused in
+        textField.setOnFocusChangedListener { view, isFocused in
             //do something
         }
 
@@ -580,7 +606,6 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         XCTAssertTrue(uiTextFieldMock.resignFirstResponderCalled)
     }
-
 
     // MARK: Internal properties
 
@@ -660,8 +685,10 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
             && lhsA == rhsA
     }
 
-    private func assertConstraints(_ textField:AccessCheckoutUITextField,
-                                          top:CGFloat, bottom:CGFloat, leading:CGFloat, trailing:CGFloat) {
+    private func assertConstraints(
+        _ textField: AccessCheckoutUITextField,
+        top: CGFloat, bottom: CGFloat, leading: CGFloat, trailing: CGFloat
+    ) {
         XCTAssertEqual(4, textField.constraints.count)
 
         let topConstraint = textField.constraints[0]
@@ -699,7 +726,10 @@ private class UITextFieldDelegateMock: NSObject {}
 extension UITextFieldDelegateMock: UITextFieldDelegate {
     public func textFieldDidEndEditing(_ textField: UITextField) {}
 
-    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    public func textField(
+        _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
         return false
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/components/CVVViewTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/components/CVVViewTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcViewTests: XCTestCase {
     private let brandsStartingWith4AndCvv2DigitsLong = TextFixtures.createCardBrandModel(
@@ -9,148 +10,163 @@ class CvcViewTests: XCTestCase {
         panValidLengths: [16],
         cvcValidLength: 2
     )
-    
+
     private let cvvView = CvcView()
     private let panView = PANView()
-    
+
     // MARK: testing what the end user can and cannot type
     func testCanEnterAnyTextWhenNoPresenter() {
         XCTAssertTrue(type("abc", into: cvvView))
     }
-    
+
     func testCanClearText() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
         XCTAssertTrue(type("", into: cvvView))
     }
-    
+
     func testCannotTypeNonNumericalCharactersForUnknownBrand() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
-        
+
         XCTAssertFalse(type("abc", into: cvvView))
         XCTAssertFalse(type("+*-", into: cvvView))
     }
-    
+
     func testCanTypePartialCvvForUnknownBrand() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
-        
+
         let result = type("12", into: cvvView)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanTypeCvvAsLongAsMinLengthForUnknownBrand() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
-        
+
         let result = type("123", into: cvvView)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanTypeCvvAsLongAsMaxLengthForUnknownBrand() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
-        
+
         let result = type("1234", into: cvvView)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCannotTypeCvvThatExceedsMaximiumLengthForUnknownBrand() {
         initialiseValidation(cardBrands: [], cvvView: cvvView, panView: panView)
-        
+
         let result = type("12345", into: cvvView)
-        
+
         XCTAssertFalse(result)
     }
-    
+
     func testCannotTypeNonNumericalCharactersForABrand() {
-        initialiseValidation(cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
+        initialiseValidation(
+            cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
         type("4111111", into: panView)
-        
+
         XCTAssertFalse(type("ab", into: cvvView))
         XCTAssertFalse(type("+*", into: cvvView))
     }
-    
+
     func testCanTypePartialCvvForABrand() {
-        initialiseValidation(cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
+        initialiseValidation(
+            cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
         type("4111111", into: panView)
-        
+
         let result = type("1", into: cvvView)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCanTypeValidCvvForABrand() {
-        initialiseValidation(cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
+        initialiseValidation(
+            cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
         type("4111111", into: panView)
-        
+
         let result = type("12", into: cvvView)
-        
+
         XCTAssertTrue(result)
     }
-    
+
     func testCannotTypeCvvThatExceedsMaximiumLengthForABrand() {
-        initialiseValidation(cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
+        initialiseValidation(
+            cardBrands: [brandsStartingWith4AndCvv2DigitsLong], cvvView: cvvView, panView: panView)
         type("4111111", into: panView)
-        
+
         let result = type("123", into: cvvView)
-        
+
         XCTAssertFalse(result)
     }
-    
+
     // MARK: testing the text colour feature
     func testCanSetColourOfText() {
         cvvView.textColor = UIColor.red
-        
+
         XCTAssertEqual(UIColor.red, cvvView.textField.textColor)
     }
-    
+
     func testUnsetColourOfTextSetsColourToDefault() {
         cvvView.textColor = nil
-        
+
         XCTAssertEqual(UIColor.black, cvvView.textField.textColor)
     }
-    
+
     private func type(_ text: String, into view: PANView) {
         view.textField.text = text
         view.textFieldEditingChanged(view.textField)
     }
-    
+
     private func type(_ text: String, into view: CvcView) -> Bool {
         let range = NSRange(location: 0, length: 0)
-        
-        return view.textField(view.textField, shouldChangeCharactersIn: range, replacementString: text)
+
+        return view.textField(
+            view.textField, shouldChangeCharactersIn: range, replacementString: text)
     }
-    
-    private func initialiseValidation(cardBrands: [CardBrandModel], cvvView: CvcView, panView: PANView) {
+
+    private func initialiseValidation(
+        cardBrands: [CardBrandModel], cvvView: CvcView, panView: PANView
+    ) {
         let merchantDelegate = createMerchantDelegate()
-        let configurationProvider = createConfigurationProvider(with: [brandsStartingWith4AndCvv2DigitsLong])
-        
-        let validationConfig = CardValidationConfig(panView: panView,
-                                                    expiryDateView: ExpiryDateView(),
-                                                    cvvView: cvvView,
-                                                    accessBaseUrl: "http://localhost",
-                                                    validationDelegate: merchantDelegate)
-        
+        let configurationProvider = createConfigurationProvider(with: [
+            brandsStartingWith4AndCvv2DigitsLong
+        ])
+
+        let validationConfig = CardValidationConfig(
+            panView: panView,
+            expiryDateView: ExpiryDateView(),
+            cvvView: cvvView,
+            accessBaseUrl: "http://localhost",
+            validationDelegate: merchantDelegate)
+
         AccessCheckoutValidationInitialiser(configurationProvider).initialise(validationConfig)
     }
-    
-    private func createConfigurationProvider(with cardBrands: [CardBrandModel]) -> CardBrandsConfigurationProvider {
+
+    private func createConfigurationProvider(with cardBrands: [CardBrandModel])
+        -> CardBrandsConfigurationProvider
+    {
         let configurationFactory = CardBrandsConfigurationFactoryMock()
-        
-        let configurationProvider: MockCardBrandsConfigurationProvider = MockCardBrandsConfigurationProvider(configurationFactory)
-        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any()).thenDoNothing()
-        configurationProvider.getStubbingProxy().get().thenReturn(CardBrandsConfiguration(cardBrands))
-        
+
+        let configurationProvider: MockCardBrandsConfigurationProvider =
+            MockCardBrandsConfigurationProvider(configurationFactory)
+        configurationProvider.getStubbingProxy().retrieveRemoteConfiguration(baseUrl: any())
+            .thenDoNothing()
+        configurationProvider.getStubbingProxy().get().thenReturn(
+            CardBrandsConfiguration(cardBrands))
+
         return configurationProvider
     }
-    
+
     private func createMerchantDelegate() -> AccessCheckoutCardValidationDelegate {
         let merchantDelegate = MockAccessCheckoutCardValidationDelegate()
         merchantDelegate.getStubbingProxy().cardBrandChanged(cardBrand: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().panValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().expiryDateValidChanged(isValid: any()).thenDoNothing()
         merchantDelegate.getStubbingProxy().cvcValidChanged(isValid: any()).thenDoNothing()
-        
+
         return merchantDelegate
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/ExpiryDateFormatterTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/ExpiryDateFormatterTests.swift
@@ -1,14 +1,15 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ExpiryDateFormatterTests: XCTestCase {
     private let formatter = ExpiryDateFormatter()
-    
+
     func testDoesNotFormatEmptyText() {
         XCTAssertEqual("", formatter.format(""))
         XCTAssertEqual("", formatter.format(""))
     }
-    
+
     func testPadsMonthGreaterThan1WithLeading0() {
         XCTAssertEqual("02/", formatter.format("2"))
         XCTAssertEqual("03/", formatter.format("3"))
@@ -19,31 +20,31 @@ class ExpiryDateFormatterTests: XCTestCase {
         XCTAssertEqual("08/", formatter.format("8"))
         XCTAssertEqual("09/", formatter.format("9"))
     }
-    
+
     // Month 1 is not padded because we do not know whether the end user intends to type in 01 or 10/11/12
     func testDoesNotPadMonthEqualTo1() {
         XCTAssertEqual("1", formatter.format("1"))
     }
-    
+
     func testDoesNotPadMonthEqualTo0() {
         XCTAssertEqual("0", formatter.format("0"))
     }
-    
+
     func testAppendsASlashAfter2DigitsMonth() {
         XCTAssertEqual("01/", formatter.format("01"))
         XCTAssertEqual("12/", formatter.format("12"))
     }
-    
+
     func testInsertsASingleSlashBetweenMonthAndFirstDigitOfYear() {
         XCTAssertEqual("02/3", formatter.format("023"))
         XCTAssertEqual("01/3", formatter.format("13"))
         XCTAssertEqual("11/3", formatter.format("113"))
     }
-    
+
     func testAllowsToTypeInADateWithASlash() {
         XCTAssertEqual("02/34", formatter.format("02/34"))
     }
-    
+
     func testStripsOutNonNumericalCharacters() {
         XCTAssertEqual("03/", formatter.format("3ab"))
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/PanFormatterTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/PanFormatterTests.swift
@@ -1,56 +1,71 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanFormatterTests: XCTestCase {
     private let formatterWithCardSpacing = PanFormatter(cardSpacingEnabled: true)
     private let formatterWithNoCardSpacing = PanFormatter(cardSpacingEnabled: false)
-    
+
     let visaBrand = TestFixtures.visaBrand()
     let amexBrand = TestFixtures.amexBrand()
-    
+
     // MARK: card spacing disabled
-    
+
     func testShouldReturnSamePanIfPanHasDigitsOnlyAndCardSpacingNotEnabled() {
         XCTAssertEqual("44444", formatterWithNoCardSpacing.format(pan: "44444", brand: visaBrand))
     }
-    
+
     // This use case would happen when pasting in a pan with spaces
     func testShouldReturnPanWithNoSpacesIfPanHasSpacesAndCardSpacingNotEnabled() {
-        XCTAssertEqual("44444", formatterWithNoCardSpacing.format(pan: "44  444 ", brand: visaBrand))
+        XCTAssertEqual(
+            "44444", formatterWithNoCardSpacing.format(pan: "44  444 ", brand: visaBrand))
     }
-    
+
     // This use case would happen when pasting in a pan with spaces
-    func testShouldReturnPanWithNoSpacesIfCardSpacingNotEnabledAndPanHasFourCharactersOrLessIncludingSpaces() {
+    func
+        testShouldReturnPanWithNoSpacesIfCardSpacingNotEnabledAndPanHasFourCharactersOrLessIncludingSpaces()
+    {
         XCTAssertEqual("4", formatterWithNoCardSpacing.format(pan: "4 ", brand: visaBrand))
         XCTAssertEqual("44", formatterWithNoCardSpacing.format(pan: "4 4 ", brand: visaBrand))
     }
-    
+
     // MARK: card spacing enabled
-    
+
     func testShouldReturnSamePanIfCardSpacingEnabledAndFourDigitsOrLess() {
         XCTAssertEqual("444", formatterWithCardSpacing.format(pan: "444", brand: visaBrand))
         XCTAssertEqual("4444", formatterWithCardSpacing.format(pan: "4444", brand: visaBrand))
     }
-    
+
     // This use case would happen when pasting in a pan with spaces
     func testShouldReturnFormattedPanIfCardSpacingEnabled() {
         XCTAssertEqual("4444 4", formatterWithCardSpacing.format(pan: "44444", brand: visaBrand))
-        XCTAssertEqual("4444 4444 4444 4444", formatterWithCardSpacing.format(pan: "4444444444444444", brand: visaBrand))
-        XCTAssertEqual("4444 444", formatterWithCardSpacing.format(pan: "4444 444", brand: visaBrand))
-        XCTAssertEqual("4444 444", formatterWithCardSpacing.format(pan: "  4  44 4 44   4     ", brand: visaBrand))
-        
+        XCTAssertEqual(
+            "4444 4444 4444 4444",
+            formatterWithCardSpacing.format(pan: "4444444444444444", brand: visaBrand))
+        XCTAssertEqual(
+            "4444 444", formatterWithCardSpacing.format(pan: "4444 444", brand: visaBrand))
+        XCTAssertEqual(
+            "4444 444",
+            formatterWithCardSpacing.format(pan: "  4  44 4 44   4     ", brand: visaBrand))
+
         XCTAssertEqual("1234 567", formatterWithCardSpacing.format(pan: "1234567", brand: nil))
     }
-    
-    func testShouldReturnFormattedPanIfCardSpacingEnabledAndPanHasFourCharactersOrLessIncludingSpaces() {
+
+    func
+        testShouldReturnFormattedPanIfCardSpacingEnabledAndPanHasFourCharactersOrLessIncludingSpaces()
+    {
         XCTAssertEqual("4", formatterWithCardSpacing.format(pan: "4 ", brand: visaBrand))
         XCTAssertEqual("44", formatterWithCardSpacing.format(pan: "  4 4   ", brand: visaBrand))
     }
-    
+
     func testShouldReturnFormattedAmexPanIfCardSpacingEnabledAnd() {
         XCTAssertEqual("3717 4", formatterWithCardSpacing.format(pan: "37174", brand: amexBrand))
-        XCTAssertEqual("3717 444444 44444", formatterWithCardSpacing.format(pan: "371744444444444", brand: amexBrand))
-        XCTAssertEqual("3717 444", formatterWithCardSpacing.format(pan: "3717444", brand: amexBrand))
-        XCTAssertEqual("3717 444444 4", formatterWithCardSpacing.format(pan: "37174444444", brand: amexBrand))
+        XCTAssertEqual(
+            "3717 444444 44444",
+            formatterWithCardSpacing.format(pan: "371744444444444", brand: amexBrand))
+        XCTAssertEqual(
+            "3717 444", formatterWithCardSpacing.format(pan: "3717444", brand: amexBrand))
+        XCTAssertEqual(
+            "3717 444444 4", formatterWithCardSpacing.format(pan: "37174444444", brand: amexBrand))
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/PanTextChangeHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/PanTextChangeHandlerTests.swift
@@ -1,138 +1,153 @@
-@testable import AccessCheckoutSDK
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class PanTextChangeHandlerTests: XCTestCase {
     func testSupportsAppendingText() {
         let originalText = "abc"
         let textChange = "de"
         let selection: NSRange = NSRange(location: 3, length: 0)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("abcd e", result)
     }
-    
+
     func testSupportsDeletingACharacter() {
         let originalText = "1234 5"
         let textChange = ""
         let selection: NSRange = NSRange(location: 3, length: 1)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("1235", result)
     }
-    
+
     func testReturnsSameStringWhenDeletingASpace() {
         let originalText = "1234 5"
         let textChange = ""
         let selection: NSRange = NSRange(location: 4, length: 1)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("1234 5", result)
     }
-    
+
     func testSupportsDeletingASpaceAndText() {
         let originalText = "1234 5"
         let textChange = ""
         let selection: NSRange = NSRange(location: 3, length: 3)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("123", result)
     }
-    
+
     func testSupportsReplacingText() {
         let originalText = "abcd"
         let textChange = "123"
         let selection: NSRange = NSRange(location: 2, length: 2)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("ab12 3", result)
     }
-    
+
     func testSupportsDeletingASelection() {
         let originalText = "abcd"
         let textChange = ""
         let selection: NSRange = NSRange(location: 2, length: 2)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("ab", result)
     }
-    
+
     func testSupportsDeletingEntireText() {
         let originalText = "abcd"
         let textChange = ""
         let selection: NSRange = NSRange(location: 0, length: originalText.count)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("", result)
     }
-    
+
     func testReturnsOriginalTextWhenSelectionIsInvalid() {
         let originalText = "abcd"
         let textChange = "efg"
         let selection: NSRange = NSRange(location: 0, length: 10)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("abcd", result)
     }
-    
+
     func testReturnsTextWithSpacesWhenFormattingEnabled() {
         let originalText = "44444444"
         let textChange = "4"
         let selection: NSRange = NSRange(location: 8, length: 0)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual(result, "4444 4444 4")
     }
-    
+
     func testReturnsTextWithSpacesWhenFormattingEnabledAndAmexPan() {
         let originalText = "3717 444444"
         let textChange = "1"
         let selection: NSRange = NSRange(location: 11, length: 0)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual(result, "3717 444444 1")
     }
-    
+
     func testReturnsTextWithSpacesWhenFormattingEnabledAndInsertingInAmexPan() {
         let originalText = "3717 444444"
         let textChange = "1"
         let selection: NSRange = NSRange(location: 8, length: 0)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual(result, "3717 444144 4")
     }
-    
+
     func testReturnsTextCutToMaxLengthIfLongerThanMaxLengthForBrand() {
         let originalText = "4444 3333 2222"
         let textChange = "111100009999"
         let selection: NSRange = NSRange(location: 14, length: 0)
-        
-        let result = panTextChangeHandler().change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+
+        let result = panTextChangeHandler().change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual(result, "4444 3333 2222 1111 000")
     }
-    
+
     private func panTextChangeHandler() -> PanTextChangeHandler {
         let cardBrandsInConfig = [TestFixtures.amexBrand(), TestFixtures.visaBrand()]
-        
+
         let acceptedCardBrands: [String] = []
-        let configuration = CardBrandsConfiguration(allCardBrands: cardBrandsInConfig, acceptedCardBrands: acceptedCardBrands)
+        let configuration = CardBrandsConfiguration(
+            allCardBrands: cardBrandsInConfig, acceptedCardBrands: acceptedCardBrands)
         let configurationFactory = CardBrandsConfigurationFactoryMock()
         configurationFactory.willReturn(configuration)
-        
+
         let configurationProvider = CardBrandsConfigurationProvider(configurationFactory)
-        configurationProvider.retrieveRemoteConfiguration(baseUrl: "", acceptedCardBrands: acceptedCardBrands)
-        
+        configurationProvider.retrieveRemoteConfiguration(
+            baseUrl: "", acceptedCardBrands: acceptedCardBrands)
+
         return PanTextChangeHandler(PanValidator(configurationProvider), panFormattingEnabled: true)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/TextChangeHandlerTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/formatting/TextChangeHandlerTests.swift
@@ -1,77 +1,85 @@
-@testable import AccessCheckoutSDK
 import XCTest
 
-class TextChangeHandlerTests : XCTestCase {
-        
+@testable import AccessCheckoutSDK
+
+class TextChangeHandlerTests: XCTestCase {
+
     private let textChangeHandler = TextChangeHandler()
-        
+
     func testSupportsAppendingText() {
         let originalText = "abc"
         let textChange = "de"
-        let selection:NSRange = NSRange(location: 3, length: 0)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 3, length: 0)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("abcde", result)
     }
-    
+
     func testSupportsDeletingACharacter() {
         let originalText = "abcd"
         let textChange = ""
-        let selection:NSRange = NSRange(location: 3, length: 1)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 3, length: 1)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("abc", result)
     }
 
     func testSupportsReplacingText() {
         let originalText = "abcd"
         let textChange = "123"
-        let selection:NSRange = NSRange(location: 2, length: 2)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 2, length: 2)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("ab123", result)
     }
-    
+
     func testSupportsDeletingASelection() {
         let originalText = "abcd"
         let textChange = ""
-        let selection:NSRange = NSRange(location: 2, length: 2)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 2, length: 2)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("ab", result)
     }
-    
+
     func testSupportsDeletingEntireText() {
         let originalText = "abcd"
         let textChange = ""
-        let selection:NSRange = NSRange(location: 0, length: originalText.count)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 0, length: originalText.count)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("", result)
     }
-    
+
     func testReturnsOriginalTextWhenSelectionIsInvalid() {
         let originalText = "abcd"
         let textChange = "efg"
-        let selection:NSRange = NSRange(location: 0, length: 10)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 0, length: 10)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("abcd", result)
     }
-    
+
     func testReturnsTextChangeWhenNoOriginalText() {
-        let originalText:String? = nil
+        let originalText: String? = nil
         let textChange = "123"
-        let selection:NSRange = NSRange(location: 0, length: 0)
-    
-        let result = textChangeHandler.change(originalText: originalText, textChange: textChange, usingSelection: selection)
-        
+        let selection: NSRange = NSRange(location: 0, length: 0)
+
+        let result = textChangeHandler.change(
+            originalText: originalText, textChange: textChange, usingSelection: selection)
+
         XCTAssertEqual("123", result)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/CvcViewPresenterTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/CvcViewPresenterTests.swift
@@ -1,13 +1,15 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class CvcViewPresenterTests: PresenterTestSuite {
     func testOnEditingValidatesCvc() {
         let cvc = "123"
         let cvcValidator = CvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         validationFlow.getStubbingProxy().validate(cvc: any()).thenDoNothing()
         let presenter = CvcViewPresenter(validationFlow, cvcValidator)
 
@@ -19,8 +21,9 @@ class CvcViewPresenterTests: PresenterTestSuite {
     func testOnEditEndNotifiesMerchantOfValidationStateIfNotAlreadyNotified() {
         let cvc = "12"
         let cvcValidator = CvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         validationFlow.getStubbingProxy().notifyMerchant().thenDoNothing()
         let presenter = CvcViewPresenter(validationFlow, cvcValidator)
 
@@ -29,12 +32,15 @@ class CvcViewPresenterTests: PresenterTestSuite {
         verify(validationFlow).notifyMerchant()
     }
 
-    func testCanChangeTextChecksIfTheTextCanBeEnteredUsingTheCurrentCvcValidationRuleAndDoesNotTriggerValidationFlow() {
+    func
+        testCanChangeTextChecksIfTheTextCanBeEnteredUsingTheCurrentCvcValidationRuleAndDoesNotTriggerValidationFlow()
+    {
         let text = "123"
         let cvcValidator = MockCvcValidator()
         let expectedValidationRule = ValidationRule(matcher: "something", validLengths: [1, 2])
-        let validationFlow = MockCvcValidationFlow(cvcValidator,
-                                                   CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         validationFlow.getStubbingProxy().validate(cvc: any()).thenDoNothing()
         validationFlow.getStubbingProxy().validationRule.get.thenReturn(expectedValidationRule)
         cvcValidator.getStubbingProxy().canValidate(any(), using: any()).thenReturn(true)
@@ -49,8 +55,9 @@ class CvcViewPresenterTests: PresenterTestSuite {
 
     func testCanChangeTextWithEmptyText() {
         let cvcValidator = MockCvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         validationFlow.getStubbingProxy().validate(cvc: any()).thenDoNothing()
         cvcValidator.getStubbingProxy().canValidate(any(), using: any()).thenReturn(true)
         let presenter = CvcViewPresenter(validationFlow, cvcValidator)
@@ -64,8 +71,9 @@ class CvcViewPresenterTests: PresenterTestSuite {
 
     func testCanTypeIfCvcValidatorReturnsTrue() {
         let cvcValidator = MockCvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         let expectedValidationRule = ValidationRule(matcher: "something", validLengths: [1, 2])
 
         validationFlow.getStubbingProxy().validate(cvc: any()).thenDoNothing()
@@ -79,8 +87,9 @@ class CvcViewPresenterTests: PresenterTestSuite {
 
     func testCannotTypeIfCvcValidatorReturnsFalse() {
         let cvcValidator = MockCvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         let expectedValidationRule = ValidationRule(matcher: "something", validLengths: [1, 2])
 
         validationFlow.getStubbingProxy().validate(cvc: any()).thenDoNothing()
@@ -94,8 +103,9 @@ class CvcViewPresenterTests: PresenterTestSuite {
     func testTextFieldDidEndEditingNotifiesMerchantOfValidationState() {
         cvcTextField.text = "12"
         let cvcValidator = CvcValidator()
-        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(cvcValidator,
-                                                                          CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
+        let validationFlow: MockCvcValidationFlow = MockCvcValidationFlow(
+            cvcValidator,
+            CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate()))
         validationFlow.getStubbingProxy().notifyMerchant().thenDoNothing()
         let presenter = CvcViewPresenter(validationFlow, cvcValidator)
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/ExpiryDateViewPresenterTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/ExpiryDateViewPresenterTests.swift
@@ -1,6 +1,7 @@
-@testable import AccessCheckoutSDK
 import Cuckoo
 import XCTest
+
+@testable import AccessCheckoutSDK
 
 class ExpiryDateViewPresenterTests: PresenterTestSuite {
     private let expiryDateValidatorMock = MockExpiryDateValidator()
@@ -51,7 +52,8 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
 
     private static func mockExpiryDateValidationFlow() -> MockExpiryDateValidationFlow {
         let validator = ExpiryDateValidator()
-        let validationStateHandler = CardValidationStateHandler(MockAccessCheckoutCardValidationDelegate())
+        let validationStateHandler = CardValidationStateHandler(
+            MockAccessCheckoutCardValidationDelegate())
 
         return MockExpiryDateValidationFlow(validator, validationStateHandler)
     }
@@ -149,15 +151,17 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
     func testShouldFormatSingleDigitsCorrectly_Overwrite() {
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        let testDictionary = ["1": "1",
-                              "2": "02/",
-                              "3": "03/",
-                              "4": "04/",
-                              "5": "05/",
-                              "6": "06/",
-                              "7": "07/",
-                              "8": "08/",
-                              "9": "09/"]
+        let testDictionary = [
+            "1": "1",
+            "2": "02/",
+            "3": "03/",
+            "4": "04/",
+            "5": "05/",
+            "6": "06/",
+            "7": "07/",
+            "8": "08/",
+            "9": "09/",
+        ]
 
         for (key, value) in testDictionary {
             XCTAssertEqual(value, editExpiryDateAndGetResultingText(presenter: presenter, key))
@@ -167,15 +171,17 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
     func testShouldFormatSingleDigitsCorrectly_NewlyEntered() {
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        let testDictionary = ["1": "1",
-                              "2": "02/",
-                              "3": "03/",
-                              "4": "04/",
-                              "5": "05/",
-                              "6": "06/",
-                              "7": "07/",
-                              "8": "08/",
-                              "9": "09/"]
+        let testDictionary = [
+            "1": "1",
+            "2": "02/",
+            "3": "03/",
+            "4": "04/",
+            "5": "05/",
+            "6": "06/",
+            "7": "07/",
+            "8": "08/",
+            "9": "09/",
+        ]
 
         for (key, value) in testDictionary {
             _ = editExpiryDateAndGetResultingText(presenter: presenter, "")
@@ -193,12 +199,14 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
     func testShouldFormatDoubleDigitsCorrectly() {
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        let testDictionary = ["10": "10/",
-                              "11": "11/",
-                              "12": "12/",
-                              "13": "01/3",
-                              "14": "01/4",
-                              "24": "02/4"]
+        let testDictionary = [
+            "10": "10/",
+            "11": "11/",
+            "12": "12/",
+            "13": "01/3",
+            "14": "01/4",
+            "24": "02/4",
+        ]
 
         for (key, value) in testDictionary {
             _ = editExpiryDateAndGetResultingText(presenter: presenter, "")
@@ -209,12 +217,14 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
     func testShouldFormatTripleDigitsCorrectly() {
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        let testDictionary = ["100": "10/0",
-                              "110": "11/0",
-                              "120": "12/0",
-                              "133": "01/33",
-                              "143": "01/43",
-                              "244": "02/44"]
+        let testDictionary = [
+            "100": "10/0",
+            "110": "11/0",
+            "120": "12/0",
+            "133": "01/33",
+            "143": "01/43",
+            "244": "02/44",
+        ]
 
         for (key, value) in testDictionary {
             _ = editExpiryDateAndGetResultingText(presenter: presenter, "")
@@ -228,19 +238,25 @@ class ExpiryDateViewPresenterTests: PresenterTestSuite {
         expiryDateValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(false)
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        XCTAssertFalse(canEnterExpiryDate(presenter: presenter, uiTextField: expiryDateTextField, "12"))
+        XCTAssertFalse(
+            canEnterExpiryDate(presenter: presenter, uiTextField: expiryDateTextField, "12"))
     }
 
     func testCanTypeIfValidatorReturnsFalse() {
         expiryDateValidatorMock.getStubbingProxy().canValidate(any()).thenReturn(true)
         let presenter = ExpiryDateViewPresenter(expiryDateValidationFlow, expiryDateValidatorMock)
 
-        XCTAssertTrue(canEnterExpiryDate(presenter: presenter, uiTextField: expiryDateTextField, "12"))
+        XCTAssertTrue(
+            canEnterExpiryDate(presenter: presenter, uiTextField: expiryDateTextField, "12"))
     }
 
-    private func editExpiryDateAndGetResultingText(presenter: ExpiryDateViewPresenter, _ text: String) -> String {
+    private func editExpiryDateAndGetResultingText(
+        presenter: ExpiryDateViewPresenter, _ text: String
+    ) -> String {
         // This line is here to reproduce the behaviour where the state of the before applying the text to type would be saved by this call in production code when the text is being edited
-        _ = presenter.textField(expiryDateTextField, shouldChangeCharactersIn: NSRange(location: 0, length: 0), replacementString: "")
+        _ = presenter.textField(
+            expiryDateTextField, shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "")
 
         expiryDateTextField.text = text
         presenter.textFieldEditingChanged(expiryDateTextField)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,13 @@ See instructions in the `AccessCheckoutSDK/scripts/mocks-build-phase.sh` script
 ## Code formatting
 
 [Swift format](https://github.com/swiftlang/swift-format) is used to format the code and uses the configuration set up in the `.swift-format` file as per the [configuration options available](https://github.com/swiftlang/swift-format/blob/main/Documentation/Configuration.md) in swift format
-The code can be reformatted in command line by using `swift-format --in-place --recursive .`
+The code can be reformatted in command line by using 
+
+```swift-format -i -r ./AccessCheckoutDemo ./AccessCheckoutSDK```
+
+Note you may see errors due to swift format trying to format swift files in `Pods` directories. You can ignore those. This issue will be solved once swift-format supports ignoring files.
+
+Do not format code using XCode as the indentation settings (and other formatting configuration) would be different to that defined in the .swift-format file.
 
 **Code must be formatted using this tool before raising a PR.**
 


### PR DESCRIPTION
### What
- add support for `inputAccessoryView` on AccessCheckoutUITextField

### Why
- this will be used by merchants to add custom views on top of the keyboard displayed when an instance of AccessCheckoutUITextField gets the focus