### PR TITLE
US2128873: Card bin service abort mechanism

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		517145862AE2CA8D00A73A3F /* UITextFieldMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517145852AE2CA8D00A73A3F /* UITextFieldMock.swift */; };
 		5173EF252970367300770177 /* WpSdkHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EF242970367300770177 /* WpSdkHeaderTests.swift */; };
 		5182FA752AC485C500976088 /* AccessCheckoutUITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */; };
+		519F14402E4B7AAA00038113 /* MiscUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519F143F2E4B7AA300038113 /* MiscUtils.swift */; };
 		51D610D125CD750A00B1B685 /* CardValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */; };
 		51D610D325CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */; };
 		51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E831E12ACDB49900A8FC22 /* UIUtils.swift */; };
@@ -291,6 +292,7 @@
 		517145852AE2CA8D00A73A3F /* UITextFieldMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextFieldMock.swift; sourceTree = "<group>"; };
 		5173EF242970367300770177 /* WpSdkHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WpSdkHeaderTests.swift; sourceTree = "<group>"; };
 		5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCheckoutUITextField.swift; sourceTree = "<group>"; };
+		519F143F2E4B7AA300038113 /* MiscUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscUtils.swift; sourceTree = "<group>"; };
 		51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CvcOnlyValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51E831E12ACDB49900A8FC22 /* UIUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
@@ -1160,6 +1162,7 @@
 		E7D19F7D2463FEE3001EA13A /* testUtils */ = {
 			isa = PBXGroup;
 			children = (
+				519F143F2E4B7AA300038113 /* MiscUtils.swift */,
 				51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */,
 				E719B08724642EF80037DED4 /* CuckooExtension.swift */,
 				E7C4D235249CF4D100D7B9F1 /* EncodableExtension.swift */,
@@ -1785,6 +1788,7 @@
 				513039A22B10F68800C01B10 /* ApiHeadersTests.swift in Sources */,
 				E75C5E6A248E7020003A1BDE /* AccessCheckoutCardValidationDelegate_EditText_Tests.swift in Sources */,
 				E7633D2D249D1F4800FFE190 /* AccessCheckoutErrorTests.swift in Sources */,
+				519F14402E4B7AAA00038113 /* MiscUtils.swift in Sources */,
 				E7D19F8124640008001EA13A /* StubUtils.swift in Sources */,
 				5173EF252970367300770177 /* WpSdkHeaderTests.swift in Sources */,
 				E77B8BA9245C552200564C19 /* RetrieveCardSessionHandlerTests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		5173EF252970367300770177 /* WpSdkHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EF242970367300770177 /* WpSdkHeaderTests.swift */; };
 		5182FA752AC485C500976088 /* AccessCheckoutUITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */; };
 		519F14402E4B7AAA00038113 /* MiscUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519F143F2E4B7AA300038113 /* MiscUtils.swift */; };
+		519F14422E4B8AB500038113 /* CardBinApiClientTestsWithStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519F14412E4B8AA300038113 /* CardBinApiClientTestsWithStubService.swift */; };
 		51D610D125CD750A00B1B685 /* CardValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */; };
 		51D610D325CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */; };
 		51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E831E12ACDB49900A8FC22 /* UIUtils.swift */; };
@@ -187,7 +188,6 @@
 		E7AD2454246412C800C4C92D /* MockSingleLinkDiscoveryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AD2453246412C800C4C92D /* MockSingleLinkDiscoveryFactory.swift */; };
 		E7AE68C724195050002380AF /* RestClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AE68C624195050002380AF /* RestClientMock.swift */; };
 		E7AFC3F7241FEBEB00C0E432 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DF0FE5331B699757B3D19 /* URLSessionMock.swift */; };
-		E7AFC3F8241FEBEB00C0E432 /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DFFF2A0D1603232514AD9 /* URLSessionDataTaskMock.swift */; };
 		E7B0A17424293D290028797E /* scripts in Resources */ = {isa = PBXBuildFile; fileRef = E7B0A17324293D290028797E /* scripts */; };
 		E7C4D236249CF4D100D7B9F1 /* EncodableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C4D235249CF4D100D7B9F1 /* EncodableExtension.swift */; };
 		E7D19F622462F5E2001EA13A /* CardDetailsForSessionTypeValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D19F612462F5E2001EA13A /* CardDetailsForSessionTypeValidator.swift */; };
@@ -293,6 +293,7 @@
 		5173EF242970367300770177 /* WpSdkHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WpSdkHeaderTests.swift; sourceTree = "<group>"; };
 		5182FA742AC485C500976088 /* AccessCheckoutUITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCheckoutUITextField.swift; sourceTree = "<group>"; };
 		519F143F2E4B7AA300038113 /* MiscUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscUtils.swift; sourceTree = "<group>"; };
+		519F14412E4B8AA300038113 /* CardBinApiClientTestsWithStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinApiClientTestsWithStubService.swift; sourceTree = "<group>"; };
 		51D610D025CD750A00B1B685 /* CardValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51D610D225CD754C00B1B685 /* CvcOnlyValidationConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CvcOnlyValidationConfigBuilderTests.swift; sourceTree = "<group>"; };
 		51E831E12ACDB49900A8FC22 /* UIUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
@@ -307,7 +308,6 @@
 		63E9AC2FDE45ABB3E75E6DFE /* Pods-AccessCheckoutSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDK.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDK/Pods-AccessCheckoutSDK.release.xcconfig"; sourceTree = "<group>"; };
 		683DF0BDC6FFC7C2D7F84EED /* RestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestClient.swift; sourceTree = "<group>"; };
 		683DF0FE5331B699757B3D19 /* URLSessionMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
-		683DFFF2A0D1603232514AD9 /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		683DFFF3DC25699A1CE15270 /* CvcSessionURLRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CvcSessionURLRequestFactory.swift; sourceTree = "<group>"; };
 		6F228E4B50C5655DF4E7F378 /* Pods-AccessCheckoutSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDK.debug.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDK/Pods-AccessCheckoutSDK.debug.xcconfig"; sourceTree = "<group>"; };
 		7B355B4B411B9052D09D24D3 /* Pods-AccessCheckoutSDKPactTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDKPactTests.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -530,6 +530,7 @@
 				62BF77372E4C975500369257 /* CardBinServiceTests.swift */,
 				62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */,
 				514A38322E329258000948C3 /* CardBinApiClientTests.swift */,
