### PR TITLE
Us2128871 add call to card bin service final

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -680,6 +680,13 @@
 			path = service;
 			sourceTree = "<group>";
 		};
+		62E75C5B2E561E59001FDD73 /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		683DF03ADFFF76E72571BEAE /* mock */ = {
 			isa = PBXGroup;
 			children = (
@@ -870,6 +877,7 @@
 		E72C3F13248AFB5D00284A31 /* pan */ = {
 			isa = PBXGroup;
 			children = (
+				62E75C5B2E561E59001FDD73 /* New Group */,
 				D7D6D5F42481550200D57D7A /* PanValidationFlow.swift */,
 				E72C3EE124866ED200284A31 /* PanValidationResult.swift */,
 				D7D6D5F024814F5500D57D7A /* PanValidationStateHandler.swift */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E831E12ACDB49900A8FC22 /* UIUtils.swift */; };
 		51EEC2BC2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EEC2BB2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift */; };
 		51F7EEEC25C88E41002FE45F /* AcceptanceTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */; };
+		623C43D52E65955400AAC441 /* MockCardBinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623C43D42E65955400AAC441 /* MockCardBinService.swift */; };
 		626ED9492E4F932400D34413 /* MockCardBinApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */; };
 		62A11ECD2E44B6BC00B0B96C /* CardBinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A11ECC2E44B6B700B0B96C /* CardBinService.swift */; };
 		62AA43732E390E760018EAAA /* CardBinCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */; };
@@ -306,6 +307,7 @@
 		51EEC2BB2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCheckoutUITextFieldTests.swift; sourceTree = "<group>"; };
 		51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceTestSuite.swift; sourceTree = "<group>"; };
 		5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDKPactTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		623C43D42E65955400AAC441 /* MockCardBinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinService.swift; sourceTree = "<group>"; };
 		626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
 		62A11ECC2E44B6B700B0B96C /* CardBinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinService.swift; sourceTree = "<group>"; };
 		62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinCacheManagerTests.swift; sourceTree = "<group>"; };
@@ -328,7 +330,6 @@
 		C23DD1322E561E2400506DAE /* RestClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestClientProtocol.swift; sourceTree = "<group>"; };
 		C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRetryRestClientDecorator.swift; sourceTree = "<group>"; };
 		C253C10E2E38D68500D01D1F /* ServiceDiscoveryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceDiscoveryProviderTests.swift; sourceTree = "<group>"; };
-		C28D9E112E5778EA007100EB /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
 		C2C116A72E5753D600C12A45 /* RetryRestClientDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryRestClientDecoratorTests.swift; sourceTree = "<group>"; };
 		C2C116A92E5754E800C12A45 /* RetryRestClientDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryRestClientDecorator.swift; sourceTree = "<group>"; };
 		C981F8AC51B8A59C0F308006 /* Pods-AccessCheckoutSDKPactTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutSDKPactTests.debug.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -690,6 +691,7 @@
 		683DF03ADFFF76E72571BEAE /* mock */ = {
 			isa = PBXGroup;
 			children = (
+				623C43D42E65955400AAC441 /* MockCardBinService.swift */,
 				626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */,
 				C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */,
 				62C188862E4F8B5B001F0BDA /* URLSessionDataTaskMock.swift */,
@@ -1809,6 +1811,7 @@
 				C253C10F2E38D69100D01D1F /* ServiceDiscoveryProviderTests.swift in Sources */,
 				E719B084246417110037DED4 /* SingleLinkDiscoveryMock.swift in Sources */,
 				E719B08824642EF80037DED4 /* CuckooExtension.swift in Sources */,
+				623C43D52E65955400AAC441 /* MockCardBinService.swift in Sources */,
 				E719B0AA2464A3B30037DED4 /* CardSessionsApiClientMock.swift in Sources */,
 				51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */,
 				D74028332592136700104B32 /* PresenterTestSuite.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -56,7 +56,10 @@
 		51EEC2BC2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EEC2BB2AE1EC55000BA998 /* AccessCheckoutUITextFieldTests.swift */; };
 		51F7EEEC25C88E41002FE45F /* AcceptanceTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */; };
 		623C43D52E65955400AAC441 /* MockCardBinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623C43D42E65955400AAC441 /* MockCardBinService.swift */; };
+		623C43D92E66760300AAC441 /* PanValidationFlowCobrandedCardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623C43D82E6675F700AAC441 /* PanValidationFlowCobrandedCardsTests.swift */; };
+		623C43DB2E66967E00AAC441 /* PanViewPresenterCobrandedCardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623C43DA2E66967100AAC441 /* PanViewPresenterCobrandedCardsTests.swift */; };
 		626ED9492E4F932400D34413 /* MockCardBinApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */; };
+		6279FF192E66BE0E002623A5 /* MockPanValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6279FF182E66BE0E002623A5 /* MockPanValidator.swift */; };
 		62A11ECD2E44B6BC00B0B96C /* CardBinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A11ECC2E44B6B700B0B96C /* CardBinService.swift */; };
 		62AA43732E390E760018EAAA /* CardBinCacheManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */; };
 		62AA43752E39122E0018EAAA /* MockCardBinCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */; };
@@ -130,7 +133,6 @@
 		E72C3ED62485B0F500284A31 /* ExpiryDateViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3ED52485B0F500284A31 /* ExpiryDateViewPresenter.swift */; };
 		E72C3ED82485B2E100284A31 /* CvcViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3ED72485B2E100284A31 /* CvcViewPresenter.swift */; };
 		E72C3EDE248669EF00284A31 /* MockPanValidationStateHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3EDD248669EF00284A31 /* MockPanValidationStateHandler.swift */; };
-		E72C3EE024866B8000284A31 /* MockPanValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3EDF24866B8000284A31 /* MockPanValidator.swift */; };
 		E72C3EE224866ED200284A31 /* PanValidationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3EE124866ED200284A31 /* PanValidationResult.swift */; };
 		E72C3EE424866F6D00284A31 /* EquatableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3EE324866F6D00284A31 /* EquatableExtension.swift */; };
 		E72C3EEA24879C1C00284A31 /* CardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72C3EE924879C1C00284A31 /* CardBrand.swift */; };
