### PR TITLE
US2193399: downgrade objectVersion to 54 + fix issue related to cardBin folder

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,11 @@
 		1BCBFECE22B8F40300A65FAA /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 1BCBFECA22B8F40200A65FAA /* CHANGELOG.md */; };
 		1BCBFECF22B8F40300A65FAA /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 1BCBFECB22B8F40300A65FAA /* LICENSE */; };
 		5115F54F2E327B0900BC3FDB /* CardBinURLRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115F54E2E327B0500BC3FDB /* CardBinURLRequestFactoryTests.swift */; };
+		511B6C4A2E40EC28005E1457 /* CardBinCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B6C462E40EC28005E1457 /* CardBinCacheManager.swift */; };
+		511B6C4B2E40EC28005E1457 /* CardBinRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B6C472E40EC28005E1457 /* CardBinRequest.swift */; };
+		511B6C4C2E40EC28005E1457 /* CardBinResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B6C482E40EC28005E1457 /* CardBinResponse.swift */; };
+		511B6C4D2E40EC28005E1457 /* CardBinURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B6C492E40EC28005E1457 /* CardBinURLRequestFactory.swift */; };
+		511B6C4E2E40EC28005E1457 /* CardBinApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B6C452E40EC28005E1457 /* CardBinApiClient.swift */; };
 		5121EC422AF2A50800C8FC72 /* EncodableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5121EC412AF2A50800C8FC72 /* EncodableExtension.swift */; };
 		5125FFC22DD5FCAD00EF7380 /* MockCvcValidationStateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5125FFC12DD5FCAD00EF7380 /* MockCvcValidationStateHandler.swift */; };
 		5125FFC52DD5FCC700EF7380 /* MockCvcValidationFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5125FFC32DD5FCC700EF7380 /* MockCvcValidationFlow.swift */; };
@@ -254,6 +259,11 @@
 		1BCBFECA22B8F40200A65FAA /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		1BCBFECB22B8F40300A65FAA /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		5115F54E2E327B0500BC3FDB /* CardBinURLRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinURLRequestFactoryTests.swift; sourceTree = "<group>"; };
+		511B6C452E40EC28005E1457 /* CardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinApiClient.swift; sourceTree = "<group>"; };
+		511B6C462E40EC28005E1457 /* CardBinCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinCacheManager.swift; sourceTree = "<group>"; };
+		511B6C472E40EC28005E1457 /* CardBinRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinRequest.swift; sourceTree = "<group>"; };
+		511B6C482E40EC28005E1457 /* CardBinResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinResponse.swift; sourceTree = "<group>"; };
+		511B6C492E40EC28005E1457 /* CardBinURLRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinURLRequestFactory.swift; sourceTree = "<group>"; };
 		5121EC412AF2A50800C8FC72 /* EncodableExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableExtension.swift; sourceTree = "<group>"; };
 		5125FFC12DD5FCAD00EF7380 /* MockCvcValidationStateHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCvcValidationStateHandler.swift; sourceTree = "<group>"; };
 		5125FFC32DD5FCC700EF7380 /* MockCvcValidationFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCvcValidationFlow.swift; sourceTree = "<group>"; };
@@ -471,10 +481,6 @@
 		EA77127DB45BFE97F1FBCF23 /* Pods_AccessCheckoutSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		5115F5472E32790100BC3FDB /* cardBin */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = cardBin; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
-
 /* Begin PBXFrameworksBuildPhase section */
 		1BCBFEB222B8EA3C00A65FAA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -538,6 +544,18 @@
 				62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */,
 				514A38322E329258000948C3 /* CardBinApiClientTests.swift */,
 				5115F54E2E327B0500BC3FDB /* CardBinURLRequestFactoryTests.swift */,
+			);
+			path = cardBin;
+			sourceTree = "<group>";
+		};
+		511B6C512E40EC5F005E1457 /* cardBin */ = {
+			isa = PBXGroup;
+			children = (
+				511B6C452E40EC28005E1457 /* CardBinApiClient.swift */,
+				511B6C462E40EC28005E1457 /* CardBinCacheManager.swift */,
+				511B6C472E40EC28005E1457 /* CardBinRequest.swift */,
+				511B6C482E40EC28005E1457 /* CardBinResponse.swift */,
+				511B6C492E40EC28005E1457 /* CardBinURLRequestFactory.swift */,
 			);
 			path = cardBin;
 			sourceTree = "<group>";
@@ -1147,7 +1165,7 @@
 		E7D37F8124815E7A0039DD98 /* api */ = {
 			isa = PBXGroup;
 			children = (
-				5115F5472E32790100BC3FDB /* cardBin */,
+				511B6C512E40EC5F005E1457 /* cardBin */,
 				E7D37F88248168C70039DD98 /* CardBrandDto.swift */,
 				E745CC21248575FE000390CA /* CardBrandDtoTransformer.swift */,
 			);
@@ -1294,9 +1312,6 @@
 			buildRules = (
 			);
 			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				5115F5472E32790100BC3FDB /* cardBin */,
 			);
 			name = AccessCheckoutSDK;
 			productName = AccessCheckoutSDK;
@@ -1640,6 +1655,11 @@
 				E72C3ED82485B2E100284A31 /* CvcViewPresenter.swift in Sources */,
 				E7D19F622462F5E2001EA13A /* CardDetailsForSessionTypeValidator.swift in Sources */,
 				D7E536F1264A90B300A476E6 /* PanFormatter.swift in Sources */,
+				511B6C4A2E40EC28005E1457 /* CardBinCacheManager.swift in Sources */,
+				511B6C4B2E40EC28005E1457 /* CardBinRequest.swift in Sources */,
+				511B6C4C2E40EC28005E1457 /* CardBinResponse.swift in Sources */,
+				511B6C4D2E40EC28005E1457 /* CardBinURLRequestFactory.swift in Sources */,
+				511B6C4E2E40EC28005E1457 /* CardBinApiClient.swift in Sources */,
 				E7D37F87248161CD0039DD98 /* CardBrandsConfiguration.swift in Sources */,
 				D7851B302489010900461377 /* AccessCheckoutCvcOnlyValidationDelegate.swift in Sources */,
 				D7851B2C2488EC2800461377 /* CvcOnlyValidationStateHandler.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
@@ -98,7 +98,7 @@ class CardBinApiClientTests: XCTestCase {
         let apiClient = CardBinApiClient(
             url: "some-url",
             checkoutId: "00000000-0000-0000-0000-000000000000",
-            restClient: mockRestClient,
+            restClient: mockRestClient
         )
 
         apiClient.retrieveBinInfo(cardNumber: "444433332222") { result in


### PR DESCRIPTION
### What
- fix broken build

### How
- downgrade `objectVersion` to `54` in `project.pbxproj` (version 70 that we had before on this feature branch is compatible only with XCode 16)
- change `cardBin` under `validation/api/` to be a group rather than a folder as use of folder was breaking the build (probably due to how folders are managed on XCode 16)