+				519F14412E4B8AA300038113 /* CardBinApiClientTestsWithStubService.swift */,
 				5115F54E2E327B0500BC3FDB /* CardBinURLRequestFactoryTests.swift */,
 			);
 			path = cardBin;
@@ -694,7 +695,6 @@
 				E719B0AB2464A47E0037DED4 /* SessionsApiClientMock.swift */,
 				E719B083246417110037DED4 /* SingleLinkDiscoveryMock.swift */,
 				683DF0FE5331B699757B3D19 /* URLSessionMock.swift */,
-				683DFFF2A0D1603232514AD9 /* URLSessionDataTaskMock.swift */,
 				E719B0A92464A3B30037DED4 /* CardSessionsApiClientMock.swift */,
 				E77B8BA4245C516E00564C19 /* RetrieveCardSessionHandlerMock.swift */,
 				E719B09D246481DA0037DED4 /* CardSessionURLRequestFactoryMock.swift */,
@@ -1726,12 +1726,12 @@
 				E75C5E67248E6F7F003A1BDE /* MockAccessCheckoutCardValidationDelegate.swift in Sources */,
 				D7D6D5D2247EBA0600D57D7A /* ExpiryDateValidatorTests.swift in Sources */,
 				517145862AE2CA8D00A73A3F /* UITextFieldMock.swift in Sources */,
+				519F14422E4B8AB500038113 /* CardBinApiClientTestsWithStubService.swift in Sources */,
 				E7D37F8C248170300039DD98 /* CardBrandDtoTests.swift in Sources */,
 				D7D6D5D8247FC96100D57D7A /* CvcValidatorTests.swift in Sources */,
 				D7E536F3264A90FC00A476E6 /* PanFormatterTests.swift in Sources */,
 				E7D37F852481601B0039DD98 /* CardBrandsConfigurationFactoryTests.swift in Sources */,
 				E7D37F7E248154DF0039DD98 /* AccessCheckoutValidationInitialiserTests.swift in Sources */,
-				E7AFC3F8241FEBEB00C0E432 /* URLSessionDataTaskMock.swift in Sources */,
 				E70305A124924AAA00802AF1 /* TestFixtures.swift in Sources */,
 				51EEC2BC2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift in Sources */,
 				E75C5E6E248E7171003A1BDE /* AccessCheckoutCardValidationDelegate_FocusOut_Tests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -55,11 +55,12 @@
 		51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E831E12ACDB49900A8FC22 /* UIUtils.swift */; };
 		51EEC2BC2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EEC2BB2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift */; };
 		51F7EEEC25C88E41002FE45F /* AcceptanceTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */; };
+		626ED9492E4F932400D34413 /* MockCardBinApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */; };
 		62A11ECD2E44B6BC00B0B96C /* CardBinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A11ECC2E44B6B700B0B96C /* CardBinService.swift */; };
 		62AA43732E390E760018EAAA /* CardBinCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */; };
 		62AA43752E39122E0018EAAA /* MockCardBinCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */; };
 		62BF77382E4C975B00369257 /* CardBinServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BF77372E4C975500369257 /* CardBinServiceTests.swift */; };
-		62EBE6122E4CA78C002944BF /* MockCardBinApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EBE6112E4CA78C002944BF /* MockCardBinApiClient.swift */; };
+		62C188872E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */; };
 		683DFBB48F1684E7AFD56E13 /* CvcSessionURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DFFF3DC25699A1CE15270 /* CvcSessionURLRequestFactory.swift */; };
 		75E83DCA95B5103C9D6B49BA /* Pods_AccessCheckoutSDKPactTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */; };
 		8CA5FFEF295CCB1011335D28 /* Pods_AccessCheckoutSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADB48EA1E45E15A6C80CC190 /* Pods_AccessCheckoutSDKTests.framework */; };
