### PR TITLE
US2193501 add service discovery retry mech

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -68,7 +68,11 @@
 		C213F7772E32853200B89815 /* ServiceDiscoveryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C213F7762E32853200B89815 /* ServiceDiscoveryProvider.swift */; };
 		C22B02A42E4F8862004CA273 /* MockRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22B02A32E4F8862004CA273 /* MockRestClient.swift */; };
 		C22CF9772E3B8B3000D77EBA /* MockApiResponseLinkLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22CF9752E3B8B3000D77EBA /* MockApiResponseLinkLookup.swift */; };
+		C23DD1332E561E2B00506DAE /* RestClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23DD1322E561E2400506DAE /* RestClientProtocol.swift */; };
+		C23DD1372E56261C00506DAE /* MockRetryRestClientDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */; };
 		C253C10F2E38D69100D01D1F /* ServiceDiscoveryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C253C10E2E38D68500D01D1F /* ServiceDiscoveryProviderTests.swift */; };
+		C2C116A82E5753E100C12A45 /* RetryRestClientDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C116A72E5753D600C12A45 /* RetryRestClientDecoratorTests.swift */; };
+		C2C116AA2E5754E800C12A45 /* RetryRestClientDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C116A92E5754E800C12A45 /* RetryRestClientDecorator.swift */; };
 		C9AFE3DD22B7996200943B3E /* AccessCheckoutSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9AFE3D322B7996200943B3E /* AccessCheckoutSDK.framework */; };
 		C9AFE3E422B7996200943B3E /* AccessCheckoutSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = C9AFE3D622B7996200943B3E /* AccessCheckoutSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C9AFE45A22B7AA4800943B3E /* AccessCheckoutError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AFE44722B7AA4700943B3E /* AccessCheckoutError.swift */; };
@@ -321,7 +325,12 @@
 		C213F7762E32853200B89815 /* ServiceDiscoveryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDiscoveryProvider.swift; sourceTree = "<group>"; };
 		C22B02A32E4F8862004CA273 /* MockRestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRestClient.swift; sourceTree = "<group>"; };
 		C22CF9752E3B8B3000D77EBA /* MockApiResponseLinkLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApiResponseLinkLookup.swift; sourceTree = "<group>"; };
+		C23DD1322E561E2400506DAE /* RestClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestClientProtocol.swift; sourceTree = "<group>"; };
+		C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRetryRestClientDecorator.swift; sourceTree = "<group>"; };
 		C253C10E2E38D68500D01D1F /* ServiceDiscoveryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDiscoveryProviderTests.swift; sourceTree = "<group>"; };
+		C28D9E112E5778EA007100EB /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
+		C2C116A72E5753D600C12A45 /* RetryRestClientDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryRestClientDecoratorTests.swift; sourceTree = "<group>"; };
+		C2C116A92E5754E800C12A45 /* RetryRestClientDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryRestClientDecorator.swift; sourceTree = "<group>"; };
 		C981F8AC51B8A59C0F308006 /* Pods-AccessCheckoutSDKPactTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDKPactTests.debug.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C9AFE3D322B7996200943B3E /* AccessCheckoutSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AccessCheckoutSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9AFE3D622B7996200943B3E /* AccessCheckoutSDK.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessCheckoutSDK.h; sourceTree = "<group>"; };
@@ -675,6 +684,7 @@
 			isa = PBXGroup;
 			children = (
 				626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */,
+				C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */,
 				62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */,
 				C22B02A32E4F8862004CA273 /* MockRestClient.swift */,
 				62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */,