@@ -308,7 +310,10 @@
 		51F7EEEB25C88E41002FE45F /* AcceptanceTestSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcceptanceTestSuite.swift; sourceTree = "<group>"; };
 		5744B765A4A0CEB7971CB446 /* Pods_AccessCheckoutSDKPactTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutSDKPactTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		623C43D42E65955400AAC441 /* MockCardBinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinService.swift; sourceTree = "<group>"; };
+		623C43D82E6675F700AAC441 /* PanValidationFlowCobrandedCardsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanValidationFlowCobrandedCardsTests.swift; sourceTree = "<group>"; };
+		623C43DA2E66967100AAC441 /* PanViewPresenterCobrandedCardsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanViewPresenterCobrandedCardsTests.swift; sourceTree = "<group>"; };
 		626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinApiClient.swift; sourceTree = "<group>"; };
+		6279FF182E66BE0E002623A5 /* MockPanValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPanValidator.swift; sourceTree = "<group>"; };
 		62A11ECC2E44B6B700B0B96C /* CardBinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinService.swift; sourceTree = "<group>"; };
 		62AA43722E390E6B0018EAAA /* CardBinCacheManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBinCacheManagerTests.swift; sourceTree = "<group>"; };
 		62AA43742E39122E0018EAAA /* MockCardBinCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardBinCacheManager.swift; sourceTree = "<group>"; };
@@ -392,7 +397,6 @@
 		E72C3ED52485B0F500284A31 /* ExpiryDateViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiryDateViewPresenter.swift; sourceTree = "<group>"; };
 		E72C3ED72485B2E100284A31 /* CvcViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CvcViewPresenter.swift; sourceTree = "<group>"; };
 		E72C3EDD248669EF00284A31 /* MockPanValidationStateHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPanValidationStateHandler.swift; sourceTree = "<group>"; };
-		E72C3EDF24866B8000284A31 /* MockPanValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPanValidator.swift; sourceTree = "<group>"; };
 		E72C3EE124866ED200284A31 /* PanValidationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanValidationResult.swift; sourceTree = "<group>"; };
 		E72C3EE324866F6D00284A31 /* EquatableExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableExtension.swift; sourceTree = "<group>"; };
 		E72C3EE924879C1C00284A31 /* CardBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrand.swift; sourceTree = "<group>"; };
@@ -691,6 +695,7 @@
 		683DF03ADFFF76E72571BEAE /* mock */ = {
 			isa = PBXGroup;
 			children = (
+				6279FF182E66BE0E002623A5 /* MockPanValidator.swift */,
 				623C43D42E65955400AAC441 /* MockCardBinService.swift */,
 				626ED9482E4F932400D34413 /* MockCardBinApiClient.swift */,
 				C23DD1362E56261C00506DAE /* MockRetryRestClientDecorator.swift */,
@@ -710,7 +715,6 @@
 				D7C6EE222486A69C00170B92 /* MockExpiryDateValidationStateHandler.swift */,
 				E7AC80AB248EB58300E28D76 /* MockPanValidationFlow.swift */,
 				E72C3EDD248669EF00284A31 /* MockPanValidationStateHandler.swift */,
-				E72C3EDF24866B8000284A31 /* MockPanValidator.swift */,
 				E7AD2453246412C800C4C92D /* MockSingleLinkDiscoveryFactory.swift */,
 				E7409D55248FA3C200016AEB /* MockTextChangeHandler.swift */,
 				E7D37F8D24818E210039DD98 /* CardBrandsConfigurationFactoryMock.swift */,
@@ -848,6 +852,7 @@
 		E72C3EF6248A57A400284A31 /* presenters */ = {
 			isa = PBXGroup;
 			children = (
+				623C43DA2E66967100AAC441 /* PanViewPresenterCobrandedCardsTests.swift */,
 				E72C3F01248A78DA00284A31 /* CvcViewPresenterTests.swift */,
 				E72C3EFD248A5CBA00284A31 /* ExpiryDateViewPresenterTests.swift */,
 				E72C3EF7248A57C300284A31 /* PanViewPresenterNoCardSpacingTests.swift */,
@@ -1102,6 +1107,7 @@
 		E7776E2B248B07C4006B57DD /* pan */ = {
 			isa = PBXGroup;
 			children = (
+				623C43D82E6675F700AAC441 /* PanValidationFlowCobrandedCardsTests.swift */,
 				D7D6D5F2248154B900D57D7A /* PanValidationFlowTests.swift */,
 				D76E404F247D62A1002FAA39 /* PanValidatorTests.swift */,
 			);
@@ -1744,7 +1750,6 @@
 				E72C3EE424866F6D00284A31 /* EquatableExtension.swift in Sources */,
 				E7AC80AC248EB58300E28D76 /* MockPanValidationFlow.swift in Sources */,
 				D7C6EE212486A4F000170B92 /* ExpiryDateValidationFlowTests.swift in Sources */,
-				E72C3EE024866B8000284A31 /* MockPanValidator.swift in Sources */,
 				E72C3F0D248AB84900284A31 /* CardBrandModelTransformerTests.swift in Sources */,
 				62E75C5A2E5498B9001FDD73 /* CardBinServiceTestsWithStubService.swift in Sources */,
 				E719B0AE2464A4B90037DED4 /* CvcSessionsApiClientTests.swift in Sources */,
@@ -1761,6 +1766,7 @@
 				519F14422E4B8AB500038113 /* CardBinApiClientTestsWithStubService.swift in Sources */,
 				E7D37F8C248170300039DD98 /* CardBrandDtoTests.swift in Sources */,
 				D7D6D5D8247FC96100D57D7A /* CvcValidatorTests.swift in Sources */,
+				623C43DB2E66967E00AAC441 /* PanViewPresenterCobrandedCardsTests.swift in Sources */,
 				D7E536F3264A90FC00A476E6 /* PanFormatterTests.swift in Sources */,
 				E7D37F852481601B0039DD98 /* CardBrandsConfigurationFactoryTests.swift in Sources */,
 				E7D37F7E248154DF0039DD98 /* AccessCheckoutValidationInitialiserTests.swift in Sources */,
@@ -1814,6 +1820,7 @@
 				623C43D52E65955400AAC441 /* MockCardBinService.swift in Sources */,
 				E719B0AA2464A3B30037DED4 /* CardSessionsApiClientMock.swift in Sources */,
 				51E831E22ACDB49900A8FC22 /* UIUtils.swift in Sources */,
+				6279FF192E66BE0E002623A5 /* MockPanValidator.swift in Sources */,
 				D74028332592136700104B32 /* PresenterTestSuite.swift in Sources */,
 				E719B09E246481DA0037DED4 /* CardSessionURLRequestFactoryMock.swift in Sources */,
 				E745CC2424857616000390CA /* CardBrandDtoTransformerTests.swift in Sources */,
@@ -1822,6 +1829,7 @@
 				51D610D125CD750A00B1B685 /* CardValidationConfigBuilderTests.swift in Sources */,
 				513039A22B10F68800C01B10 /* ApiHeadersTests.swift in Sources */,
 				E75C5E6A248E7020003A1BDE /* AccessCheckoutCardValidationDelegate_EditText_Tests.swift in Sources */,
+				623C43D92E66760300AAC441 /* PanValidationFlowCobrandedCardsTests.swift in Sources */,
 				E7633D2D249D1F4800FFE190 /* AccessCheckoutErrorTests.swift in Sources */,
 				519F14402E4B7AAA00038113 /* MiscUtils.swift in Sources */,
 				E7D19F8124640008001EA13A /* StubUtils.swift in Sources */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -685,13 +685,6 @@
 			path = service;
 			sourceTree = "<group>";
 		};
-		62E75C5B2E561E59001FDD73 /* New Group */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "New Group";
-			sourceTree = "<group>";
-		};
 		683DF03ADFFF76E72571BEAE /* mock */ = {
 			isa = PBXGroup;
 			children = (
@@ -884,7 +877,6 @@
 		E72C3F13248AFB5D00284A31 /* pan */ = {
 			isa = PBXGroup;
 			children = (
-				62E75C5B2E561E59001FDD73 /* New Group */,
 				D7D6D5F42481550200D57D7A /* PanValidationFlow.swift */,
 				E72C3EE124866ED200284A31 /* PanValidationResult.swift */,
 				D7D6D5F024814F5500D57D7A /* PanValidationStateHandler.swift */,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/AccessCheckoutValidationInitialiser.swift
@@ -38,12 +38,19 @@ public struct AccessCheckoutValidationInitialiser {
             acceptedCardBrands: config.acceptedCardBrands
         )
 
+        let cardBinService = CardBinService(
+            checkoutId: config.checkoutId,
+            client: CardBinApiClient(),
+            configurationProvider: configurationProvider
+        )
+
         let validationStateHandler = CardValidationStateHandler(config.validationDelegate)
         let cvcValidator = CvcValidator()
         let cvcValidationFlow = CvcValidationFlow(cvcValidator, validationStateHandler)
 
         let panPresenter = panViewPresenter(
             configurationProvider,
+            cardBinService,
             cvcValidationFlow,
             validationStateHandler,
             config.panFormattingEnabled
@@ -72,6 +79,7 @@ public struct AccessCheckoutValidationInitialiser {
 
     private func panViewPresenter(
         _ configurationProvider: CardBrandsConfigurationProvider,
+        _ cardBinService: CardBinService,
         _ cvcValidationFlow: CvcValidationFlow,
         _ validationStateHandler: PanValidationStateHandler,
         _ panFormattingEnabled: Bool
@@ -80,7 +88,8 @@ public struct AccessCheckoutValidationInitialiser {
         let panValidationFlow = PanValidationFlow(
             panValidator,
             validationStateHandler,
-            cvcValidationFlow
+            cvcValidationFlow,
+            cardBinService
         )
         return PanViewPresenter(
             panValidationFlow,

--- a/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/client/validation/card/CardValidationConfig.swift
@@ -16,6 +16,7 @@ public struct CardValidationConfig: ValidationConfig {
 
     let acceptedCardBrands: [String]
     let panFormattingEnabled: Bool
+    let checkoutId: String
 
     /**
      - Returns: an instance of a builder used to create an instance  of `CardValidationConfig`
@@ -35,6 +36,7 @@ public struct CardValidationConfig: ValidationConfig {
      - Parameter validationDelegate: `AccessCheckoutCardValidationDelegate` that represents the validation events listener
      - Parameter acceptedCardBrands: `Array` of `String` that represents the list of card brands to accept for validation. Any unrecognised card brand will be accepted at all times.
      - Parameter panFormattingEnabled: `Bool` that represents whether the PAN field will be formatted.
+     - Parameter checkoutId: `String` that represents the checkout ID for the merchant
      */
     internal init(
         pan: AccessCheckoutUITextField,
@@ -43,7 +45,8 @@ public struct CardValidationConfig: ValidationConfig {
         accessBaseUrl: String,
         validationDelegate: AccessCheckoutCardValidationDelegate,
         acceptedCardBrands: [String] = [],
-        panFormattingEnabled: Bool = false
+        panFormattingEnabled: Bool = false,
+        checkoutId: String
     ) {
         self.pan = pan
         self.expiryDate = expiryDate
@@ -54,6 +57,7 @@ public struct CardValidationConfig: ValidationConfig {
 
         self.acceptedCardBrands = acceptedCardBrands
         self.panFormattingEnabled = panFormattingEnabled
+        self.checkoutId = checkoutId
     }
 }
 
@@ -68,11 +72,12 @@ public class CardValidationConfigBuilder {
     private var validationDelegate: AccessCheckoutCardValidationDelegate?
     private var acceptedCardBrands: [String] = []
     private var panFormattingEnabled: Bool = false
+    private var checkoutId: String?
 
     fileprivate init() {}
 
     /**
-     Sets the pan ui element to be validatedg
+     Sets the pan ui element to be validated
      - Parameter pan: `AccessCheckoutUITextField` to be validated
      - Returns: the same instance of the builder
      */
@@ -140,6 +145,15 @@ public class CardValidationConfigBuilder {
     }
 
     /**
+     - Parameter checkoutId: checkoutId of the merchant
+     - Returns: the same instance of the builder
+     */
+    public func checkoutId(_ checkoutId: String) -> CardValidationConfigBuilder {
+        self.checkoutId = checkoutId
+        return self
+    }
+
+    /**
      Use this method to create an instance of `CardValidationConfig`
      - Returns: an instance of `CardValidationConfig`
     
@@ -161,6 +175,10 @@ public class CardValidationConfigBuilder {
         guard let validationDelegate = validationDelegate else {
             throw AccessCheckoutIllegalArgumentError.missingValidationDelegate()
         }
+        guard let checkoutId = checkoutId else {
+            throw
+                AccessCheckoutIllegalArgumentError.missingCheckoutId()
+        }
 
         return CardValidationConfig(
             pan: pan!,
@@ -169,7 +187,8 @@ public class CardValidationConfigBuilder {
             accessBaseUrl: accessBaseUrl,
             validationDelegate: validationDelegate,
             acceptedCardBrands: acceptedCardBrands,
-            panFormattingEnabled: panFormattingEnabled
+            panFormattingEnabled: panFormattingEnabled,
+            checkoutId: checkoutId
         )
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -15,7 +15,7 @@ internal class CardBinApiClient {
     ///   - cacheManager: The cache manager which is a simple map to improve request performance for repeated numbers
     init(
         restClient: RestClient<CardBinResponse> = RestClient<CardBinResponse>(),
-        cacheManager: CardBinCacheManager = CardBinCacheManager(),
+        cacheManager: CardBinCacheManager = CardBinCacheManager()
     ) {
         self.restClient = restClient
         self.cacheManager = cacheManager

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -68,6 +68,8 @@ internal class CardBinApiClient {
 
     func abort() {
         self.taskForRequestInFlight?.cancel()
+        // log to test abort mechanism for ticket US2128871
+        NSLog("CardBinApiClient: Previous request in flight aborted")
     }
 
     /// Fetches card BIN details from the API with automatic retry mechanism.
@@ -91,7 +93,6 @@ internal class CardBinApiClient {
         attempt: UInt,
         completionHandler: @escaping (Result<CardBinResponse, AccessCheckoutError>) -> Void
     ) {
-        // url passed into this will come from service discovery
         let urlRequestFactory = CardBinURLRequestFactory(url: url, checkoutId: checkoutId)
         let request = urlRequestFactory.create(cardNumber: cardNumber)
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/client/CardBinApiClient.swift
@@ -5,7 +5,7 @@ import Foundation
 internal class CardBinApiClient {
     private let restClient: RestClient<CardBinResponse>
     private let cacheManager: CardBinCacheManager
-    private let endpointProvider: () -> String?
+    private let cardBinEndpointProvider: () -> String?
     private let maxAttempts = 3
     private var taskForRequestInFlight: URLSessionTask?
 
@@ -14,16 +14,17 @@ internal class CardBinApiClient {
     /// - Parameters:
     ///   - restClient: The REST client used to make HTTP requests
     ///   - cacheManager: The cache manager which is a simple map to improve request performance for repeated numbers
+    ///   - cardBinEndpointProvider: A closure that provides the card BIN endpoint URL, allowing for dependency injection (for testing)
     init(
         restClient: RestClient<CardBinResponse> = RestClient<CardBinResponse>(),
         cacheManager: CardBinCacheManager = CardBinCacheManager(),
-        endpointProvider: @escaping () -> String? = {
+        cardBinEndpointProvider: @escaping () -> String? = {
             ServiceDiscoveryProvider.getCardBinEndpoint()
         }
     ) {
         self.restClient = restClient
         self.cacheManager = cacheManager
-        self.endpointProvider = endpointProvider
+        self.cardBinEndpointProvider = cardBinEndpointProvider
     }
 
     /// Retrieves BIN information for the provided card number.
@@ -40,7 +41,7 @@ internal class CardBinApiClient {
         checkoutId: String,
         completionHandler: @escaping (Result<CardBinResponse, AccessCheckoutError>) -> Void
     ) {
-        guard let cardBinUrl = self.endpointProvider() else {
+        guard let cardBinUrl = self.cardBinEndpointProvider() else {
             completionHandler(
                 .failure(
                     AccessCheckoutError.discoveryLinkNotFound(

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/service/CardBinService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/api/cardBin/service/CardBinService.swift
@@ -2,7 +2,6 @@ import Foundation
 
 internal class CardBinService {
     private let checkoutId: String
-    private let baseURL: String
     private let client: CardBinApiClient
     private let configurationProvider: CardBrandsConfigurationProvider
 
@@ -10,17 +9,14 @@ internal class CardBinService {
     ///
     /// - Parameters:
     ///   - checkoutId: The checkout session identifier
-    ///   - baseURL: The base URL for the card bin API
     ///   - client: The API client for making requests
     ///   - configurationProvider: Provider for card brand configurations
     init(
         checkoutId: String,
-        baseURL: String,
         client: CardBinApiClient,
         configurationProvider: CardBrandsConfigurationProvider
     ) {
         self.checkoutId = checkoutId
-        self.baseURL = baseURL
         self.client = client
         self.configurationProvider = configurationProvider
     }
@@ -38,15 +34,7 @@ internal class CardBinService {
     ) {
         client.abort()
 
-        let sanitisedCardNumber = cardNumber.replacingOccurrences(of: " ", with: "")
-
-        guard !sanitisedCardNumber.isEmpty else {
-            return
-        }
-
-        let cardNumberPrefix = String(sanitisedCardNumber.prefix(12))
-
-        client.retrieveBinInfo(cardNumber: cardNumberPrefix, checkoutId: checkoutId) { result in
+        client.retrieveBinInfo(cardNumber: cardNumber, checkoutId: checkoutId) { result in
             switch result {
             case .success(let response):
                 let cardBrands = self.transform(

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
@@ -23,12 +23,12 @@ class PanValidationFlow {
     func handleCobrandedCards(pan: String) {
         let sanitisedCardNumber = pan.replacingOccurrences(of: " ", with: "")
 
-        let cardNumberPrefix = String(sanitisedCardNumber.prefix(12))
-
-        guard !cardNumberPrefix.isEmpty else {
+        guard sanitisedCardNumber.count >= 12 else {
             lastCheckedPanPrefix = ""
             return
         }
+
+        let cardNumberPrefix = String(sanitisedCardNumber.prefix(12))
 
         let hasChanged = cardNumberPrefix != lastCheckedPanPrefix
 
@@ -37,6 +37,8 @@ class PanValidationFlow {
 
             let globalBrand = panValidationStateHandler.getCardBrand()
 
+            // currently logs out card bin lookup result for debugging purposes
+            // will call PanValidationStateHandler to handle updating merchant delegeate with returned card brands
             cardBinService.getCardBrands(
                 globalBrand: globalBrand,
                 cardNumber: cardNumberPrefix

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
@@ -4,15 +4,51 @@ class PanValidationFlow {
     private let panValidator: PanValidator
     private let panValidationStateHandler: PanValidationStateHandler
     private let cvcFlow: CvcValidationFlow
+    private let cardBinService: CardBinService
+
+    private var lastCheckedPanPrefix: String = ""
 
     init(
         _ panValidator: PanValidator,
         _ panValidationStateHandler: PanValidationStateHandler,
-        _ cvcFlow: CvcValidationFlow
+        _ cvcFlow: CvcValidationFlow,
+        _ cardBinService: CardBinService
     ) {
         self.panValidator = panValidator
         self.panValidationStateHandler = panValidationStateHandler
         self.cvcFlow = cvcFlow
+        self.cardBinService = cardBinService
+    }
+
+    func handleCobrandedCards(pan: String) {
+        let sanitisedCardNumber = pan.replacingOccurrences(of: " ", with: "")
+
+        let cardNumberPrefix = String(sanitisedCardNumber.prefix(12))
+
+        guard !cardNumberPrefix.isEmpty else {
+            lastCheckedPanPrefix = ""
+            return
+        }
+
+        let hasChanged = cardNumberPrefix != lastCheckedPanPrefix
+
+        if hasChanged {
+            lastCheckedPanPrefix = cardNumberPrefix
+
+            let globalBrand = panValidationStateHandler.getCardBrand()
+
+            cardBinService.getCardBrands(
+                globalBrand: globalBrand,
+                cardNumber: cardNumberPrefix
+            ) { result in
+                switch result {
+                case .success(let cardBrands):
+                    NSLog("Card BIN lookup succeeded: \(cardBrands)")
+                case .failure(_):
+                    NSLog("Card BIN lookup failed:")
+                }
+            }
+        }
     }
 
     func validate(pan: String) {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/PanViewPresenter.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/presenters/PanViewPresenter.swift
@@ -23,6 +23,7 @@ class PanViewPresenter: NSObject, Presenter {
 
     func onEditing(text: String) {
         validationFlow.validate(pan: text)
+        validationFlow.handleCobrandedCards(pan: text)
     }
 
     func onEditEnd() {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/Configuration.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/Configuration.swift
@@ -1,3 +1,4 @@
 internal struct Configuration {
     static let accessBaseUrl: String = "https://try.access.worldpay.com"
+    static let checkoutId: String = "00000000-0000-0000-0000-000000000000"
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
@@ -113,6 +113,7 @@ class ViewController: UIViewController {
             .accessBaseUrl(Configuration.accessBaseUrl)
             .validationDelegate(self)
             .acceptedCardBrands(["visa", "mastercard", "AMEX"])
+            .checkoutId(Configuration.checkoutId)
 
         if cardNumberSpacingEnabled {
             _ = validationConfigBuilder.enablePanFormatting()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestApp/ViewController.swift
@@ -106,6 +106,7 @@ class ViewController: UIViewController {
         cardNumberSpacingEnabled: Bool
     ) {
         let validationConfigBuilder = CardValidationConfig.builder()
+            .checkoutId("00000000-0000-0000-0000-000000000000")
             .pan(panAccessCheckoutUITextField)
             .expiryDate(AccessCheckoutUITextField(frame: CGRect()))
             .cvc(AccessCheckoutUITextField(frame: CGRect()))

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/AccessCheckoutValidationInitialiserTests.swift
@@ -13,6 +13,7 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
     let cvcAccessCheckoutUITextField = AccessCheckoutUITextField()
 
     let baseUrl = "some-url"
+    let checkoutId = "0000-0000-0000-0000-000000000000"
     let cardValidationDelegateMock = MockAccessCheckoutCardValidationDelegate()
     let cvcOnlyValidationDelegateMock = MockAccessCheckoutCvcOnlyValidationDelegate()
 
@@ -35,6 +36,7 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
             .enablePanFormatting()
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])
+            .checkoutId(checkoutId)
             .build()
 
         accessCheckoutValidationInitialiser!.initialise(validationConfig)
@@ -52,6 +54,7 @@ class AccessCheckoutValidationInitialiserTests: XCTestCase {
             .enablePanFormatting()
             .validationDelegate(cardValidationDelegateMock)
             .acceptedCardBrands(["amex", "visa"])
+            .checkoutId(checkoutId)
             .build()
 
         accessCheckoutValidationInitialiser!.initialise(validationConfig)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/client/validation/card/CardValidationConfigBuilderTests.swift
@@ -10,6 +10,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
     private let accessBaseUrl = "some-url"
     private let validationDelegate = MockAccessCheckoutCardValidationDelegate()
     private let acceptedCardBrands = ["visa", "amex"]
+    private let checkoutId = "0000-0000-0000-0000"
 
     func testConfigWithHasFormattingNotEnabledByDefault() throws {
         let config =
@@ -19,6 +20,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .cvc(cvcAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
+            .checkoutId(checkoutId)
             .build()
 
         XCTAssertFalse(config.panFormattingEnabled)
@@ -33,6 +35,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .enablePanFormatting()
+            .checkoutId(checkoutId)
             .build()
 
         XCTAssertTrue(config.panFormattingEnabled)
@@ -46,6 +49,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .cvc(cvcAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
+            .checkoutId(checkoutId)
             .build()
 
         XCTAssertEqual(panAccessCheckoutUITextField, config.pan)
@@ -65,6 +69,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
             .build()
 
         XCTAssertEqual(panAccessCheckoutUITextField, config.pan)
@@ -83,6 +88,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
         let expectedMessage = "Expected pan to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in
@@ -98,6 +104,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
         let expectedMessage = "Expected expiry date to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in
@@ -113,6 +120,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .accessBaseUrl(accessBaseUrl)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
         let expectedMessage = "Expected cvc to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in
@@ -128,6 +136,7 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .cvc(cvcAccessCheckoutUITextField)
             .validationDelegate(validationDelegate)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
         let expectedMessage = "Expected base url to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in
@@ -143,7 +152,24 @@ class CardValidationConfigBuilderTests: XCTestCase {
             .cvc(cvcAccessCheckoutUITextField)
             .accessBaseUrl(accessBaseUrl)
             .acceptedCardBrands(acceptedCardBrands)
+            .checkoutId(checkoutId)
         let expectedMessage = "Expected validation delegate to be provided but was not"
+
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)
+        }
+    }
+
+    func testThrowsErrorWhenCheckoutIdIsNotSpecified() throws {
+        _ =
+            builder
+            .pan(panAccessCheckoutUITextField)
+            .expiryDate(expiryDateAccessCheckoutUITextField)
+            .cvc(cvcAccessCheckoutUITextField)
+            .accessBaseUrl(accessBaseUrl)
+            .acceptedCardBrands(acceptedCardBrands)
+            .validationDelegate(validationDelegate)
+        let expectedMessage = "Expected checkout ID to be provided but was not"
 
         XCTAssertThrowsError(try builder.build()) { error in
             XCTAssertEqual(expectedMessage, (error as! AccessCheckoutIllegalArgumentError).message)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBinService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardBinService.swift
@@ -1,0 +1,136 @@
+import Cuckoo
+import Foundation
+
+@testable import AccessCheckoutSDK
+
+class MockCardBinService: CardBinService, Cuckoo.ClassMock {
+
+    typealias MocksType = CardBinService
+
+    typealias Stubbing = __StubbingProxy_CardBinService
+    typealias Verification = __VerificationProxy_CardBinService
+
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
+
+    private var __defaultImplStub: CardBinService?
+
+    func enableDefaultImplementation(_ stub: CardBinService) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+
+    override func getCardBrands(
+        globalBrand: CardBrandModel?, cardNumber: String,
+        completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+    ) {
+
+        return cuckoo_manager.call(
+            """
+            getCardBrands(globalBrand: CardBrandModel?, cardNumber: String, completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void)
+            """,
+            parameters: (globalBrand, cardNumber, completion),
+            escapingParameters: (globalBrand, cardNumber, completion),
+            superclassCall:
+
+                super.getCardBrands(
+                    globalBrand: globalBrand, cardNumber: cardNumber, completion: completion),
+            defaultCall: __defaultImplStub!.getCardBrands(
+                globalBrand: globalBrand, cardNumber: cardNumber, completion: completion))
+
+    }
+
+    struct __StubbingProxy_CardBinService: Cuckoo.StubbingProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+
+        init(manager: Cuckoo.MockManager) {
+            self.cuckoo_manager = manager
+        }
+
+        func getCardBrands<
+            M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable
+        >(globalBrand: M1, cardNumber: M2, completion: M3)
+            -> Cuckoo.ClassStubNoReturnFunction<
+                (CardBrandModel?, String, (Result<[CardBrandModel], AccessCheckoutError>) -> Void)
+            >
+        where
+            M1.OptionalMatchedType == CardBrandModel, M2.MatchedType == String,
+            M3.MatchedType == (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+        {
+            let matchers:
+                [Cuckoo.ParameterMatcher<
+                    (
+                        CardBrandModel?, String,
+                        (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+                    )
+                >] = [
+                    wrap(matchable: globalBrand) { $0.0 }, wrap(matchable: cardNumber) { $0.1 },
+                    wrap(matchable: completion) { $0.2 },
+                ]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockCardBinService.self,
+                    method:
+                        """
+                        getCardBrands(globalBrand: CardBrandModel?, cardNumber: String, completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void)
+                        """, parameterMatchers: matchers))
+        }
+
+    }
+
+    struct __VerificationProxy_CardBinService: Cuckoo.VerificationProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+        private let callMatcher: Cuckoo.CallMatcher
+        private let sourceLocation: Cuckoo.SourceLocation
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
+            self.cuckoo_manager = manager
+            self.callMatcher = callMatcher
+            self.sourceLocation = sourceLocation
+        }
+
+        @discardableResult
+        func getCardBrands<
+            M1: Cuckoo.OptionalMatchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable
+        >(globalBrand: M1, cardNumber: M2, completion: M3)
+            -> Cuckoo.__DoNotUse<
+                (CardBrandModel?, String, (Result<[CardBrandModel], AccessCheckoutError>) -> Void),
+                Void
+            >
+        where
+            M1.OptionalMatchedType == CardBrandModel, M2.MatchedType == String,
+            M3.MatchedType == (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+        {
+            let matchers:
+                [Cuckoo.ParameterMatcher<
+                    (
+                        CardBrandModel?, String,
+                        (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+                    )
+                >] = [
+                    wrap(matchable: globalBrand) { $0.0 }, wrap(matchable: cardNumber) { $0.1 },
+                    wrap(matchable: completion) { $0.2 },
+                ]
+            return cuckoo_manager.verify(
+                """
+                getCardBrands(globalBrand: CardBrandModel?, cardNumber: String, completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
+        }
+
+    }
+}
+
+class CardBinServiceStub: CardBinService {
+
+    override func getCardBrands(
+        globalBrand: CardBrandModel?, cardNumber: String,
+        completion: @escaping (Result<[CardBrandModel], AccessCheckoutError>) -> Void
+    ) {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockPanValidationFlow.swift
@@ -20,6 +20,21 @@ class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
         cuckoo_manager.enableDefaultStubImplementation()
     }
 
+    override func handleCobrandedCards(pan: String) {
+
+        return cuckoo_manager.call(
+            """
+            handleCobrandedCards(pan: String)
+            """,
+            parameters: (pan),
+            escapingParameters: (pan),
+            superclassCall:
+
+                super.handleCobrandedCards(pan: pan),
+            defaultCall: __defaultImplStub!.handleCobrandedCards(pan: pan))
+
+    }
+
     override func validate(pan: String) {
 
         return cuckoo_manager.call(
@@ -70,6 +85,19 @@ class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
 
         init(manager: Cuckoo.MockManager) {
             self.cuckoo_manager = manager
+        }
+
+        func handleCobrandedCards<M1: Cuckoo.Matchable>(pan: M1)
+            -> Cuckoo.ClassStubNoReturnFunction<(String)> where M1.MatchedType == String
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
+            return .init(
+                stub: cuckoo_manager.createStub(
+                    for: MockPanValidationFlow.self,
+                    method:
+                        """
+                        handleCobrandedCards(pan: String)
+                        """, parameterMatchers: matchers))
         }
 
         func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.ClassStubNoReturnFunction<(String)>
@@ -123,6 +151,18 @@ class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
         }
 
         @discardableResult
+        func handleCobrandedCards<M1: Cuckoo.Matchable>(pan: M1)
+            -> Cuckoo.__DoNotUse<(String), Void> where M1.MatchedType == String
+        {
+            let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
+            return cuckoo_manager.verify(
+                """
+                handleCobrandedCards(pan: String)
+                """, callMatcher: callMatcher, parameterMatchers: matchers,
+                sourceLocation: sourceLocation)
+        }
+
+        @discardableResult
         func validate<M1: Cuckoo.Matchable>(pan: M1) -> Cuckoo.__DoNotUse<(String), Void>
         where M1.MatchedType == String {
             let matchers: [Cuckoo.ParameterMatcher<(String)>] = [wrap(matchable: pan) { $0 }]
@@ -157,6 +197,10 @@ class MockPanValidationFlow: PanValidationFlow, Cuckoo.ClassMock {
 }
 
 class PanValidationFlowStub: PanValidationFlow {
+
+    override func handleCobrandedCards(pan: String) {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
 
     override func validate(pan: String) {
         return DefaultValueRegistry.defaultValue(for: (Void).self)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/testUtils/AcceptanceTestSuite.swift
@@ -7,6 +7,7 @@ class AcceptanceTestSuite: XCTestCase {
     let panTextField = AccessCheckoutUITextField()
     let expiryDateTextField = AccessCheckoutUITextField()
     let cvcTextField = AccessCheckoutUITextField()
+    let checkoutId = "0000-0000-0000-0000-000000000000"
 
     func initialiseCardValidation(cardBrands: [CardBrandModel], acceptedCardBrands: [String] = [])
         -> MockAccessCheckoutCardValidationDelegate
@@ -52,6 +53,7 @@ class AcceptanceTestSuite: XCTestCase {
         .accessBaseUrl("a-url")
         .validationDelegate(merchantDelegate)
         .acceptedCardBrands(acceptedBrands)
+        .checkoutId(checkoutId)
         .build()
 
         let validationInitialiser = AccessCheckoutValidationInitialiser(configurationProvider)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
@@ -1,3 +1,4 @@
+import Cuckoo
 import XCTest
 
 @testable import AccessCheckoutSDK
@@ -13,31 +14,42 @@ class CardBinApiClientTests: XCTestCase {
     private let testCheckoutId = "00000000-0000-0000-0000-000000000000"
     private var request: CardBinRequest!
 
+    let cardBinServiceUrl = "card-bin-service-url"
+    let restClient = MockRetryRestClientDecorator<ApiResponse>()
+    let apiResponseLookUpMock = MockApiResponseLinkLookup()
+
     override func setUp() {
         super.setUp()
         request = CardBinRequest(cardNumber: testCardNumber, checkoutId: testCheckoutId)
+        ServiceDiscoveryProvider.shared = ServiceDiscoveryProvider(
+            restClient,
+            apiResponseLookUpMock)
+        ServiceDiscoveryProvider.shared.clearCache()
+
+        setUpDiscoveryResponses()
+        setUpApiResponseLookups()
     }
 
     func testCallsRestClientWithRequestCreatedByUrlRequestFactory() {
         expectationToFulfill = expectation(
             description: "should have called mock rest client with expected request")
 
-        let expectedURLRequest = createExpectedURLRequest(
-            url: "some-url",
-            cardNumber: testCardNumber,
-            checkoutId: testCheckoutId
-        )
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let expectedURLRequest = self.createExpectedURLRequest(
+                url: self.cardBinServiceUrl,
+                cardNumber: self.testCardNumber,
+                checkoutId: self.testCheckoutId
+            )
 
-        let mockRestClient = RestClientMock(replyWith: expectedResponse)
+            let mockRestClient = RestClientMock(replyWith: self.expectedResponse)
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
-
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) { _ in
-            XCTAssertEqual(expectedURLRequest, mockRestClient.requestSent)
-            self.expectationToFulfill!.fulfill()
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) { _ in
+                XCTAssertEqual(expectedURLRequest, mockRestClient.requestSent)
+                self.expectationToFulfill!.fulfill()
+            }
         }
 
         wait(for: [expectationToFulfill!], timeout: 1)
@@ -47,23 +59,24 @@ class CardBinApiClientTests: XCTestCase {
         expectationToFulfill = expectation(
             description: "should have called completion handler with response from rest client")
 
-        let mockRestClient = RestClientMock(replyWith: expectedResponse)
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let mockRestClient = RestClientMock(replyWith: self.expectedResponse)
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(self.expectedResponse.brand, response.brand)
-                XCTAssertEqual(self.expectedResponse.fundingType, response.fundingType)
-                XCTAssertEqual(self.expectedResponse.luhnCompliant, response.luhnCompliant)
-            case .failure:
-                XCTFail("Retrieval of card bin info should have succeeded")
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success(let response):
+                    XCTAssertEqual(self.expectedResponse.brand, response.brand)
+                    XCTAssertEqual(self.expectedResponse.fundingType, response.fundingType)
+                    XCTAssertEqual(self.expectedResponse.luhnCompliant, response.luhnCompliant)
+                case .failure:
+                    XCTFail("Retrieval of card bin info should have succeeded")
+                }
+                self.expectationToFulfill!.fulfill()
             }
-            self.expectationToFulfill!.fulfill()
         }
 
         wait(for: [expectationToFulfill!], timeout: 1)
@@ -73,26 +86,27 @@ class CardBinApiClientTests: XCTestCase {
         expectationToFulfill = expectation(
             description: "should have called completion handler with error from rest client")
 
-        let mockRestClient = RestClientMock<CardBinResponse>(
-            errorWith: AccessCheckoutError.unexpectedApiError(message: "some error"))
-        let detailedErrorMessage = "Message: unexpectedApiError : some error\n Validation: "
-        let expectedError = AccessCheckoutError.unexpectedApiError(
-            message: "Failed after 3 attempt(s) with error \(detailedErrorMessage)")
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let mockRestClient = RestClientMock<CardBinResponse>(
+                errorWith: AccessCheckoutError.unexpectedApiError(message: "some error"))
+            let detailedErrorMessage = "Message: unexpectedApiError : some error\n Validation: "
+            let expectedError = AccessCheckoutError.unexpectedApiError(
+                message: "Failed after 3 attempt(s) with error \(detailedErrorMessage)")
 
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success:
-                XCTFail("Retrieval of card bin info should have failed")
-            case .failure(let error):
-                XCTAssertEqual(expectedError, error)
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success:
+                    XCTFail("Retrieval of card bin info should have failed")
+                case .failure(let error):
+                    XCTAssertEqual(expectedError, error)
+                }
+                self.expectationToFulfill!.fulfill()
             }
-            self.expectationToFulfill!.fulfill()
         }
 
         wait(for: [expectationToFulfill!], timeout: 1)
@@ -104,36 +118,38 @@ class CardBinApiClientTests: XCTestCase {
                 "should return bin info from cache manager if it exists and rest client is not called"
         )
 
-        let mockRestClient = RestClientMock<CardBinResponse>(replyWith: expectedResponse)
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let mockRestClient = RestClientMock<CardBinResponse>(replyWith: self.expectedResponse)
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
-
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(self.expectedResponse.brand, response.brand)
-                XCTAssertEqual(
-                    mockRestClient.numberOfCalls, 1,
-                    "Rest client is called once on new card bin number")
-            case .failure:
-                XCTFail("Retrieval of card bin info failed")
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success(let response):
+                    XCTAssertEqual(self.expectedResponse.brand, response.brand)
+                    XCTAssertEqual(
+                        mockRestClient.numberOfCalls, 1,
+                        "Rest client is called once on new card bin number")
+                case .failure:
+                    XCTFail("Retrieval of card bin info failed")
+                }
             }
-        }
 
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success(let response):
-                XCTAssertEqual(self.expectedResponse.brand, response.brand)
-                XCTAssertEqual(
-                    mockRestClient.numberOfCalls, 1, "Rest client should not be called again")
-                self.expectationToFulfill!.fulfill()
-            case .failure:
-                XCTFail("Retrieval of card bin info failed")
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success(let response):
+                    XCTAssertEqual(self.expectedResponse.brand, response.brand)
+                    XCTAssertEqual(
+                        mockRestClient.numberOfCalls, 1, "Rest client should not be called again")
+                    self.expectationToFulfill!.fulfill()
+                case .failure:
+                    XCTFail("Retrieval of card bin info failed")
+                }
             }
         }
 
@@ -145,30 +161,30 @@ class CardBinApiClientTests: XCTestCase {
             description: "should attempt request three times on server error (5xx)"
         )
 
-        let serverError = AccessCheckoutError.unexpectedApiError(message: "unexpectedApiError")
-        let mockRestClient = RestClientMock<CardBinResponse>(
-            errorWith: serverError, statusCode: 500)
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let serverError = AccessCheckoutError.unexpectedApiError(message: "unexpectedApiError")
+            let mockRestClient = RestClientMock<CardBinResponse>(
+                errorWith: serverError, statusCode: 500)
 
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success:
-                XCTFail("Retrieval of card bin info should have failed")
-            case .failure(let error):
-                XCTAssertEqual(
-                    3, mockRestClient.numberOfCalls, "Rest client should be called three times")
-                XCTAssertTrue(error.localizedDescription.contains("unexpectedApiError"))
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success:
+                    XCTFail("Retrieval of card bin info should have failed")
+                case .failure(let error):
+                    XCTAssertEqual(
+                        3, mockRestClient.numberOfCalls, "Rest client should be called three times")
+                    XCTAssertTrue(error.localizedDescription.contains("unexpectedApiError"))
+                }
+                self.expectationToFulfill!.fulfill()
             }
-            self.expectationToFulfill!.fulfill()
         }
 
         wait(for: [expectationToFulfill!], timeout: 1)
-
     }
 
     func testDoesNotRetryOnClientError() {
@@ -176,33 +192,32 @@ class CardBinApiClientTests: XCTestCase {
             description: "should not retry request on client error (4xx)"
         )
 
-        let serverError = AccessCheckoutError.unexpectedApiError(message: "Bad request")
-        let mockRestClient = RestClientMock<CardBinResponse>(
-            errorWith: serverError, statusCode: 400)
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            let serverError = AccessCheckoutError.unexpectedApiError(message: "Bad request")
+            let mockRestClient = RestClientMock<CardBinResponse>(
+                errorWith: serverError, statusCode: 400)
 
-        let apiClient = CardBinApiClient(
-            restClient: mockRestClient,
-            cardBinEndpointProvider: { "some-url" }
-        )
+            let apiClient = CardBinApiClient(restClient: mockRestClient)
 
-        apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
-            result in
-            switch result {
-            case .success:
-                XCTFail("Retrieval of card bin info should have failed")
-            case .failure(let error):
-                XCTAssertEqual(
-                    1, mockRestClient.numberOfCalls,
-                    "Rest client should be called one time (no retries)")
-                XCTAssertTrue(error.localizedDescription.contains("unexpectedApiError"))
+            apiClient.retrieveBinInfo(
+                cardNumber: self.testCardNumber, checkoutId: self.testCheckoutId
+            ) {
+                result in
+                switch result {
+                case .success:
+                    XCTFail("Retrieval of card bin info should have failed")
+                case .failure(let error):
+                    XCTAssertEqual(
+                        1, mockRestClient.numberOfCalls,
+                        "Rest client should be called one time (no retries)")
+                    XCTAssertTrue(error.localizedDescription.contains("unexpectedApiError"))
+                }
+                self.expectationToFulfill!.fulfill()
             }
-            self.expectationToFulfill!.fulfill()
         }
 
         wait(for: [expectationToFulfill!], timeout: 1)
-
     }
-
 }
 
 extension CardBinApiClientTests {
@@ -221,5 +236,47 @@ extension CardBinApiClientTests {
         urlRequest.addValue("1", forHTTPHeaderField: "WP-Api-Version")
 
         return urlRequest
+    }
+
+    private func setUpDiscoveryResponses() {
+        restClient.getStubbingProxy()
+            .send(urlSession: any(), request: any(), completionHandler: any())
+            .then { _, _, completionHandler in
+                completionHandler(.success(self.genericApiResponse()), nil)
+                return URLSessionTask()
+            }.then { _, _, completionHandler in
+                completionHandler(.success(self.genericApiResponse()), nil)
+                return URLSessionTask()
+            }
+    }
+
+    // cuckoo requires stubbing all methods to avoid error
+    private func setUpApiResponseLookups() {
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.service, in: any())
+            .thenReturn("sessions-service-url")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardBin.service, in: any())
+            .thenReturn(cardBinServiceUrl)
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.endpoint, in: any())
+            .thenReturn("sessions-card-href")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cvcSessions.endpoint, in: any())
+            .thenReturn("sessions-cvc-href")
+    }
+
+    private func genericApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "a:service": {
+                        "href": "http://www.example.com"
+                    }
+                }
+            }
+            """
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
@@ -32,7 +32,7 @@ class CardBinApiClientTests: XCTestCase {
 
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) { _ in
@@ -50,7 +50,7 @@ class CardBinApiClientTests: XCTestCase {
         let mockRestClient = RestClientMock(replyWith: expectedResponse)
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -81,7 +81,7 @@ class CardBinApiClientTests: XCTestCase {
 
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -108,7 +108,7 @@ class CardBinApiClientTests: XCTestCase {
 
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -151,7 +151,7 @@ class CardBinApiClientTests: XCTestCase {
 
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -182,7 +182,7 @@ class CardBinApiClientTests: XCTestCase {
 
         let apiClient = CardBinApiClient(
             restClient: mockRestClient,
-            endpointProvider: { "some-url" }
+            cardBinEndpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTests.swift
@@ -31,8 +31,8 @@ class CardBinApiClientTests: XCTestCase {
         let mockRestClient = RestClientMock(replyWith: expectedResponse)
 
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) { _ in
@@ -49,8 +49,8 @@ class CardBinApiClientTests: XCTestCase {
 
         let mockRestClient = RestClientMock(replyWith: expectedResponse)
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -80,8 +80,8 @@ class CardBinApiClientTests: XCTestCase {
             message: "Failed after 3 attempt(s) with error \(detailedErrorMessage)")
 
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -107,8 +107,8 @@ class CardBinApiClientTests: XCTestCase {
         let mockRestClient = RestClientMock<CardBinResponse>(replyWith: expectedResponse)
 
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -150,8 +150,8 @@ class CardBinApiClientTests: XCTestCase {
             errorWith: serverError, statusCode: 500)
 
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {
@@ -181,8 +181,8 @@ class CardBinApiClientTests: XCTestCase {
             errorWith: serverError, statusCode: 400)
 
         let apiClient = CardBinApiClient(
-            url: "some-url",
-            restClient: mockRestClient
+            restClient: mockRestClient,
+            endpointProvider: { "some-url" }
         )
 
         apiClient.retrieveBinInfo(cardNumber: testCardNumber, checkoutId: testCheckoutId) {

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -14,7 +14,10 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
 
     override func setUp() {
         serviceStubs = ServiceStubs()
-        cardBinApiClient = CardBinApiClient(url: "\(serviceStubs.baseUrl)/somewhere")
+        // CRITICAL FIX: Use the full URL with the stub service base URL
+        cardBinApiClient = CardBinApiClient(
+            endpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
+        )
     }
 
     override func tearDown() {
@@ -56,7 +59,7 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
      - assert that the completion handler passed to the retrieveBinInfo() method was never called
      */
     func testClientSupportsCancellingRequestInFlightWhenRetrying() {
-        serviceStubs.post500(path: "/somewhere", delayInSeconds: 0.2)
+        serviceStubs.post500(path: "/somewhere", delayInSeconds: 0.5)
             .start()
 
         var calledCompletionHandler = false

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -14,9 +14,8 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
 
     override func setUp() {
         serviceStubs = ServiceStubs()
-        // CRITICAL FIX: Use the full URL with the stub service base URL
         cardBinApiClient = CardBinApiClient(
-            endpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
+            cardBinEndpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
         )
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinApiClientTestsWithStubService.swift
@@ -9,29 +9,40 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
     private var serviceStubs: ServiceStubs = ServiceStubs()
     private var cardBinApiClient: CardBinApiClient!
 
+    let restClient = MockRetryRestClientDecorator<ApiResponse>()
+    let apiResponseLookUpMock = MockApiResponseLinkLookup()
+
     private let checkoutId = "00000000-0000-0000-000000000000"
     private let visaTestPan = "444433332222"
 
     override func setUp() {
         serviceStubs = ServiceStubs()
-        cardBinApiClient = CardBinApiClient(
-            cardBinEndpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
-        )
+
+        ServiceDiscoveryProvider.shared = ServiceDiscoveryProvider(
+            restClient,
+            apiResponseLookUpMock)
+        ServiceDiscoveryProvider.shared.clearCache()
+
+        setUpDiscoveryResponses()
+        setUpApiResponseLookups()
+
+        cardBinApiClient = CardBinApiClient()
     }
 
     override func tearDown() {
-        cardBinApiClient = nil
         serviceStubs.stop()
+        ServiceDiscoveryProvider.shared.clearCache()
     }
 
-    /*
-     This test is designed to:
-     - use a stub server
-     - delay the response from a stub server by 0.5 seconds
-     - abort the call to the retrieveBinInfo() method of the CardBinApiClient class
-     - assert that the completion handler passed to the retrieveBinInfo() method was never called
-     */
     func testClientSupportsCancellingRequestInFlight() {
+        let expectation = self.expectation(description: "Discovery should complete")
+
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+
         serviceStubs.post200(path: "/somewhere", textResponse: "some response", delayInSeconds: 0.5)
             .start()
 
@@ -48,17 +59,16 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
         XCTAssertFalse(calledCompletionHandler)
     }
 
-    /*
-     This test is designed to:
-     - use a stub server
-     - delay the response from a stub server by 0.2 seconds and always send back a 500
-     - 500s are used to make sure that the CardBinApiClient can retry since it would not if the error is an 4xx
-     - abort the call to the retrieveBinInfo() method of the CardBinApiClient class after 0.3 seconds, i.e. in the middle of the 2nd attempt
-     - wait 1s, for any potential retry to occur although they should not since abort() has been called
-     - assert that the completion handler passed to the retrieveBinInfo() method was never called
-     */
     func testClientSupportsCancellingRequestInFlightWhenRetrying() {
-        serviceStubs.post500(path: "/somewhere", delayInSeconds: 0.5)
+        let expectation = self.expectation(description: "Discovery should complete")
+
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+
+        serviceStubs.post500(path: "/somewhere", delayInSeconds: 0.2)
             .start()
 
         var calledCompletionHandler = false
@@ -68,12 +78,71 @@ class CardBinApiClientTestsWithStubService: XCTestCase {
             calledCompletionHandler = true
         }
 
-        // Aborting the request after the 1st attempt has failed with 500
         Thread.sleep(forTimeInterval: 0.3)
         cardBinApiClient.abort()
 
-        // Waiting until the end of any potential future retries
         Thread.sleep(forTimeInterval: 1)
         XCTAssertFalse(calledCompletionHandler)
+    }
+
+    private func setUpDiscoveryResponses() {
+        restClient.getStubbingProxy()
+            .send(urlSession: any(), request: any(), completionHandler: any())
+            .then { _, _, completionHandler in
+                completionHandler(.success(self.accessRootApiResponse()), nil)
+                return URLSessionTask()
+            }.then { _, _, completionHandler in
+                completionHandler(.success(self.sessionsApiResponse()), nil)
+                return URLSessionTask()
+            }
+    }
+
+    private func setUpApiResponseLookups() {
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.service, in: any())
+            .thenReturn("sessions-service-url")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardBin.service, in: any())
+            .thenReturn("\(serviceStubs.baseUrl)/somewhere")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.endpoint, in: any())
+            .thenReturn("sessions-card-href")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cvcSessions.endpoint, in: any())
+            .thenReturn("sessions-cvc-href")
+    }
+
+    private func accessRootApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "service:sessions": {
+                        "href": "sessions-service-url"
+                    },
+                    "service:card-bin": {
+                        "href": "\(serviceStubs.baseUrl)/somewhere"
+                    }
+                }
+            }
+            """
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
+    }
+
+    private func sessionsApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "sessions:card": {
+                        "href": "sessions-card-href"
+                    },
+                    "sessions:cvc": {
+                        "href": "sessions-cvc-href"
+                    }
+                }
+            }
+            """
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTests.swift
@@ -11,13 +11,12 @@ class CardBinServiceTests: XCTestCase {
     private var cardBinService: CardBinService!
 
     private let checkoutId = "00000000-0000-0000-000000000000"
-    private let baseURL = "some-url"
     private let visaTestPan = "444433332222"
     private let discoverDinersTestPan = "601100040000"
 
     override func setUp() {
 
-        mockClient = MockCardBinApiClient(url: baseURL)
+        mockClient = MockCardBinApiClient()
         mockFactory = CardBrandsConfigurationFactoryMock()
         mockConfigurationProvider = MockCardBrandsConfigurationProvider(mockFactory)
 
@@ -27,7 +26,6 @@ class CardBinServiceTests: XCTestCase {
 
         cardBinService = CardBinService(
             checkoutId: checkoutId,
-            baseURL: baseURL,
             client: mockClient,
             configurationProvider: mockConfigurationProvider
         )
@@ -40,11 +38,10 @@ class CardBinServiceTests: XCTestCase {
     }
 
     func testShouldInstantiateCardBinServiceWithDefaultClient() {
-        let client = CardBinApiClient(url: baseURL)
+        let client = CardBinApiClient()
         let configurationProvider = MockCardBrandsConfigurationProvider(mockFactory)
         let service = CardBinService(
             checkoutId: "testCheckoutId",
-            baseURL: baseURL,
             client: client,
             configurationProvider: configurationProvider
         )

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
@@ -12,11 +12,10 @@ class CardBinServiceTestsWithStubService: XCTestCase {
     private var cardBinService: CardBinService!
 
     private let checkoutId = "00000000-0000-0000-000000000000"
-    private let baseURL = "http://example.com"
-
     private let visaTestPan = "444433332222"
 
     override func setUp() {
+        serviceStubs = ServiceStubs()
         mockFactory = CardBrandsConfigurationFactoryMock()
         mockConfigurationProvider = MockCardBrandsConfigurationProvider(mockFactory)
 
@@ -24,11 +23,12 @@ class CardBinServiceTestsWithStubService: XCTestCase {
             when(stub.get()).thenReturn(TestFixtures.createDefaultCardConfiguration())
         }
 
-        let cardBinApiClient = CardBinApiClient(url: "\(serviceStubs.baseUrl)/somewhere")
+        let cardBinApiClient = CardBinApiClient(
+            endpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
+        )
 
         cardBinService = CardBinService(
             checkoutId: checkoutId,
-            baseURL: "\(serviceStubs.baseUrl)/somewhere",
             client: cardBinApiClient,
             configurationProvider: mockConfigurationProvider
         )

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
@@ -11,6 +11,9 @@ class CardBinServiceTestsWithStubService: XCTestCase {
     private var mockConfigurationProvider: MockCardBrandsConfigurationProvider!
     private var cardBinService: CardBinService!
 
+    let restClient = MockRetryRestClientDecorator<ApiResponse>()
+    let apiResponseLookUpMock = MockApiResponseLinkLookup()
+
     private let checkoutId = "00000000-0000-0000-000000000000"
     private let visaTestPan = "444433332222"
 
@@ -23,9 +26,15 @@ class CardBinServiceTestsWithStubService: XCTestCase {
             when(stub.get()).thenReturn(TestFixtures.createDefaultCardConfiguration())
         }
 
-        let cardBinApiClient = CardBinApiClient(
-            cardBinEndpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
-        )
+        ServiceDiscoveryProvider.shared = ServiceDiscoveryProvider(
+            restClient,
+            apiResponseLookUpMock)
+        ServiceDiscoveryProvider.shared.clearCache()
+
+        setUpDiscoveryResponses()
+        setUpApiResponseLookups()
+
+        let cardBinApiClient = CardBinApiClient()
 
         cardBinService = CardBinService(
             checkoutId: checkoutId,
@@ -35,18 +44,19 @@ class CardBinServiceTestsWithStubService: XCTestCase {
     }
 
     override func tearDown() {
-        cardBinService = nil
         serviceStubs.stop()
+        ServiceDiscoveryProvider.shared.clearCache()
     }
 
-    /*
-     This test is designed to:
-     - use a stub server with delayed response
-     - make a first call that will be aborted
-     - make a second call that will complete successfully
-     - verify that only the second completion handler is called
-     */
     func testServiceCancelsFirstRequestAndOnlyCompletesSecond_withSwifter() {
+        let expectation = self.expectation(description: "Discovery should complete")
+
+        ServiceDiscoveryProvider.discover(baseUrl: "some-url") { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+
         let cardBinResponse = """
             {
                 "brand": ["visa"],
@@ -59,7 +69,6 @@ class CardBinServiceTestsWithStubService: XCTestCase {
             .start()
 
         let firstExpectation = self.expectation(description: "First call should not complete ")
-        // we expect this to not be fulfilled as it should be an aborted call
         firstExpectation.isInverted = true
         let secondExpectation = self.expectation(
             description: "Second call should complete successfully")
@@ -71,7 +80,6 @@ class CardBinServiceTestsWithStubService: XCTestCase {
             firstExpectation.fulfill()
         }
 
-        // small delay to ensure first request is in flight
         Thread.sleep(forTimeInterval: 0.05)
 
         cardBinService.getCardBrands(
@@ -87,8 +95,67 @@ class CardBinServiceTestsWithStubService: XCTestCase {
             secondExpectation.fulfill()
         }
 
-        // should pass if first expectation does not to fulfill (inverted expectation) and second expectation does fulfill
         wait(for: [firstExpectation, secondExpectation], timeout: 1.0)
+    }
 
+    private func setUpDiscoveryResponses() {
+        restClient.getStubbingProxy()
+            .send(urlSession: any(), request: any(), completionHandler: any())
+            .then { _, _, completionHandler in
+                completionHandler(.success(self.accessRootApiResponse()), nil)
+                return URLSessionTask()
+            }.then { _, _, completionHandler in
+                completionHandler(.success(self.sessionsApiResponse()), nil)
+                return URLSessionTask()
+            }
+    }
+
+    private func setUpApiResponseLookups() {
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.service, in: any())
+            .thenReturn("sessions-service-url")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardBin.service, in: any())
+            .thenReturn("\(serviceStubs.baseUrl)/somewhere")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cardSessions.endpoint, in: any())
+            .thenReturn("sessions-card-href")
+        apiResponseLookUpMock.getStubbingProxy()
+            .lookup(link: ApiLinks.cvcSessions.endpoint, in: any())
+            .thenReturn("sessions-cvc-href")
+    }
+
+    private func accessRootApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "service:sessions": {
+                        "href": "sessions-service-url"
+                    },
+                    "service:card-bin": {
+                        "href": "\(serviceStubs.baseUrl)/somewhere"
+                    }
+                }
+            }
+            """
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
+    }
+
+    private func sessionsApiResponse() -> ApiResponse {
+        let jsonString = """
+            {
+                "_links": {
+                    "sessions:card": {
+                        "href": "sessions-card-href"
+                    },
+                    "sessions:cvc": {
+                        "href": "sessions-cvc-href"
+                    }
+                }
+            }
+            """
+        let data = Data(jsonString.utf8)
+        return try! JSONDecoder().decode(ApiResponse.self, from: data)
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/api/cardBin/CardBinServiceTestsWithStubService.swift
@@ -24,7 +24,7 @@ class CardBinServiceTestsWithStubService: XCTestCase {
         }
 
         let cardBinApiClient = CardBinApiClient(
-            endpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
+            cardBinEndpointProvider: { "\(self.serviceStubs.baseUrl)/somewhere" }
         )
 
         cardBinService = CardBinService(

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowCobrandedCardsTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowCobrandedCardsTests.swift
@@ -1,0 +1,172 @@
+import Cuckoo
+import XCTest
+
+@testable import AccessCheckoutSDK
+
+class PanValidationFlowCobrandedCardsTests: XCTestCase {
+
+    private var mockPanValidator: MockPanValidator!
+    private var mockPanValidationStateHandler: MockPanValidationStateHandler!
+    private var mockCvcFlow: MockCvcValidationFlow!
+    private var mockCardBinService: MockCardBinService!
+    private var panValidationFlow: PanValidationFlow!
+
+    override func setUp() {
+        super.setUp()
+
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
+        mockPanValidator = MockPanValidator(configurationProvider)
+        mockPanValidationStateHandler = MockPanValidationStateHandler()
+        mockCvcFlow = MockCvcValidationFlow(
+            MockCvcValidator(),
+            MockCvcValidationStateHandler()
+        )
+        mockCardBinService = MockCardBinService(
+            checkoutId: "0000-0000-0000-0000-000000000000",
+            client: MockCardBinApiClient(),
+            configurationProvider: configurationProvider
+        )
+
+        panValidationFlow = PanValidationFlow(
+            mockPanValidator,
+            mockPanValidationStateHandler,
+            mockCvcFlow,
+            mockCardBinService
+        )
+
+        stub(mockPanValidationStateHandler) { stub in
+            when(stub.getCardBrand()).thenReturn(nil)
+        }
+    }
+
+    override func tearDown() {
+        mockPanValidator = nil
+        mockPanValidationStateHandler = nil
+        mockCvcFlow = nil
+        mockCardBinService = nil
+        panValidationFlow = nil
+        super.tearDown()
+    }
+
+    func testHandleCobrandedCards_withEmptyPan_doesNotCallCardBinService() {
+        let emptyPan = ""
+
+        panValidationFlow.handleCobrandedCards(pan: emptyPan)
+
+        verifyNoMoreInteractions(mockCardBinService)
+    }
+
+    func testHandleCobrandedCards_withLessThan12Digits_doesNotCallService() {
+        let shortPan = "44443333"
+
+        stub(mockPanValidationStateHandler) { stub in
+            when(stub.getCardBrand()).thenReturn(nil)
+        }
+
+        var wasCalled = false
+        stub(mockCardBinService) { stub in
+            when(
+                stub.getCardBrands(
+                    globalBrand: any(),
+                    cardNumber: any(),
+                    completion: any()
+                )
+            ).then { _, _, completion in
+                wasCalled = true
+                completion(.success([]))
+            }
+        }
+
+        panValidationFlow.handleCobrandedCards(pan: shortPan)
+
+        XCTAssertFalse(wasCalled)
+    }
+
+    func testHandleCobrandedCards_withSpacesInPan_sanitisesBeforeProcessing() {
+        let panWithSpaces = "4444 3333 2222 1111"
+        let expectedSanitised = "444433332222"
+        let visaBrand = TestFixtures.visaBrand()
+
+        stub(mockPanValidationStateHandler) { stub in
+            when(stub.getCardBrand()).thenReturn(visaBrand)
+        }
+
+        stub(mockCardBinService) { stub in
+            when(
+                stub.getCardBrands(
+                    globalBrand: equal(to: visaBrand),
+                    cardNumber: equal(to: expectedSanitised),
+                    completion: any()
+                )
+            ).then { _, _, completion in
+                completion(.success([visaBrand]))
+            }
+        }
+
+        panValidationFlow.handleCobrandedCards(pan: panWithSpaces)
+
+        verify(mockCardBinService).getCardBrands(
+            globalBrand: equal(to: visaBrand),
+            cardNumber: equal(to: expectedSanitised),
+            completion: any()
+        )
+    }
+
+    func testHandleCobrandedCards_withSamePrefixCalledTwice_onlyCallsServiceOnce() {
+        let pan1 = "444433332222111"
+        let pan2 = "444433332222999"
+
+        stub(mockPanValidationStateHandler) { stub in
+            when(stub.getCardBrand()).thenReturn(nil)
+        }
+
+        var callCount = 0
+        stub(mockCardBinService) { stub in
+            when(
+                stub.getCardBrands(
+                    globalBrand: any(),
+                    cardNumber: any(),
+                    completion: any()
+                )
+            ).then { _, _, completion in
+                callCount += 1
+                completion(.success([]))
+            }
+        }
+
+        panValidationFlow.handleCobrandedCards(pan: pan1)
+        panValidationFlow.handleCobrandedCards(pan: pan2)
+
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testHandleCobrandedCards_withDifferentPrefix_callsServiceForEachPrefix() {
+        let pan1 = "444433332222"
+        let pan2 = "555544443333"
+
+        stub(mockPanValidationStateHandler) { stub in
+            when(stub.getCardBrand()).thenReturn(nil)
+        }
+
+        var callCount = 0
+        stub(mockCardBinService) { stub in
+            when(
+                stub.getCardBrands(
+                    globalBrand: any(),
+                    cardNumber: any(),
+                    completion: any()
+                )
+            ).then { _, _, completion in
+                callCount += 1
+                completion(.success([]))
+            }
+        }
+
+        panValidationFlow.handleCobrandedCards(pan: pan1)
+        panValidationFlow.handleCobrandedCards(pan: pan2)
+
+        XCTAssertEqual(callCount, 2)
+    }
+}

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowCobrandedCardsTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowCobrandedCardsTests.swift
@@ -42,11 +42,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
     }
 
     override func tearDown() {
-        mockPanValidator = nil
-        mockPanValidationStateHandler = nil
-        mockCvcFlow = nil
-        mockCardBinService = nil
-        panValidationFlow = nil
         super.tearDown()
     }
 
@@ -65,7 +60,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
             when(stub.getCardBrand()).thenReturn(nil)
         }
 
-        var wasCalled = false
         stub(mockCardBinService) { stub in
             when(
                 stub.getCardBrands(
@@ -74,14 +68,13 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
                     completion: any()
                 )
             ).then { _, _, completion in
-                wasCalled = true
                 completion(.success([]))
             }
         }
 
         panValidationFlow.handleCobrandedCards(pan: shortPan)
 
-        XCTAssertFalse(wasCalled)
+        verifyNoMoreInteractions(mockCardBinService)
     }
 
     func testHandleCobrandedCards_withSpacesInPan_sanitisesBeforeProcessing() {
@@ -122,7 +115,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
             when(stub.getCardBrand()).thenReturn(nil)
         }
 
-        var callCount = 0
         stub(mockCardBinService) { stub in
             when(
                 stub.getCardBrands(
@@ -131,7 +123,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
                     completion: any()
                 )
             ).then { _, _, completion in
-                callCount += 1
                 completion(.success([]))
             }
         }
@@ -139,7 +130,11 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
         panValidationFlow.handleCobrandedCards(pan: pan1)
         panValidationFlow.handleCobrandedCards(pan: pan2)
 
-        XCTAssertEqual(callCount, 1)
+        verify(mockCardBinService, times(1)).getCardBrands(
+            globalBrand: any(),
+            cardNumber: any(),
+            completion: any()
+        )
     }
 
     func testHandleCobrandedCards_withDifferentPrefix_callsServiceForEachPrefix() {
@@ -150,7 +145,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
             when(stub.getCardBrand()).thenReturn(nil)
         }
 
-        var callCount = 0
         stub(mockCardBinService) { stub in
             when(
                 stub.getCardBrands(
@@ -159,7 +153,6 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
                     completion: any()
                 )
             ).then { _, _, completion in
-                callCount += 1
                 completion(.success([]))
             }
         }
@@ -167,6 +160,10 @@ class PanValidationFlowCobrandedCardsTests: XCTestCase {
         panValidationFlow.handleCobrandedCards(pan: pan1)
         panValidationFlow.handleCobrandedCards(pan: pan2)
 
-        XCTAssertEqual(callCount, 2)
+        verify(mockCardBinService, times(2)).getCardBrands(
+            globalBrand: any(),
+            cardNumber: any(),
+            completion: any()
+        )
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/validation/model/pan/PanValidationFlowTests.swift
@@ -4,15 +4,7 @@ import XCTest
 @testable import AccessCheckoutSDK
 
 class PanValidationFlowTests: XCTestCase {
-    let visaBrand = CardBrandModel(
-        name: "visa",
-        images: [],
-        panValidationRule: ValidationRule(
-            matcher: "^(?!^493698\\d*$)4\\d*$",
-            validLengths: [16, 18, 19]
-        ),
-        cvcValidationRule: ValidationRule(matcher: nil, validLengths: [3])
-    )
+    let visaBrand = TestFixtures.visaBrand()
 
     private var mockCardBinService: MockCardBinService!
     private let panValidationStateHandler = MockPanValidationStateHandler()
@@ -21,7 +13,7 @@ class PanValidationFlowTests: XCTestCase {
         super.setUp()
 
         mockCardBinService = MockCardBinService(
-            checkoutId: "test-checkout-id",
+            checkoutId: "0000-0000-0000-0000-000000000000",
             client: MockCardBinApiClient(),
             configurationProvider: MockCardBrandsConfigurationProvider(
                 CardBrandsConfigurationFactoryMock()

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterCobrandedCardsTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/presenters/PanViewPresenterCobrandedCardsTests.swift
@@ -1,0 +1,74 @@
+import Cuckoo
+import XCTest
+
+@testable import AccessCheckoutSDK
+
+class PanViewPresenterCobrandedCardsTests: XCTestCase {
+
+    private var mockPanValidationFlow: MockPanValidationFlow!
+    private var mockPanValidator: MockPanValidator!
+    private var presenter: PanViewPresenter!
+
+    override func setUp() {
+        super.setUp()
+
+        let configurationProvider = MockCardBrandsConfigurationProvider(
+            CardBrandsConfigurationFactoryMock()
+        )
+        mockPanValidator = MockPanValidator(configurationProvider)
+
+        let mockCardBinService = MockCardBinService(
+            checkoutId: "0000-0000-0000-0000-000000000000",
+            client: MockCardBinApiClient(),
+            configurationProvider: configurationProvider
+        )
+
+        mockPanValidationFlow = MockPanValidationFlow(
+            mockPanValidator,
+            MockPanValidationStateHandler(),
+            MockCvcValidationFlow(MockCvcValidator(), MockCvcValidationStateHandler()),
+            mockCardBinService
+        )
+
+        stub(mockPanValidationFlow) { stub in
+            when(stub.validate(pan: any())).thenDoNothing()
+            when(stub.handleCobrandedCards(pan: any())).thenDoNothing()
+            when(stub.notifyMerchant()).thenDoNothing()
+        }
+
+        presenter = PanViewPresenter(
+            mockPanValidationFlow,
+            mockPanValidator,
+            panFormattingEnabled: false
+        )
+    }
+
+    func testOnEditing_callsHandleCobrandedCards() {
+        let pan = "444433332222"
+
+        presenter.onEditing(text: pan)
+
+        verify(mockPanValidationFlow).handleCobrandedCards(pan: pan)
+        verify(mockPanValidationFlow).validate(pan: pan)
+    }
+
+    func testOnEditing_callsHandleCobrandedCardsWithShortPan() {
+        let pan = "4444"
+
+        presenter.onEditing(text: pan)
+
+        verify(mockPanValidationFlow).handleCobrandedCards(pan: pan)
+        verify(mockPanValidationFlow).validate(pan: pan)
+    }
+
+    func testTextFieldEditingChanged_triggersHandleCobrandedCards() {
+        let textField = UITextField()
+        textField.text = "444433332222"
+
+        presenter.textFieldEditingChanged(textField)
+
+        verify(mockPanValidationFlow).handleCobrandedCards(pan: "444433332222")
+        verify(mockPanValidationFlow).validate(pan: "444433332222")
+    }
+
+}

--- a/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
+++ b/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
@@ -12,16 +12,16 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "identity": "identity",
-          "cardNumber": "4111111111111110",
           "cardExpiryDate": {
             "month": 12,
             "year": 2099
           },
+          "cardNumber": "4111111111111110",
           "cvc": "123"
         }
       },
@@ -31,15 +31,15 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "errorName": "bodyDoesNotMatchSchema",
           "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "jsonPath": "$.cardNumber",
               "errorName": "panFailedLuhnCheck",
+              "jsonPath": "$.cardNumber",
               "message": "The identified field contains a PAN that has failed the Luhn check."
             }
-          ]
+          ],
+          "errorName": "bodyDoesNotMatchSchema"
         },
         "matchingRules": {
           "$.body.message": {
@@ -57,17 +57,17 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "cvc": "123",
-          "cardNumber": "notACardNumber",
+          "identity": "identity",
           "cardExpiryDate": {
-            "month": 1,
-            "year": 2099
+            "year": 2099,
+            "month": 1
           },
-          "identity": "identity"
+          "cardNumber": "notACardNumber"
         }
       },
       "response": {
@@ -77,20 +77,20 @@
         },
         "body": {
           "errorName": "bodyDoesNotMatchSchema",
+          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "message": "Card number must be numeric",
+              "jsonPath": "$.cardNumber",
               "errorName": "fieldHasInvalidValue",
-              "jsonPath": "$.cardNumber"
+              "message": "Card number must be numeric"
             }
-          ],
-          "message": "The json body provided does not match the expected schema"
+          ]
         },
         "matchingRules": {
-          "$.body.validationErrors[0].message": {
+          "$.body.message": {
             "match": "type"
           },
-          "$.body.message": {
+          "$.body.validationErrors[0].message": {
             "match": "type"
           }
         }
@@ -106,11 +106,56 @@
           "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
+          "cardNumber": "4111111111111111",
+          "cvc": "123",
           "identity": "incorrectValue",
           "cardExpiryDate": {
-            "year": 2099,
-            "month": 12
+            "month": 12,
+            "year": 2099
+          }
+        }
+      },
+      "response": {
+        "status": 400,
+        "headers": {
+          "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
+        },
+        "body": {
+          "errorName": "bodyDoesNotMatchSchema",
+          "validationErrors": [
+            {
+              "errorName": "fieldHasInvalidValue",
+              "message": "Identity is invalid",
+              "jsonPath": "$.identity"
+            }
+          ],
+          "message": "The json body provided does not match the expected schema"
+        },
+        "matchingRules": {
+          "$.body.validationErrors[0].message": {
+            "match": "type"
           },
+          "$.body.message": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "POST request to /sessions/card with expiry date month that is too large",
+      "request": {
+        "method": "post",
+        "path": "/sessions/card",
+        "headers": {
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+        },
+        "body": {
+          "cardExpiryDate": {
+            "month": 13,
+            "year": 2099
+          },
+          "identity": "identity",
           "cvc": "123",
           "cardNumber": "4111111111111111"
         }
@@ -125,9 +170,9 @@
           "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "message": "Identity is invalid",
-              "jsonPath": "$.identity",
-              "errorName": "fieldHasInvalidValue"
+              "message": "Card expiry month is too large - must be between 1 & 12",
+              "jsonPath": "$.cardExpiryDate.month",
+              "errorName": "integerIsTooLarge"
             }
           ]
         },
@@ -142,22 +187,17 @@
       }
     },
     {
-      "description": "POST request to /sessions/card with expiry date month that is too large",
+      "description": "POST request to /sessions/payments/cvc with invalid identity in body",
       "request": {
         "method": "post",
-        "path": "/sessions/card",
+        "path": "/sessions/payments/cvc",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "cardNumber": "4111111111111111",
-          "cardExpiryDate": {
-            "month": 13,
-            "year": 2099
-          },
           "cvc": "123",
-          "identity": "identity"
+          "identity": "incorrectValue"
         }
       },
       "response": {
@@ -168,9 +208,9 @@
         "body": {
           "validationErrors": [
             {
-              "jsonPath": "$.cardExpiryDate.month",
-              "message": "Card expiry month is too large - must be between 1 & 12",
-              "errorName": "integerIsTooLarge"
+              "errorName": "fieldHasInvalidValue",
+              "jsonPath": "$.identity",
+              "message": "Identity is invalid"
             }
           ],
           "errorName": "bodyDoesNotMatchSchema",
@@ -187,53 +227,13 @@
       }
     },
     {
-      "description": "POST request to /sessions/payments/cvc with invalid identity in body",
-      "request": {
-        "method": "post",
-        "path": "/sessions/payments/cvc",
-        "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
-        },
-        "body": {
-          "cvc": "123",
-          "identity": "incorrectValue"
-        }
-      },
-      "response": {
-        "status": 400,
-        "headers": {
-          "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
-        },
-        "body": {
-          "message": "The json body provided does not match the expected schema",
-          "errorName": "bodyDoesNotMatchSchema",
-          "validationErrors": [
-            {
-              "message": "Identity is invalid",
-              "errorName": "fieldHasInvalidValue",
-              "jsonPath": "$.identity"
-            }
-          ]
-        },
-        "matchingRules": {
-          "$.body.message": {
-            "match": "type"
-          },
-          "$.body.validationErrors[0].message": {
-            "match": "type"
-          }
-        }
-      }
-    },
-    {
       "description": "GET request to /sessions to discover sessions endpoints",
       "request": {
         "method": "get",
         "path": "/sessions",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         }
       },
       "response": {
@@ -243,22 +243,22 @@
         },
         "body": {
           "_links": {
-            "sessions:paymentsCvc": {
-              "href": "http://localhost:1234/sessions/payments/cvc"
-            },
             "sessions:card": {
               "href": "http://localhost:1234/sessions/card"
+            },
+            "sessions:paymentsCvc": {
+              "href": "http://localhost:1234/sessions/payments/cvc"
             }
           }
         },
         "matchingRules": {
-          "$.body._links.sessions:paymentsCvc.href": {
-            "match": "regex",
-            "regex": "https?:\\/\\/[^\\/]+\\/sessions\\/payments\\/cvc"
-          },
           "$.body._links.sessions:card.href": {
             "match": "regex",
             "regex": "https?:\\/\\/[^\\/]+\\/sessions\\/card"
+          },
+          "$.body._links.sessions:paymentsCvc.href": {
+            "match": "regex",
+            "regex": "https?:\\/\\/[^\\/]+\\/sessions\\/payments\\/cvc"
           }
         }
       }
@@ -273,13 +273,13 @@
           "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "cvc": "123",
           "cardNumber": "4111111111111111",
           "cardExpiryDate": {
-            "year": 2099,
-            "month": 12
+            "month": 12,
+            "year": 2099
           },
-          "identity": "identity"
+          "identity": "identity",
+          "cvc": "123"
         }
       },
       "response": {
@@ -308,8 +308,8 @@
         "method": "post",
         "path": "/sessions/payments/cvc",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "cvc": "1234",

--- a/AccessCheckoutSDK/scripts/mocks-build-phase.sh
+++ b/AccessCheckoutSDK/scripts/mocks-build-phase.sh
@@ -41,6 +41,7 @@ INPUT_SOURCE_DIR="${PROJECT_DIR}/${PROJECT_NAME}"
 "${INPUT_SOURCE_DIR}/validation/api/cardBin/client/CardBinCacheManager.swift" \
 "${INPUT_SOURCE_DIR}/api/ApiResponseLinkLookup.swift" \
 "${INPUT_SOURCE_DIR}/validation/api/cardBin/client/CardBinApiClient.swift" \
+"${INPUT_SOURCE_DIR}/validation/api/cardBin/service/CardBinService.swift" \
 "${INPUT_SOURCE_DIR}/api/RestClient.swift" \
 "${INPUT_SOURCE_DIR}/api/RetryRestClientDecorator.swift" 
 


### PR DESCRIPTION
What: 

1. Adds mandatory for checkout id to be included in the card validation config for the merchant
2. Adds call to handleCobrandedCards in PanViewPresenter when when text field is edited
3. Handles santisation and prefixing of card number in handleCobranded cards
4. Calls CardBinService with card number and global brand

Why

1. Checkout id is needed to instantiate card bin service on sdk initalisation which is needed for sending request to card bin service
2. when pan field is text is changed it should call handleCobrandedCards to see if the card brands are returned from card bin service
3. validation of pan text so the card bin service is only called with valid length and no spaces in the card number

How

1. Modifying CVC, ACVI, PVP, PVF files 
2. Testing that these calls to handleCobrandedCards are made correctly
3. Testing that subsequent calls are not made for same prefix
4. Testing that checkoutId is a mandatory field that raises AccessCheckoutExpection if not added to config