@@ -300,11 +301,12 @@
 		51EEC2BB2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCheckoutUITextFieldTests.swift; sourceTree = "<group>"; };
 		51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceTestSuite.swift; sourceTree = "<group>"; };
 		5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDKPactTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
 		62A11ECC2E44B6B700B0B96C /* CardBinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinService.swift; sourceTree = "<group>"; };
 		62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinCacheManagerTests.swift; sourceTree = "<group>"; };
 		62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinCacheManager.swift; sourceTree = "<group>"; };
 		62BF77372E4C975500369257 /* CardBinServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinServiceTests.swift; sourceTree = "<group>"; };
-		62EBE6112E4CA78C002944BF /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
+		62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		63E9AC2FDE45ABB3E75E6DFE /* Pods-AccessCheckoutSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDK.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDK/Pods-AccessCheckoutSDK.release.xcconfig"; sourceTree = "<group>"; };
 		683DF0BDC6FFC7C2D7F84EED /* RestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestClient.swift; sourceTree = "<group>"; };
 		683DF0FE5331B699757B3D19 /* URLSessionMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
@@ -669,7 +671,8 @@
 		683DF03ADFFF76E72571BEAE /* mock */ = {
 			isa = PBXGroup;
 			children = (
-				62EBE6112E4CA78C002944BF /* MockCardBinApiClient.swift */,
+				626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */,
+				62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */,
 				C22B02A32E4F8862004CA273 /* MockRestClient.swift */,
 				62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */,
 				C22CF9752E3B8B3000D77EBA /* MockApiResponseLinkLookup.swift */,
@@ -1463,13 +1466,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1506,13 +1505,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1703,7 +1698,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E77B8BAB245C562200564C19 /* RetrieveCvcSessionHandlerTests.swift in Sources */,
-				62EBE6122E4CA78C002944BF /* MockCardBinApiClient.swift in Sources */,
 				E7AD2454246412C800C4C92D /* MockSingleLinkDiscoveryFactory.swift in Sources */,
 				E749024B247FEE3C00889AAA /* TextChangeHandlerTests.swift in Sources */,
 				E7409D56248FA3C200016AEB /* MockTextChangeHandler.swift in Sources */,
@@ -1726,6 +1720,7 @@
 				E75C5E67248E6F7F003A1BDE /* MockAccessCheckoutCardValidationDelegate.swift in Sources */,
 				D7D6D5D2247EBA0600D57D7A /* ExpiryDateValidatorTests.swift in Sources */,
 				517145862AE2CA8D00A73A3F /* UITextFieldMock.swift in Sources */,
+				626ED9492E4F932400D34413 /* MockCardBinApiClient.swift in Sources */,
 				519F14422E4B8AB500038113 /* CardBinApiClientTestsWithStubService.swift in Sources */,
 				E7D37F8C248170300039DD98 /* CardBrandDtoTests.swift in Sources */,
 				D7D6D5D8247FC96100D57D7A /* CvcValidatorTests.swift in Sources */,
@@ -1753,6 +1748,7 @@
 				E719B0A2246483FF0037DED4 /* CardSessionsApiClientTests.swift in Sources */,
 				D7D6D5EB248117FB00D57D7A /* CardValidationStateHandlerTests.swift in Sources */,
 				E78C9AEA24928B0F00381214 /* AccessCheckoutCardValidationDelegate_ClearText_Tests.swift in Sources */,
+				62C188872E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift in Sources */,
 				E72C3F02248A78DA00284A31 /* CvcViewPresenterTests.swift in Sources */,
 				514A38332E329258000948C3 /* CardBinApiClientTests.swift in Sources */,
 				E74EB7452497A790008743E7 /* ExpiryDateFormatterTests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		62AA43752E39122E0018EAAA /* MockCardBinCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */; };
 		62BF77382E4C975B00369257 /* CardBinServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BF77372E4C975500369257 /* CardBinServiceTests.swift */; };
 		62C188872E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */; };
+		62E75C5A2E5498B9001FDD73 /* CardBinServiceTestsWithStubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E75C592E5498AD001FDD73 /* CardBinServiceTestsWithStubService.swift */; };
 		683DFBB48F1684E7AFD56E13 /* CvcSessionURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DFFF3DC25699A1CE15270 /* CvcSessionURLRequestFactory.swift */; };
 		75E83DCA95B5103C9D6B49BA /* Pods_AccessCheckoutSDKPactTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */; };
 		8CA5FFEF295CCB1011335D28 /* Pods_AccessCheckoutSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ADB48EA1E45E15A6C80CC190 /* Pods_AccessCheckoutSDKTests.framework */; };
