### PR TITLE
Minor changes in CardBinApiClient + refactor RestClient class

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-internal class RestClient {
-    func send<T: Decodable>(
+internal class RestClient<T: Decodable> {
+    func send(
         urlSession: URLSession,
         request: URLRequest,
         responseType: T.Type,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
@@ -4,7 +4,6 @@ internal class RestClient<T: Decodable> {
     func send(
         urlSession: URLSession,
         request: URLRequest,
-        responseType: T.Type,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
     ) {
         urlSession.dataTask(with: request) { data, urlResponse, error in

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryResponseFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryResponseFactory.swift
@@ -13,8 +13,7 @@ class ServiceDiscoveryResponseFactory {
     ) {
         restClient.send(
             urlSession: URLSession.shared,
-            request: request,
-            responseType: ApiResponse.self
+            request: request
         ) {
             result, _ in
             let apiResponse: ApiResponse?

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryResponseFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryResponseFactory.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 class ServiceDiscoveryResponseFactory {
-    private let restClient: RestClient
+    private let restClient: RestClient<ApiResponse>
 
-    init(restClient: RestClient = RestClient()) {
+    init(restClient: RestClient<ApiResponse> = RestClient()) {
         self.restClient = restClient
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
@@ -16,8 +16,7 @@ class SingleLinkDiscovery {
     func discover(completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
         restClient.send(
             urlSession: URLSession.shared,
-            request: urlRequest,
-            responseType: ApiResponse.self
+            request: urlRequest
         ) { result, _ in
             switch result {
             case .success(let response):

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 class SingleLinkDiscovery {
-    private let restClient: RestClient
+    private let restClient: RestClient<ApiResponse>
     private let apiResponseLinkLookup: ApiResponseLinkLookup
     private(set) var linkToFind: String
     private(set) var urlRequest: URLRequest
 
     init(linkToFind: String, urlRequest: URLRequest) {
-        self.restClient = RestClient()
+        self.restClient = RestClient<ApiResponse>()
         self.apiResponseLinkLookup = ApiResponseLinkLookup()
         self.linkToFind = linkToFind
         self.urlRequest = urlRequest

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
@@ -10,7 +10,7 @@ public struct AccessCheckoutValidationInitialiser {
      This initialiser should be used to create an instance of `AccessCheckoutValidationInitialiser`
      */
     public init() {
-        let restClient = RestClient()
+        let restClient = RestClient<[CardBrandDto]>()
         let transformer = CardBrandDtoTransformer()
         let configurationFactory = CardBrandsConfigurationFactory(restClient, transformer)
         self.configurationProvider = CardBrandsConfigurationProvider(configurationFactory)

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
@@ -95,8 +95,7 @@ class CardSessionsApiClient {
         )
         restClient.send(
             urlSession: URLSession.shared,
-            request: request,
-            responseType: ApiResponse.self
+            request: request
         ) { result, _ in
             completionHandler(result)
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
@@ -7,7 +7,7 @@ class CardSessionsApiClient {
 
     private var discovery: CardSessionsApiDiscovery
     private var urlRequestFactory: CardSessionURLRequestFactory
-    private var restClient: RestClient
+    private var restClient: RestClient<ApiResponse>
     private var apiResponseLinkLookup: ApiResponseLinkLookup
 
     init() {
@@ -27,7 +27,7 @@ class CardSessionsApiClient {
     init(
         discovery: CardSessionsApiDiscovery,
         urlRequestFactory: CardSessionURLRequestFactory,
-        restClient: RestClient
+        restClient: RestClient<ApiResponse>
     ) {
         self.discovery = discovery
         self.urlRequestFactory = urlRequestFactory

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
@@ -76,8 +76,7 @@ class CvcSessionsApiClient {
 
         restClient.send(
             urlSession: URLSession.shared,
-            request: request,
-            responseType: ApiResponse.self
+            request: request
         ) { result, _ in
             completionHandler(result)
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
@@ -7,7 +7,7 @@ class CvcSessionsApiClient {
 
     private var discovery: CvcSessionsApiDiscovery
     private var urlRequestFactory: CvcSessionURLRequestFactory
-    private var restClient: RestClient
+    private var restClient: RestClient<ApiResponse>
     private var apiResponseLinkLookup: ApiResponseLinkLookup
 
     init() {
@@ -27,7 +27,7 @@ class CvcSessionsApiClient {
     init(
         discovery: CvcSessionsApiDiscovery,
         urlRequestFactory: CvcSessionURLRequestFactory,
-        restClient: RestClient
+        restClient: RestClient<ApiResponse>
     ) {
         self.discovery = discovery
         self.urlRequestFactory = urlRequestFactory

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -7,7 +7,7 @@ internal struct CardBinApiClient {
     private var checkoutId: String
     private var restClient: RestClient
     private let cacheManager = CardBinCacheManager()
-    private let maxRetries = 3
+    private let maxAttempts = 3
 
     /// Initialises a new CardBinApiClient instance.
     ///
@@ -43,7 +43,7 @@ internal struct CardBinApiClient {
         fetchCardBinResponseWithRetry(
             cardNumber: cardNumber,
             cacheKey: cacheKey,
-            retries: 1,
+            attempt: 1,
             completionHandler: completionHandler
         )
     }
@@ -63,7 +63,7 @@ internal struct CardBinApiClient {
     private func fetchCardBinResponseWithRetry(
         cardNumber: String,
         cacheKey: String,
-        retries: Int,
+        attempt: UInt,
         completionHandler: @escaping (Result<CardBinResponse, AccessCheckoutError>) -> Void
     ) {
         let urlRequestFactory = CardBinURLRequestFactory(url: url, checkoutId: checkoutId)
@@ -78,22 +78,21 @@ internal struct CardBinApiClient {
                 completionHandler(.success(response))
 
             case .failure(let error):
-                let shouldRetry = self.shouldRetry(error: error, statusCode: statusCode)
-
-                if retries < self.maxRetries && shouldRetry {
-
+                let nextAttempt = attempt + 1
+                if self.shouldRetry(attempt: nextAttempt, statusCode: statusCode) {
                     self.fetchCardBinResponseWithRetry(
                         cardNumber: cardNumber,
                         cacheKey: cacheKey,
-                        retries: retries + 1,
+                        attempt: nextAttempt,
                         completionHandler: completionHandler
                     )
-
                 } else {
-                    let maxRetriesReached = AccessCheckoutError.unexpectedApiError(
-                        message: "Failed after \(self.maxRetries)")
+                    let maxRetriesReachedError = AccessCheckoutError.unexpectedApiError(
+                        message:
+                            "Failed after \(attempt) attempt(s) with error \(String(error.errorDescription!))"
+                    )
 
-                    completionHandler(.failure(maxRetriesReached))
+                    completionHandler(.failure(maxRetriesReachedError))
                 }
 
             }
@@ -101,18 +100,20 @@ internal struct CardBinApiClient {
 
     }
 
-    /// Determines whether a failed request should be retried based on the error type and status code.
+    /// Determines whether a failed request should be retried based on the error type, status code and number of attempts
     ///
     /// Client errors (4xx status codes) are not retried as they indicate issues with the request
     /// that won't be resolved by retrying. Server errors (5xx) and network failures are considered
     /// transient and will trigger a retry.
+    ///  A maximum of 3 attempts are done
     ///
     /// - Parameters:
-    ///   - error: The error that occurred during the request
     ///   - statusCode: The HTTP status code returned by the server, if available
     /// - Returns: `true` if the request should be retried, `false` otherwise
-    private func shouldRetry(error: AccessCheckoutError, statusCode: Int?) -> Bool {
-        if let statusCode = statusCode, (400...499).contains(statusCode) {
+    private func shouldRetry(attempt: UInt, statusCode: Int?) -> Bool {
+        if attempt > self.maxAttempts {
+            return false
+        } else if let statusCode = statusCode, (400...499).contains(statusCode) {
             return false
         }
         return true

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -70,7 +70,7 @@ internal struct CardBinApiClient {
         let request = urlRequestFactory.create(cardNumber: cardNumber)
 
         restClient.send(
-            urlSession: URLSession.shared, request: request, responseType: CardBinResponse.self
+            urlSession: URLSession.shared, request: request
         ) { result, statusCode in
             switch result {
             case .success(let response):

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -5,7 +5,7 @@ import Foundation
 internal struct CardBinApiClient {
     private var url: String
     private var checkoutId: String
-    private var restClient: RestClient
+    private var restClient: RestClient<CardBinResponse>
     private let cacheManager = CardBinCacheManager()
     private let maxAttempts = 3
 
@@ -15,7 +15,7 @@ internal struct CardBinApiClient {
     ///   - url: The base URL for the card BIN API endpoint
     ///   - checkoutId: The checkout session identifier used for API authentication
     ///   - restClient: The REST client used to make HTTP requests
-    init(url: String, checkoutId: String, restClient: RestClient) {
+    init(url: String, checkoutId: String, restClient: RestClient<CardBinResponse>) {
         self.url = url
         self.checkoutId = checkoutId
         self.restClient = restClient

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
@@ -25,8 +25,7 @@ class CardBrandsConfigurationFactory {
 
         restClient.send(
             urlSession: URLSession.shared,
-            request: URLRequest(url: url),
-            responseType: [CardBrandDto].self
+            request: URLRequest(url: url)
         ) { result, _ in
             let brands: [CardBrandModel]
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
@@ -3,10 +3,10 @@ import Foundation
 class CardBrandsConfigurationFactory {
     private let configurationFileRelativePath = "access-checkout/cardTypes.json"
 
-    private let restClient: RestClient
+    private let restClient: RestClient<[CardBrandDto]>
     private let transformer: CardBrandDtoTransformer
 
-    init(_ restClient: RestClient, _ transformer: CardBrandDtoTransformer) {
+    init(_ restClient: RestClient<[CardBrandDto]>, _ transformer: CardBrandDtoTransformer) {
         self.restClient = restClient
         self.transformer = transformer
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
@@ -21,8 +21,7 @@ class RestClientTests: XCTestCase {
         let urlSessionDataTaskMock = URLSessionDataTaskMock()
         let urlSession = URLSessionMock(forRequest: request, usingDataTask: urlSessionDataTaskMock)
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { _, _ in }
+        restClient.send(urlSession: urlSession, request: request) { _, _ in }
 
         XCTAssertTrue(urlSession.dataTaskCalled)
         XCTAssertTrue(urlSessionDataTaskMock.resumeCalled)
@@ -35,8 +34,7 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get200(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, _ in
+        restClient.send(urlSession: urlSession, request: request) { result, _ in
             switch result {
             case .success(let response):
                 XCTAssertEqual(1, response.id)
@@ -57,8 +55,7 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get200(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, statusCode in
+        restClient.send(urlSession: urlSession, request: request) { result, statusCode in
             switch result {
             case .success(_):
                 XCTAssertEqual(200, statusCode)
@@ -83,8 +80,7 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get400(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, _ in
+        restClient.send(urlSession: urlSession, request: request) { result, _ in
             switch result {
             case .success:
                 XCTFail("Expected failed response but received successful response")
@@ -111,8 +107,7 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get400(path: "/somewhere", jsonResponse: jsonResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, statusCode in
+        restClient.send(urlSession: urlSession, request: request) { result, statusCode in
             switch result {
             case .success:
                 XCTFail("Expected failed response but received successful response")
@@ -134,8 +129,7 @@ class RestClientTests: XCTestCase {
         serviceStubs!.get200(path: "/somewhere", textResponse: textResponse)
             .start()
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, _ in
+        restClient.send(urlSession: urlSession, request: request) { result, _ in
             switch result {
             case .success:
                 XCTFail("Expected failed response but received successful response")
@@ -159,8 +153,7 @@ class RestClientTests: XCTestCase {
             errorName: "unexpectedApiError",
             message: "A server with the specified hostname could not be found.")
 
-        restClient.send(urlSession: urlSession, request: request, responseType: DummyResponse.self)
-        { result, _ in
+        restClient.send(urlSession: urlSession, request: request) { result, _ in
             switch result {
             case .success:
                 XCTFail("Expected failed response but received successful response")

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class RestClientTests: XCTestCase {
     private var serviceStubs: ServiceStubs?
     private let urlSession = URLSession(configuration: URLSessionConfiguration.default)
-    private let restClient = RestClient()
+    private let restClient = RestClient<DummyResponse>()
 
     override func setUp() {
         serviceStubs = ServiceStubs()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryFactoryTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryFactoryTests.swift
@@ -6,7 +6,7 @@ class ServiceDiscoveryFactoryTests: XCTestCase {
 
     func testShouldReturnResponseFromDiscoveryRequest() {
         let expectedResponse = toApiResponse()
-        let restClientMock = RestClientMock(replyWith: expectedResponse)
+        let restClientMock = RestClientMock<ApiResponse>(replyWith: expectedResponse)
         let request = URLRequest(url: URL(string: "http://www.example.com")!)
 
         let factory = ServiceDiscoveryResponseFactory(restClient: restClientMock)
@@ -22,7 +22,7 @@ class ServiceDiscoveryFactoryTests: XCTestCase {
     func testShouldReturnNilWhenAFailureOccurredDuringDiscoveryRequest() {
         let expectedError = AccessCheckoutError.unexpectedApiError(message: "An error occurred")
 
-        let restClientMock = RestClientMock<String>(errorWith: expectedError)
+        let restClientMock = RestClientMock<ApiResponse>(errorWith: expectedError)
 
         let request = URLRequest(url: URL(string: "http://www.example.com")!)
         let factory = ServiceDiscoveryResponseFactory(restClient: restClientMock)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardBrandsConfigurationFactoryMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/CardBrandsConfigurationFactoryMock.swift
@@ -8,7 +8,7 @@ class CardBrandsConfigurationFactoryMock: CardBrandsConfigurationFactory {
         allCardBrands: [], acceptedCardBrands: [])
 
     init() {
-        super.init(RestClientMock<String>(replyWith: ""), MockCardBrandDtoTransformer())
+        super.init(RestClientMock<[CardBrandDto]>(replyWith: []), MockCardBrandDtoTransformer())
     }
 
     func willReturn(_ expectedConfiguration: CardBrandsConfiguration) {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
@@ -22,7 +22,7 @@ class RestClientMock<T: Decodable>: RestClient<T> {
     }
 
     override func send(
-        urlSession: URLSession, request: URLRequest, responseType: T.Type,
+        urlSession: URLSession, request: URLRequest,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
     ) {
         numberOfCalls += 1

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
@@ -1,6 +1,6 @@
 @testable import AccessCheckoutSDK
 
-class RestClientMock<T: Decodable>: RestClient {
+class RestClientMock<T: Decodable>: RestClient<T> {
     private(set) var sendMethodCalled = false
     private(set) var expectedRequestSent = false
     private(set) var requestSent: URLRequest?
@@ -21,8 +21,7 @@ class RestClientMock<T: Decodable>: RestClient {
         self.statusCode = statusCode
     }
 
-    //TODO: fix warning to do with generic parameter 'T'
-    override func send<T: Decodable>(
+    override func send(
         urlSession: URLSession, request: URLRequest, responseType: T.Type,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
     ) {
@@ -31,7 +30,7 @@ class RestClientMock<T: Decodable>: RestClient {
         requestSent = request
 
         if response != nil {
-            completionHandler(.success(response as! T), 200)
+            completionHandler(.success(response! as T), 200)
         } else if error != nil {
             completionHandler(.failure(error!), statusCode)
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cardSessions/CardSessionsApiClientTests.swift
@@ -110,7 +110,7 @@ class CardSessionsApiClientTests: XCTestCase {
     func testReturnsServiceError_whenServiceErrorsOut() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
         let expectedError = StubUtils.createError(errorName: "some error", message: "some message")
-        let mockRestClient = RestClientMock<String>(errorWith: expectedError)
+        let mockRestClient = RestClientMock<ApiResponse>(errorWith: expectedError)
 
         let client = CardSessionsApiClient(
             discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/session/api/cvcSessions/CvcSessionsApiClientTests.swift
@@ -96,7 +96,7 @@ class CvcSessionsApiClientTests: XCTestCase {
     func testReturnsServiceError_whenServiceErrorsOut() {
         mockDiscovery.willComplete(with: expectedDiscoveredUrl)
         let expectedError = StubUtils.createError(errorName: "an error", message: "a message")
-        let mockRestClient = RestClientMock<String>(errorWith: expectedError)
+        let mockRestClient = RestClientMock<ApiResponse>(errorWith: expectedError)
 
         let client = CvcSessionsApiClient(
             discovery: mockDiscovery, urlRequestFactory: mockURLRequestFactory,

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/PresenterTestSuite.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/PresenterTestSuite.swift
@@ -13,7 +13,8 @@ class PresenterTestSuite: XCTestCase {
     ) {
         let range = NSRange(location: 0, length: 0)
 
-        presenter.textField(uiTextField, shouldChangeCharactersIn: range, replacementString: text)
+        _ = presenter.textField(
+            uiTextField, shouldChangeCharactersIn: range, replacementString: text)
     }
 
     func canEnterExpiryDate(

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
@@ -66,8 +66,12 @@ class CardBinApiClientTests: XCTestCase {
         expectationToFulfill = expectation(
             description: "should have called completion handler with error from rest client")
 
-        let expectedError = AccessCheckoutError.unexpectedApiError(message: "Failed after 3")
-        let mockRestClient = RestClientMock<CardBinResponse>(errorWith: expectedError)
+        let mockRestClient = RestClientMock<CardBinResponse>(
+            errorWith: AccessCheckoutError.unexpectedApiError(message: "some error"))
+        let detailedErrorMessage = "Message: unexpectedApiError : some error\n Validation: "
+        let expectedError = AccessCheckoutError.unexpectedApiError(
+            message: "Failed after 3 attempt(s) with error \(detailedErrorMessage)")
+
         let apiClient = CardBinApiClient(
             url: "some-url",
             checkoutId: "00000000-0000-0000-0000-000000000000",
@@ -128,9 +132,9 @@ class CardBinApiClientTests: XCTestCase {
         wait(for: [expectationToFulfill!], timeout: 1)
     }
 
-    func testRetriesRequestThreeTimesOn5xxError() {
+    func testAttemptsRequestThreeTimesOn5xxError() {
         expectationToFulfill = expectation(
-            description: "should retry request three times on server error (5xx)"
+            description: "should attempt request three times on server error (5xx)"
         )
 
         let serverError = AccessCheckoutError.unexpectedApiError(message: "unexpectedApiError")


### PR DESCRIPTION
### What
- change `CardBinApiClient` class to
  - use _attempts_ terminology rather than _retry_ to clarify behaviour of class
  - not swallow details of the error returned by Card BIN api
- change RestClient to use generics at class level rather than at method level (+ removed unused parameter)

### Why
- this is needed to give more clarity to the code