@@ -966,6 +976,7 @@
 		E73A20142459D3C600D5EB4C /* api */ = {
 			isa = PBXGroup;
 			children = (
+				C2C116A72E5753D600C12A45 /* RetryRestClientDecoratorTests.swift */,
 				C253C10E2E38D68500D01D1F /* ServiceDiscoveryProviderTests.swift */,
 				513039A12B10F68800C01B10 /* ApiHeadersTests.swift */,
 				513039A32B10F69800C01B10 /* ApiLinksTest.swift */,
@@ -1102,6 +1113,8 @@
 		E7821AA2245875C1003F7231 /* api */ = {
 			isa = PBXGroup;
 			children = (
+				C2C116A92E5754E800C12A45 /* RetryRestClientDecorator.swift */,
+				C23DD1322E561E2400506DAE /* RestClientProtocol.swift */,
 				E7821A86245869DB003F7231 /* ApiHeaders.swift */,
 				E7821A84245869A3003F7231 /* ApiLinks.swift */,
 				C9AFE44822B7AA4700943B3E /* ApiResponse.swift */,
@@ -1684,10 +1697,12 @@
 				E72C3EE224866ED200284A31 /* PanValidationResult.swift in Sources */,
 				C213F7772E32853200B89815 /* ServiceDiscoveryProvider.swift in Sources */,
 				E77B8B96245C2B4900564C19 /* RetrieveSessionHandlerDispatcher.swift in Sources */,
+				C23DD1332E561E2B00506DAE /* RestClientProtocol.swift in Sources */,
 				E7D37F89248168C70039DD98 /* CardBrandDto.swift in Sources */,
 				E745CC22248575FE000390CA /* CardBrandDtoTransformer.swift in Sources */,
 				E72C3ED42485B0DF00284A31 /* PanViewPresenter.swift in Sources */,
 				E72C3F0B248AB7B800284A31 /* CardBrandModelTransformer.swift in Sources */,
+				C2C116AA2E5754E800C12A45 /* RetryRestClientDecorator.swift in Sources */,
 				E745CC1C24856E68000390CA /* CardBrandModel.swift in Sources */,
 				E7D37F8024815E0C0039DD98 /* CardBrandsConfigurationFactory.swift in Sources */,
 				D7D6D5F52481550200D57D7A /* PanValidationFlow.swift in Sources */,
@@ -1750,6 +1765,7 @@
 				E77B8BA5245C516E00564C19 /* RetrieveCardSessionHandlerMock.swift in Sources */,
 				C22B02A42E4F8862004CA273 /* MockRestClient.swift in Sources */,
 				E7633D2B249D195100FFE190 /* ApiResponseTests.swift in Sources */,
+				C23DD1372E56261C00506DAE /* MockRetryRestClientDecorator.swift in Sources */,
 				E7C4D236249CF4D100D7B9F1 /* EncodableExtension.swift in Sources */,
 				E7D19F7024632243001EA13A /* ApiResponseLinkLookupTests.swift in Sources */,
 				E78C9AEC24928CD700381214 /* AccessCheckoutCvcOnlyValidationDelegate_ClearText_Tests.swift in Sources */,
@@ -1804,6 +1820,7 @@
 				5138297026863877001E61B5 /* PanViewPresenterCardSpacingTests.swift in Sources */,
 				E72C3EF8248A57C300284A31 /* PanViewPresenterNoCardSpacingTests.swift in Sources */,
 				E7AC80AA248E741800E28D76 /* AccessCheckoutCvcOnlyValidationDelegate_FocusOut_Tests.swift in Sources */,
+				C2C116A82E5753E100C12A45 /* RetryRestClientDecoratorTests.swift in Sources */,
 				D7258634264ABFBC00DB60EB /* PanTextChangeHandlerTests.swift in Sources */,
 				E760196D246D7E37004D6F2E /* RetrieveSessionResultsHandlerTests.swift in Sources */,
 				E7AC80AE248EB8FE00E28D76 /* MockExpiryDateValidationFlow.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal class RestClient<T: Decodable> {
+internal class RestClient<T: Decodable>: RestClientProtocol {
     func send(
         urlSession: URLSession,
         request: URLRequest,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClientProtocol.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClientProtocol.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol RestClientProtocol {
     associatedtype ResponseType: Decodable
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClientProtocol.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RestClientProtocol.swift
@@ -1,0 +1,9 @@
+protocol RestClientProtocol {
+    associatedtype ResponseType: Decodable
+
+    func send(
+        urlSession: URLSession,
+        request: URLRequest,
+        completionHandler: @escaping (Result<ResponseType, AccessCheckoutError>, Int?) -> Void
+    ) -> URLSessionTask
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/RetryRestClientDecorator.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/RetryRestClientDecorator.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+internal class RetryRestClientDecorator<T: Decodable>: RestClientProtocol {
+    private let baseRestClient: RestClient<T>
+    private let maxAttempts: Int
+
+    init(baseRestClient: RestClient<T> = RestClient(), maxAttempts: Int = 3) {
+        self.baseRestClient = baseRestClient
+        self.maxAttempts = maxAttempts
+    }
+
+    func send(
+        urlSession: URLSession,
+        request: URLRequest,
+        completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
+    ) -> URLSessionTask {
+        sendWithRetries(
+            urlSession: urlSession, request: request, attempts: 1,
+            completionHandler: completionHandler)
+    }
+
+    private func sendWithRetries(
+        urlSession: URLSession,
+        request: URLRequest,
+        attempts: Int,
+        completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
+    ) -> URLSessionTask {
+        baseRestClient.send(urlSession: urlSession, request: request) { result, statusCode in
+            switch result {
+            case .success(let response):
+                completionHandler(.success(response), statusCode)
+            case .failure(let error):
+                if attempts < self.maxAttempts {
+                    _ = self.sendWithRetries(
+                        urlSession: urlSession,
+                        request: request,
+                        attempts: attempts + 1,
+                        completionHandler: completionHandler
+                    )
+                } else {
+                    let error = AccessCheckoutError.unexpectedApiError(
+                        message:
+                            "Failed after \(self.maxAttempts) attempt(s) with error \(error.message)"
+                    )
+                    completionHandler(.failure(error), statusCode)
+                }
+            }
+        }
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryProvider.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/api/ServiceDiscoveryProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 import os
 
 class ServiceDiscoveryProvider {
-    private let restClient: RestClient<ApiResponse>
+    private let restClient: RetryRestClientDecorator<ApiResponse>
     private let apiResponseLinkLookup: ApiResponseLinkLookup
 
     private static let serialQueue = DispatchQueue(
@@ -19,7 +19,7 @@ class ServiceDiscoveryProvider {
     static var shared: ServiceDiscoveryProvider = ServiceDiscoveryProvider()
 
     init(
-        _ restClient: RestClient<ApiResponse> = RestClient(),
+        _ restClient: RetryRestClientDecorator<ApiResponse> = RetryRestClientDecorator(),
         _ apiResponseLinkLookup: ApiResponseLinkLookup = ApiResponseLinkLookup()
     ) {
         self.restClient = restClient

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RetryRestClientDecoratorTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/RetryRestClientDecoratorTests.swift
@@ -1,0 +1,175 @@
+import Cuckoo
+import Foundation
+import XCTest
+
+@testable import AccessCheckoutSDK
+
+class RetryRestClientDecoratorTests: XCTestCase {
+    private var expectationToFulfill: XCTestExpectation?
+
+    var baseRestClient = MockRestClient<ApiResponse>()
+    var retryRestClient: RetryRestClientDecorator<ApiResponse>!
+
+    override func setUp() {
+        retryRestClient = RetryRestClientDecorator<ApiResponse>(baseRestClient: baseRestClient)
+    }
+
+    func testShouldReturnAnErrorAfterXAttemptsToSendRequest() {
+        expectationToFulfill = expectation(description: "")
+
+        let attempts = 6
+
+        let responseError = AccessCheckoutError.unexpectedApiError(
+            message: "some error message")
+        let expectedError = AccessCheckoutError.unexpectedApiError(
+            message:
+                "Failed after \(attempts) attempt(s) with error \(responseError.message)"
+        )
+
+        setUpBaseRestClient(withError: responseError)
+
+        let (request, urlSession) = createRequestAndUrlSession(
+            url: "http://localhost/somewhere", method: "GET")
+
+        retryRestClient = RetryRestClientDecorator<ApiResponse>(
+            baseRestClient: baseRestClient, maxAttempts: attempts)
+
+        _ = retryRestClient.send(urlSession: urlSession, request: request) { result, _ in
+            switch result {
+            case .success:
+                XCTFail("Expected all request attempts to fail, but received a success")
+
+                self.expectationToFulfill!.fulfill()
+            case .failure(let error):
+                verify(self.baseRestClient, times(attempts)).send(
+                    urlSession: any(), request: any(), completionHandler: any())
+
+                XCTAssertEqual(error, expectedError)
+
+                self.expectationToFulfill!.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testShouldReturnAnErrorAfterDefaultAmountOfAttemptsHaveBeenMadeToSendRequest() {
+        expectationToFulfill = expectation(description: "")
+
+        let responseError = AccessCheckoutError.unexpectedApiError(
+            message: "some error message")
+        let expectedError = AccessCheckoutError.unexpectedApiError(
+            message:
+                "Failed after 3 attempt(s) with error \(responseError.message)"
+        )
+
+        setUpBaseRestClient(withError: responseError)
+
+        let (request, urlSession) = createRequestAndUrlSession(
+            url: "http://localhost/somewhere", method: "GET")
+
+        _ = retryRestClient.send(urlSession: urlSession, request: request) { result, _ in
+            switch result {
+            case .success:
+                XCTFail("Expected all request attempts to fail, but received a success")
+
+                self.expectationToFulfill!.fulfill()
+            case .failure(let error):
+                verify(self.baseRestClient, times(3)).send(
+                    urlSession: any(), request: any(), completionHandler: any())
+
+                XCTAssertEqual(error, expectedError)
+
+                self.expectationToFulfill!.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testShouldReturnResponseAfterTwoFailedAttemptsToSendRequest() {
+        expectationToFulfill = expectation(description: "")
+
+        let responseError = AccessCheckoutError.unexpectedApiError(
+            message: "some error message")
+
+        baseRestClient.getStubbingProxy()
+            .send(urlSession: any(), request: any(), completionHandler: any())
+            .then {
+                _, _, completionHandler in
+                completionHandler(.failure(responseError), nil)
+                return URLSessionTask()
+            }.then {
+                _, _, completionHandler in
+                completionHandler(.failure(responseError), nil)
+                return URLSessionTask()
+            }.then {
+                _, _, completionHandler in
+                completionHandler(.success(self.genericApiResponse()), nil)
+                return URLSessionTask()
+            }
+
+        let (request, urlSession) = createRequestAndUrlSession(
+            url: "http://localhost/somewhere", method: "GET")
+
+        _ = retryRestClient.send(urlSession: urlSession, request: request) { result, _ in
+            switch result {
+            case .success(let response):
+                verify(self.baseRestClient, times(3)).send(
+                    urlSession: any(), request: any(), completionHandler: any())
+                XCTAssertNotNil(response)
+                self.expectationToFulfill!.fulfill()
+            case .failure(let error):
+                XCTFail(
+                    "Expected request to succeed, but it failed with error: \(error.errorDescription!)"
+                )
+
+                self.expectationToFulfill!.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    private func setUpBaseRestClient(withError: AccessCheckoutError? = nil) {
+        let result =
+            (withError != nil)
+            ? Result.failure(withError!)
+            : Result.success(self.genericApiResponse())
+
+        baseRestClient.getStubbingProxy()
+            .send(urlSession: any(), request: any(), completionHandler: any())
+            .then {
+                _, _, completionHandler in
+                completionHandler(result, nil)
+                return URLSessionTask()
+            }
+    }
+
+    private func genericApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "a:service": {
+                        "href": "http://www.a-service.co.uk"
+                    },
+                },
+            }
+            """
+
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
+    }
+
+    private func createRequestAndUrlSession(url: String, method: String) -> (URLRequest, URLSession)
+    {
+        let urlInstance: URL? = URL(string: url)
+        var request = URLRequest(url: urlInstance!)
+        request.httpMethod = method
+
+        let urlSessionDataTaskMock = URLSessionDataTaskMock()
+        let urlSession = URLSessionMock(forRequest: request, usingDataTask: urlSessionDataTaskMock)
+
+        return (request, urlSession)
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/api/ServiceDiscoveryProviderTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class ServiceDiscoveryProviderTests: XCTestCase {
     let baseUrl = "some-url"
-    let restClient = MockRestClient<ApiResponse>()
+    let restClient = MockRetryRestClientDecorator<ApiResponse>()
     let apiResponseLookUpMock = MockApiResponseLinkLookup()
 
     // default api response values for testing

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/session/AccessCheckoutClientTests.swift
@@ -158,6 +158,8 @@ class AccessCheckoutClientTests: XCTestCase {
         let client = createAccessCheckoutClient(baseUrl: serviceStubs!.baseUrl)
         let cardDetails = validCardDetails()
         let expectedError = StubUtils.createError(errorName: "unknown", message: "an error")
+        let retryError = AccessCheckoutError.unexpectedApiError(
+            message: "Failed after 3 attempt(s) with error unknown : an error")
 
         serviceStubs!.servicesRootDiscoverySuccess()
             .sessionsEndPointDiscoveryFailure(error: expectedError)
@@ -171,7 +173,7 @@ class AccessCheckoutClientTests: XCTestCase {
             case .success:
                 XCTFail("Should have received an error but received sessions")
             case .failure(let error):
-                XCTAssertEqual(expectedError, error)
+                XCTAssertEqual(retryError, error)
             }
             expectationToFulfill.fulfill()
         }
@@ -257,6 +259,9 @@ class AccessCheckoutClientTests: XCTestCase {
         let expectedError = StubUtils.createError(errorName: "unknown", message: "an error message")
         let cardDetails = validCardDetails()
 
+        let retryError = AccessCheckoutError.unexpectedApiError(
+            message: "Failed after 3 attempt(s) with error unknown : an error message")
+
         serviceStubs!.servicesRootDiscoveryFailure(error: expectedError)
             .start()
 
@@ -266,7 +271,7 @@ class AccessCheckoutClientTests: XCTestCase {
             case .success:
                 XCTFail("Should have failed to discover services")
             case .failure(let error):
-                XCTAssertEqual("unknown : an error message", error.message)
+                XCTAssertEqual(retryError, error)
             }
             expectationToFulfill.fulfill()
         }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockRetryRestClientDecorator.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockRetryRestClientDecorator.swift
@@ -1,0 +1,131 @@
+import Cuckoo
+import Foundation
+
+@testable import AccessCheckoutSDK
+
+class MockRetryRestClientDecorator<T: Decodable>: RetryRestClientDecorator<T>, Cuckoo.ClassMock {
+
+    typealias MocksType = RetryRestClientDecorator<T>
+
+    typealias Stubbing = __StubbingProxy_RetryRestClientDecorator
+    typealias Verification = __VerificationProxy_RetryRestClientDecorator
+
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
+
+    private var __defaultImplStub: RetryRestClientDecorator<T>?
+
+    func enableDefaultImplementation(_ stub: RetryRestClientDecorator<T>) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+
+    override func send(
+        urlSession: URLSession, request: URLRequest,
+        completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
+    ) -> URLSessionTask {
+
+        return cuckoo_manager.call(
+            """
+            send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
+            """,
+            parameters: (urlSession, request, completionHandler),
+            escapingParameters: (urlSession, request, completionHandler),
+            superclassCall:
+
+                super.send(
+                    urlSession: urlSession, request: request, completionHandler: completionHandler),
+            defaultCall: __defaultImplStub!.send(
+                urlSession: urlSession, request: request, completionHandler: completionHandler))
+
+    }
+
+    struct __StubbingProxy_RetryRestClientDecorator: Cuckoo.StubbingProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+
+        init(manager: Cuckoo.MockManager) {
+            self.cuckoo_manager = manager
+        }
+
+        func send<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(
+            urlSession: M1, request: M2, completionHandler: M3
+        )
+            -> Cuckoo.ClassStubFunction<
+                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void),
+                URLSessionTask
+            >
+        where
+            M1.MatchedType == URLSession, M2.MatchedType == URLRequest,
+            M3.MatchedType == (Result<T, AccessCheckoutError>, Int?) -> Void
+        {
+            let matchers:
+                [Cuckoo.ParameterMatcher<
+                    (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void)
+                >] = [
+                    wrap(matchable: urlSession) { $0.0 }, wrap(matchable: request) { $0.1 },
+                    wrap(matchable: completionHandler) { $0.2 },
+                ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockRetryRestClientDecorator.self,
+                    method:
+                        """
+                        send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
+                        """, parameterMatchers: matchers))
+        }
+
+    }
+
+    struct __VerificationProxy_RetryRestClientDecorator: Cuckoo.VerificationProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+        private let callMatcher: Cuckoo.CallMatcher
+        private let sourceLocation: Cuckoo.SourceLocation
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
+            self.cuckoo_manager = manager
+            self.callMatcher = callMatcher
+            self.sourceLocation = sourceLocation
+        }
+
+        @discardableResult
+        func send<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(
+            urlSession: M1, request: M2, completionHandler: M3
+        )
+            -> Cuckoo.__DoNotUse<
+                (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void),
+                URLSessionTask
+            >
+        where
+            M1.MatchedType == URLSession, M2.MatchedType == URLRequest,
+            M3.MatchedType == (Result<T, AccessCheckoutError>, Int?) -> Void
+        {
+            let matchers:
+                [Cuckoo.ParameterMatcher<
+                    (URLSession, URLRequest, (Result<T, AccessCheckoutError>, Int?) -> Void)
+                >] = [
+                    wrap(matchable: urlSession) { $0.0 }, wrap(matchable: request) { $0.1 },
+                    wrap(matchable: completionHandler) { $0.2 },
+                ]
+            return cuckoo_manager.verify(
+                """
+                send(urlSession: URLSession, request: URLRequest, completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void) -> URLSessionTask
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
+        }
+
+    }
+}
+
+class RetryRestClientDecoratorStub<T: Decodable>: RetryRestClientDecorator<T> {
+
+    override func send(
+        urlSession: URLSession, request: URLRequest,
+        completionHandler: @escaping (Result<T, AccessCheckoutError>, Int?) -> Void
+    ) -> URLSessionTask {
+        return DefaultValueRegistry.defaultValue(for: (URLSessionTask).self)
+    }
+
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/StubUtils.swift
@@ -71,7 +71,7 @@ class StubUtils {
         cardUrlToReturn: String? = "cardHref",
         cvcUrlToReturn: String? = "cvcHref"
     ) {
-        let restClientMock = MockRestClient<ApiResponse>()
+        let restClientMock = MockRetryRestClientDecorator<ApiResponse>()
         let apiResponseLookUpMock = MockApiResponseLinkLookup()
 
         ServiceDiscoveryProvider.shared.clearCache()

--- a/AccessCheckoutSDK/scripts/mocks-build-phase.sh
+++ b/AccessCheckoutSDK/scripts/mocks-build-phase.sh
@@ -41,6 +41,7 @@ INPUT_SOURCE_DIR="${PROJECT_DIR}/${PROJECT_NAME}"
 "${INPUT_SOURCE_DIR}/validation/api/cardBin/client/CardBinCacheManager.swift" \
 "${INPUT_SOURCE_DIR}/api/ApiResponseLinkLookup.swift" \
 "${INPUT_SOURCE_DIR}/validation/api/cardBin/client/CardBinApiClient.swift" \
-"${INPUT_SOURCE_DIR}/api/RestClient.swift"
+"${INPUT_SOURCE_DIR}/api/RestClient.swift" \
+"${INPUT_SOURCE_DIR}/api/RetryRestClientDecorator.swift" 
 
 # all lines of this command must end with a \ apart from the last line


### PR DESCRIPTION
## What
- introduce retry mechanism in new service discovery
## How
- extend the `RestClient` with `RetryRestClient` and encapsulate retry logic there 
- add/update unit tests
## Why 
- so that we can retry service discovery request incase of unexpected failures