@@ -307,6 +308,7 @@
 		62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinCacheManager.swift; sourceTree = "<group>"; };
 		62BF77372E4C975500369257 /* CardBinServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinServiceTests.swift; sourceTree = "<group>"; };
 		62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTaskMock.swift; sourceTree = "<group>"; };
+		62E75C592E5498AD001FDD73 /* CardBinServiceTestsWithStubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinServiceTestsWithStubService.swift; sourceTree = "<group>"; };
 		63E9AC2FDE45ABB3E75E6DFE /* Pods-AccessCheckoutSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDK.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDK/Pods-AccessCheckoutSDK.release.xcconfig"; sourceTree = "<group>"; };
 		683DF0BDC6FFC7C2D7F84EED /* RestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestClient.swift; sourceTree = "<group>"; };
 		683DF0FE5331B699757B3D19 /* URLSessionMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
@@ -529,6 +531,7 @@
 		5115F54D2E327AFA00BC3FDB /* cardBin */ = {
 			isa = PBXGroup;
 			children = (
+				62E75C592E5498AD001FDD73 /* CardBinServiceTestsWithStubService.swift */,
 				62BF77372E4C975500369257 /* CardBinServiceTests.swift */,
 				62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */,
 				514A38322E329258000948C3 /* CardBinApiClientTests.swift */,
@@ -1466,9 +1469,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1505,9 +1512,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1710,6 +1721,7 @@
 				D7C6EE212486A4F000170B92 /* ExpiryDateValidationFlowTests.swift in Sources */,
 				E72C3EE024866B8000284A31 /* MockPanValidator.swift in Sources */,
 				E72C3F0D248AB84900284A31 /* CardBrandModelTransformerTests.swift in Sources */,
+				62E75C5A2E5498B9001FDD73 /* CardBinServiceTestsWithStubService.swift in Sources */,
 				E719B0AE2464A4B90037DED4 /* CvcSessionsApiClientTests.swift in Sources */,
 				E72C3EDE248669EF00284A31 /* MockPanValidationStateHandler.swift in Sources */,
 				D7D6D5F3248154B900D57D7A /* PanValidationFlowTests.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/SingleLinkDiscovery.swift
@@ -14,7 +14,7 @@ class SingleLinkDiscovery {
     }
 
     func discover(completionHandler: @escaping (Result<String, AccessCheckoutError>) -> Void) {
-        restClient.send(
+        _ = restClient.send(
             urlSession: URLSession.shared,
             request: urlRequest
         ) { result, _ in

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cardSessions/CardSessionsApiClient.swift
@@ -82,7 +82,7 @@ class CardSessionsApiClient {
             expiryYear: expiryYear,
             cvc: cvc
         )
-        restClient.send(
+        _ = restClient.send(
             urlSession: URLSession.shared,
             request: request
         ) { result, _ in

--- a/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/session/api/cvcSessions/CvcSessionsApiClient.swift
@@ -63,7 +63,7 @@ class CvcSessionsApiClient {
     ) {
         let request = createRequest(endPointUrl: endPointUrl, checkoutId: checkoutId, cvc: cvc)
 
-        restClient.send(
+        _ = restClient.send(
             urlSession: URLSession.shared,
             request: request
         ) { result, _ in

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/service/CardBinService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/service/CardBinService.swift
@@ -36,6 +36,8 @@ internal class CardBinService {
         cardNumber: String,
         completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void
     ) {
+        client.abort()
+
         let sanitisedCardNumber = cardNumber.replacingOccurrences(of: " ", with: "")
 
         guard !sanitisedCardNumber.isEmpty else {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/configuration/CardBrandsConfigurationFactory.swift
@@ -23,7 +23,7 @@ class CardBrandsConfigurationFactory {
             return
         }
 
-        restClient.send(
+        _ = restClient.send(
             urlSession: URLSession.shared,
             request: URLRequest(url: url)
         ) { result, _ in

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RestClientTests.swift
@@ -176,7 +176,7 @@ class RestClientTests: XCTestCase {
     }
 
     func testDoesNotCallCompletionHandlerWhenTaskIsCancelled() {
-        serviceStubs!.get200(path: "/somewhere", textResponse: "some response", delay: 0.5)
+        serviceStubs!.get200(path: "/somewhere", textResponse: "some response", delayInSeconds: 0.5)
             .start()
 
         var calledCompletionHandler = false
@@ -191,7 +191,7 @@ class RestClientTests: XCTestCase {
 
         Thread.sleep(forTimeInterval: 1)
 
-        XCTAssertFalse(calledCompletionHandler)
+        XCTAssertTrue(!calledCompletionHandler)
     }
 
     private func createRequest(url: String, method: String) -> URLRequest {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
@@ -409,19 +409,16 @@ class ServiceDiscoveryProviderTests: XCTestCase {
             ? Result.failure(withSessionsDiscoveryError!)
             : Result.success(self.genericApiResponse())
 
-        let dummyURLSessionTask = URLSession.shared.dataTask(
-            with: URL(string: "https://dummy-url-session-task.com")!)
-
         restClient.getStubbingProxy()
             .send(urlSession: any(), request: any(), completionHandler: any())
             .then {
                 _, _, completionHandler in
                 completionHandler(accessRootDiscoveryResult, nil)
-                return dummyURLSessionTask
+                return URLSessionTask()
             }.then {
                 _, _, completionHandler in
                 completionHandler(sessionsDiscoveryResult, nil)
-                return dummyURLSessionTask
+                return URLSessionTask()
             }
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
@@ -409,14 +409,19 @@ class ServiceDiscoveryProviderTests: XCTestCase {
             ? Result.failure(withSessionsDiscoveryError!)
             : Result.success(self.genericApiResponse())
 
+        let dummyURLSessionTask = URLSession.shared.dataTask(
+            with: URL(string: "https://dummy-url-session-task.com")!)
+
         restClient.getStubbingProxy()
             .send(urlSession: any(), request: any(), completionHandler: any())
             .then {
                 _, _, completionHandler in
                 completionHandler(accessRootDiscoveryResult, nil)
+                return dummyURLSessionTask
             }.then {
                 _, _, completionHandler in
                 completionHandler(sessionsDiscoveryResult, nil)
+                return dummyURLSessionTask
             }
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBinApiClient.swift
@@ -42,6 +42,21 @@ class MockCardBinApiClient: CardBinApiClient, Cuckoo.ClassMock {
 
     }
 
+    override func abort() {
+
+        return cuckoo_manager.call(
+            """
+            abort()
+            """,
+            parameters: (),
+            escapingParameters: (),
+            superclassCall:
+
+                super.abort(),
+            defaultCall: __defaultImplStub!.abort())
+
+    }
+
     struct __StubbingProxy_CardBinApiClient: Cuckoo.StubbingProxy {
         private let cuckoo_manager: Cuckoo.MockManager
 
@@ -72,6 +87,17 @@ class MockCardBinApiClient: CardBinApiClient, Cuckoo.ClassMock {
                     method:
                         """
                         retrieveBinInfo(cardNumber: String, checkoutId: String, completionHandler: @escaping (Result<CardBinResponse, AccessCheckoutError>) -> Void)
+                        """, parameterMatchers: matchers))
+        }
+
+        func abort() -> Cuckoo.ClassStubNoReturnFunction<()> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCardBinApiClient.self,
+                    method:
+                        """
+                        abort()
                         """, parameterMatchers: matchers))
         }
 
@@ -116,6 +142,16 @@ class MockCardBinApiClient: CardBinApiClient, Cuckoo.ClassMock {
                 sourceLocation: sourceLocation)
         }
 
+        @discardableResult
+        func abort() -> Cuckoo.__DoNotUse<(), Void> {
+            let matchers: [Cuckoo.ParameterMatcher<Void>] = []
+            return cuckoo_manager.verify(
+                """
+                abort()
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
+        }
+
     }
 }
 
@@ -125,6 +161,10 @@ class CardBinApiClientStub: CardBinApiClient {
         cardNumber: String, checkoutId: String,
         completionHandler: @escaping (Result<CardBinResponse, AccessCheckoutError>) -> Void
     ) {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+
+    override func abort() {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockRestClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockRestClient.swift
@@ -23,11 +23,11 @@ class MockRestClient<T: Decodable>: RestClient<T>, Cuckoo.ClassMock {
     override func send(
         urlSession: URLSession, request: URLRequest,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
-    ) {
+    ) -> URLSessionTask {
 
         return cuckoo_manager.call(
             """
-            send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void)
+            send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
             """,
             parameters: (urlSession, request, completionHandler),
             escapingParameters: (urlSession, request, completionHandler),
@@ -50,8 +50,9 @@ class MockRestClient<T: Decodable>: RestClient<T>, Cuckoo.ClassMock {
         func send<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(
             urlSession: M1, request: M2, completionHandler: M3
         )
-            -> Cuckoo.ClassStubNoReturnFunction<
-                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void)
+            -> Cuckoo.ClassStubFunction<
+                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void),
+                URLSessionTask
             >
         where
             M1.MatchedType == URLSession, M2.MatchedType == URLRequest,
@@ -69,7 +70,7 @@ class MockRestClient<T: Decodable>: RestClient<T>, Cuckoo.ClassMock {
                     for: MockRestClient.self,
                     method:
                         """
-                        send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void)
+                        send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
                         """, parameterMatchers: matchers))
         }
 
@@ -94,7 +95,8 @@ class MockRestClient<T: Decodable>: RestClient<T>, Cuckoo.ClassMock {
             urlSession: M1, request: M2, completionHandler: M3
         )
             -> Cuckoo.__DoNotUse<
-                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void), Void
+                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void),
+                URLSessionTask
             >
         where
             M1.MatchedType == URLSession, M2.MatchedType == URLRequest,
@@ -109,7 +111,7 @@ class MockRestClient<T: Decodable>: RestClient<T>, Cuckoo.ClassMock {
                 ]
             return cuckoo_manager.verify(
                 """
-                send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void)
+                send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
                 """, callMatcher: callMatcher, parameterMatchers: matchers,
                 sourceLocation: sourceLocation)
         }
@@ -122,8 +124,8 @@ class RestClientStub<T: Decodable>: RestClient<T> {
     override func send(
         urlSession: URLSession, request: URLRequest,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
-    ) {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    ) -> URLSessionTask {
+        return DefaultValueRegistry.defaultValue(for: (URLSessionTask).self)
     }
 
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/RestClientMock.swift
@@ -24,7 +24,7 @@ class RestClientMock<T: Decodable>: RestClient<T> {
     override func send(
         urlSession: URLSession, request: URLRequest,
         completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
-    ) {
+    ) -> URLSessionTask {
         numberOfCalls += 1
         sendMethodCalled = true
         requestSent = request
@@ -34,5 +34,7 @@ class RestClientMock<T: Decodable>: RestClient<T> {
         } else if error != nil {
             completionHandler(.failure(error!), statusCode)
         }
+
+        return URLSessionTask()
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/MiscUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/MiscUtils.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+class MiscUtils {
+    public static func wait(testCase: XCTestCase, timeoutInSeconds: TimeInterval) {
+        let exp = XCTestCase().expectation(description: "Waiting for \(timeoutInSeconds)")
+        _ = XCTWaiter.wait(for: [exp], timeout: timeoutInSeconds)
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
@@ -36,13 +36,13 @@ struct ServiceStubs {
         return self
     }
 
-    func get200(path: String, textResponse: String, delay: TimeInterval) -> ServiceStubs {
+    func get200(path: String, textResponse: String, delayInSeconds: TimeInterval) -> ServiceStubs {
         let response: ((HttpRequest) -> HttpResponse) = { req in
             return HttpResponse.ok(
                 .custom(
                     "",
                     { _ -> String in
-                        Thread.sleep(forTimeInterval: delay)
+                        Thread.sleep(forTimeInterval: delayInSeconds)
                         return ""
                     }))
         }
@@ -74,9 +74,25 @@ struct ServiceStubs {
         return self
     }
 
+    func post200(path: String, textResponse: String, delayInSeconds: TimeInterval) -> ServiceStubs {
+        httpServer.POST[path] = { _ in
+            Thread.sleep(forTimeInterval: delayInSeconds)
+            return .ok(.text(textResponse))
+        }
+        return self
+    }
+
     func post400(path: String, error: AccessCheckoutError) -> ServiceStubs {
         let jsonData = try! toJSON(toJSONString(error))
         httpServer.POST[path] = { _ in .badRequest(.json(jsonData as AnyObject)) }
+        return self
+    }
+
+    func post500(path: String, delayInSeconds: TimeInterval) -> ServiceStubs {
+        httpServer.POST[path] = { _ in
+            Thread.sleep(forTimeInterval: delayInSeconds)
+            return .internalServerError
+        }
         return self
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/ServiceStubs.swift
@@ -36,6 +36,21 @@ struct ServiceStubs {
         return self
     }
 
+    func get200(path: String, textResponse: String, delay: TimeInterval) -> ServiceStubs {
+        let response: ((HttpRequest) -> HttpResponse) = { req in
+            return HttpResponse.ok(
+                .custom(
+                    "",
+                    { _ -> String in
+                        Thread.sleep(forTimeInterval: delay)
+                        return ""
+                    }))
+        }
+
+        httpServer.GET[path] = response
+        return self
+    }
+
     func get400(path: String, jsonResponse: String) -> ServiceStubs {
         let jsonData = try! toJSON(jsonResponse)
         httpServer.GET[path] = { _ in .badRequest(.json(jsonData as AnyObject)) }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
@@ -78,9 +78,6 @@ class StubUtils {
         ServiceDiscoveryProvider.shared = ServiceDiscoveryProvider(
             restClientMock, apiResponseLookUpMock)
 
-        let dummyURLSessionTask = URLSession.shared.dataTask(
-            with: URL(string: "https://dummy-url-session-task.com")!)
-
         // simulate access root discovery and sessions discovery responses
         // a response with actual links is not needed, just a valid response
         restClientMock.getStubbingProxy()
@@ -88,11 +85,11 @@ class StubUtils {
             .then {
                 _, _, completionHandler in
                 completionHandler(Result.success(self.toApiReponse()), nil)
-                return dummyURLSessionTask
+                return URLSessionTask()
             }.then {
                 _, _, completionHandler in
                 completionHandler(Result.success(self.toApiReponse()), nil)
-                return dummyURLSessionTask
+                return URLSessionTask()
             }
 
         // simulate api response link lookups

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
@@ -78,6 +78,9 @@ class StubUtils {
         ServiceDiscoveryProvider.shared = ServiceDiscoveryProvider(
             restClientMock, apiResponseLookUpMock)
 
+        let dummyURLSessionTask = URLSession.shared.dataTask(
+            with: URL(string: "https://dummy-url-session-task.com")!)
+
         // simulate access root discovery and sessions discovery responses
         // a response with actual links is not needed, just a valid response
         restClientMock.getStubbingProxy()
@@ -85,9 +88,11 @@ class StubUtils {
             .then {
                 _, _, completionHandler in
                 completionHandler(Result.success(self.toApiReponse()), nil)
+                return dummyURLSessionTask
             }.then {
                 _, _, completionHandler in
                 completionHandler(Result.success(self.toApiReponse()), nil)
+                return dummyURLSessionTask
             }
 
         // simulate api response link lookups

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -1,3 +1,4 @@
+import Cuckoo
 import Foundation
 import Swifter
 import XCTest
@@ -6,9 +7,21 @@ import XCTest
 
 class CardBinApiClientTestsWithStubService: XCTestCase {
     private var serviceStubs: ServiceStubs = ServiceStubs()
+    private var cardBinApiClient: CardBinApiClient!
+
+    private let checkoutId = "00000000-0000-0000-000000000000"
+    private let visaTestPan = "444433332222"
+
+    override func setUp() {
+        super.setUp()
+
+        cardBinApiClient = CardBinApiClient(url: "\(serviceStubs.baseUrl)/somewhere")
+    }
 
     override func tearDown() {
+        cardBinApiClient = nil
         serviceStubs.stop()
+        super.tearDown()
     }
 
     /*
@@ -24,16 +37,15 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
 
         var calledCompletionHandler = false
 
-        let cardBinApiClient = CardBinApiClient(
-            url: "\(serviceStubs.baseUrl)/somewhere", checkoutId: "something")
-        cardBinApiClient.retrieveBinInfo(cardNumber: "444433332222") { result in
+        cardBinApiClient.retrieveBinInfo(cardNumber: visaTestPan, checkoutId: checkoutId) {
+            result in
             calledCompletionHandler = true
         }
         cardBinApiClient.abort()
 
         Thread.sleep(forTimeInterval: 1)
 
-        XCTAssertTrue(!calledCompletionHandler)
+        XCTAssertFalse(calledCompletionHandler)
     }
 
     /*
@@ -51,9 +63,8 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
 
         var calledCompletionHandler = false
 
-        let cardBinApiClient = CardBinApiClient(
-            url: "\(serviceStubs.baseUrl)/somewhere", checkoutId: "something")
-        cardBinApiClient.retrieveBinInfo(cardNumber: "444433332222") { result in
+        cardBinApiClient.retrieveBinInfo(cardNumber: visaTestPan, checkoutId: checkoutId) {
+            result in
             calledCompletionHandler = true
         }
 
@@ -63,6 +74,6 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
 
         // Waiting until the end of any potential future retries
         Thread.sleep(forTimeInterval: 1)
-        XCTAssertTrue(!calledCompletionHandler)
+        XCTAssertFalse(calledCompletionHandler)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Swifter
+import XCTest
+
+@testable import AccessCheckoutSDK
+
+class CardBinApiClientTestsWithStubService: XCTestCase {
+    private var serviceStubs: ServiceStubs = ServiceStubs()
+
+    override func tearDown() {
+        serviceStubs.stop()
+    }
+
+    /*
+     This test is designed to:
+     - use a stub server
+     - delay the response from a stub server by 0.5 seconds
+     - abort the call to the retrieveBinInfo() method of the CardBinApiClient class
+     - assert that the completion handler passed to the retrieveBinInfo() method was never called
+     */
+    func testClientSupportsCancellingRequestInFlight() {
+        serviceStubs.post200(path: "/somewhere", textResponse: "some response", delayInSeconds: 0.5)
+            .start()
+
+        var calledCompletionHandler = false
+
+        let cardBinApiClient = CardBinApiClient(
+            url: "\(serviceStubs.baseUrl)/somewhere", checkoutId: "something")
+        cardBinApiClient.retrieveBinInfo(cardNumber: "444433332222") { result in
+            calledCompletionHandler = true
+        }
+        cardBinApiClient.abort()
+
+        Thread.sleep(forTimeInterval: 1)
+
+        XCTAssertTrue(!calledCompletionHandler)
+    }
+
+    /*
+     This test is designed to:
+     - use a stub server
+     - delay the response from a stub server by 0.2 seconds and always send back a 500
+     - 500s are used to make sure that the CardBinApiClient can retry since it would not if the error is an 4xx
+     - abort the call to the retrieveBinInfo() method of the CardBinApiClient class after 0.3 seconds, i.e. in the middle of the 2nd attempt
+     - wait 1s, for any potential retry to occur although they should not since abort() has been called
+     - assert that the completion handler passed to the retrieveBinInfo() method was never called
+     */
+    func testClientSupportsCancellingRequestInFlightWhenRetrying() {
+        serviceStubs.post500(path: "/somewhere", delayInSeconds: 0.2)
+            .start()
+
+        var calledCompletionHandler = false
+
+        let cardBinApiClient = CardBinApiClient(
+            url: "\(serviceStubs.baseUrl)/somewhere", checkoutId: "something")
+        cardBinApiClient.retrieveBinInfo(cardNumber: "444433332222") { result in
+            calledCompletionHandler = true
+        }
+
+        // Aborting the request after the 1st attempt has failed with 500
+        Thread.sleep(forTimeInterval: 0.3)
+        cardBinApiClient.abort()
+
+        // Waiting until the end of any potential future retries
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertTrue(!calledCompletionHandler)
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -13,15 +13,13 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
     private let visaTestPan = "444433332222"
 
     override func setUp() {
-        super.setUp()
-
+        serviceStubs = ServiceStubs()
         cardBinApiClient = CardBinApiClient(url: "\(serviceStubs.baseUrl)/somewhere")
     }
 
     override func tearDown() {
         cardBinApiClient = nil
         serviceStubs.stop()
-        super.tearDown()
     }
 
     /*

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTests.swift
@@ -407,13 +407,11 @@ class CardBinServiceTests: XCTestCase {
             }
         }
 
-        let _ = Result<Void, AccessCheckoutError> {
-            cardBinService.getCardBrands(
-                globalBrand: TestFixtures.discoverBrand(),
-                cardNumber: discoverDinersTestPan
-            ) { _ in
-                expectation.fulfill()
-            }
+        cardBinService.getCardBrands(
+            globalBrand: TestFixtures.discoverBrand(),
+            cardNumber: discoverDinersTestPan
+        ) { _ in
+            expectation.fulfill()
         }
 
         Thread.sleep(forTimeInterval: 0.2)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
@@ -1,0 +1,94 @@
+import Cuckoo
+import Foundation
+import Swifter
+import XCTest
+
+@testable import AccessCheckoutSDK
+
+class CardBinServiceTestsWithStubService: XCTestCase {
+    private var serviceStubs: ServiceStubs = ServiceStubs()
+    private var mockFactory: CardBrandsConfigurationFactoryMock!
+    private var mockConfigurationProvider: MockCardBrandsConfigurationProvider!
+    private var cardBinService: CardBinService!
+
+    private let checkoutId = "00000000-0000-0000-000000000000"
+    private let baseURL = "http://example.com"
+
+    private let visaTestPan = "444433332222"
+
+    override func setUp() {
+        mockFactory = CardBrandsConfigurationFactoryMock()
+        mockConfigurationProvider = MockCardBrandsConfigurationProvider(mockFactory)
+
+        stub(mockConfigurationProvider) { stub in
+            when(stub.get()).thenReturn(TestFixtures.createDefaultCardConfiguration())
+        }
+
+        let cardBinApiClient = CardBinApiClient(url: "\(serviceStubs.baseUrl)/somewhere")
+
+        cardBinService = CardBinService(
+            checkoutId: checkoutId,
+            baseURL: "\(serviceStubs.baseUrl)/somewhere",
+            client: cardBinApiClient,
+            configurationProvider: mockConfigurationProvider
+        )
+    }
+
+    override func tearDown() {
+        cardBinService = nil
+        serviceStubs.stop()
+    }
+
+    /*
+     This test is designed to:
+     - use a stub server with delayed response
+     - make a first call that will be aborted
+     - make a second call that will complete successfully
+     - verify that only the second completion handler is called
+     */
+    func testServiceCancelsFirstRequestAndOnlyCompletesSecond_withSwifter() {
+        let cardBinResponse = """
+            {
+                "brand": ["visa"],
+                "fundingType": "debit",
+                "luhnCompliant": true
+            }
+            """
+
+        serviceStubs.post200(path: "/somewhere", textResponse: cardBinResponse, delayInSeconds: 0.2)
+            .start()
+
+        let firstExpectation = self.expectation(description: "First call should not complete ")
+        // we expect this to not be fulfilled as it should be an aborted call
+        firstExpectation.isInverted = true
+        let secondExpectation = self.expectation(
+            description: "Second call should complete successfully")
+
+        cardBinService.getCardBrands(
+            globalBrand: TestFixtures.visaBrand(),
+            cardNumber: "444433332222"
+        ) { result in
+            firstExpectation.fulfill()
+        }
+
+        // small delay to ensure first request is in flight
+        Thread.sleep(forTimeInterval: 0.05)
+
+        cardBinService.getCardBrands(
+            globalBrand: TestFixtures.visaBrand(),
+            cardNumber: "444455556666"
+        ) { result in
+            if case .success(let brands) = result {
+                XCTAssertEqual(brands.count, 1)
+                XCTAssertEqual(brands.first?.name, "visa")
+            } else {
+                XCTFail("Expected success but got failure")
+            }
+            secondExpectation.fulfill()
+        }
+
+        // should pass if first expectation does not to fulfill (inverted expectation) and second expectation does fulfill
+        wait(for: [firstExpectation, secondExpectation], timeout: 1.0)
+
+    }
+}

--- a/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
+++ b/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
@@ -12,17 +12,17 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "identity": "identity",
           "cardNumber": "4111111111111110",
-          "cvc": "123",
           "cardExpiryDate": {
             "month": 12,
             "year": 2099
-          }
+          },
+          "cvc": "123"
         }
       },
       "response": {
@@ -31,13 +31,13 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "message": "The json body provided does not match the expected schema",
           "errorName": "bodyDoesNotMatchSchema",
+          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "message": "The identified field contains a PAN that has failed the Luhn check.",
+              "jsonPath": "$.cardNumber",
               "errorName": "panFailedLuhnCheck",
-              "jsonPath": "$.cardNumber"
+              "message": "The identified field contains a PAN that has failed the Luhn check."
             }
           ]
         },
@@ -57,16 +57,16 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "cvc": "123",
+          "cardNumber": "notACardNumber",
           "cardExpiryDate": {
             "month": 1,
             "year": 2099
           },
-          "cardNumber": "notACardNumber",
           "identity": "identity"
         }
       },
@@ -76,6 +76,7 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
+          "errorName": "bodyDoesNotMatchSchema",
           "validationErrors": [
             {
               "message": "Card number must be numeric",
@@ -83,8 +84,7 @@
               "jsonPath": "$.cardNumber"
             }
           ],
-          "message": "The json body provided does not match the expected schema",
-          "errorName": "bodyDoesNotMatchSchema"
+          "message": "The json body provided does not match the expected schema"
         },
         "matchingRules": {
           "$.body.validationErrors[0].message": {
@@ -125,9 +125,9 @@
           "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
+              "message": "Identity is invalid",
               "jsonPath": "$.identity",
-              "errorName": "fieldHasInvalidValue",
-              "message": "Identity is invalid"
+              "errorName": "fieldHasInvalidValue"
             }
           ]
         },
@@ -151,13 +151,13 @@
           "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "identity": "identity",
+          "cardNumber": "4111111111111111",
           "cardExpiryDate": {
             "month": 13,
             "year": 2099
           },
-          "cardNumber": "4111111111111111",
-          "cvc": "123"
+          "cvc": "123",
+          "identity": "identity"
         }
       },
       "response": {
@@ -166,21 +166,21 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "errorName": "bodyDoesNotMatchSchema",
           "validationErrors": [
             {
-              "message": "Card expiry month is too large - must be between 1 & 12",
               "jsonPath": "$.cardExpiryDate.month",
+              "message": "Card expiry month is too large - must be between 1 & 12",
               "errorName": "integerIsTooLarge"
             }
           ],
+          "errorName": "bodyDoesNotMatchSchema",
           "message": "The json body provided does not match the expected schema"
         },
         "matchingRules": {
-          "$.body.message": {
+          "$.body.validationErrors[0].message": {
             "match": "type"
           },
-          "$.body.validationErrors[0].message": {
+          "$.body.message": {
             "match": "type"
           }
         }
@@ -207,14 +207,14 @@
         },
         "body": {
           "message": "The json body provided does not match the expected schema",
+          "errorName": "bodyDoesNotMatchSchema",
           "validationErrors": [
             {
-              "errorName": "fieldHasInvalidValue",
               "message": "Identity is invalid",
+              "errorName": "fieldHasInvalidValue",
               "jsonPath": "$.identity"
             }
-          ],
-          "errorName": "bodyDoesNotMatchSchema"
+          ]
         },
         "matchingRules": {
           "$.body.message": {
@@ -232,8 +232,8 @@
         "method": "get",
         "path": "/sessions",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         }
       },
       "response": {
@@ -269,17 +269,17 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
+          "cvc": "123",
+          "cardNumber": "4111111111111111",
           "cardExpiryDate": {
             "year": 2099,
             "month": 12
           },
-          "identity": "identity",
-          "cardNumber": "4111111111111111",
-          "cvc": "123"
+          "identity": "identity"
         }
       },
       "response": {


### PR DESCRIPTION
### What:
1. Card bin request abort functionlity

### Why:
1. In order to allow requests to be aborted if secondary request if fired before the first request returns
2. Stops race conditions where first request may be delayed and return later than second request

### How:
1. Card bin request aborted at service level when getCardBrands is called by second request