### PR TITLE
Us2128858 display card brands in demo

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			baseConfigurationReference = 8BA50193BD557BCBB2DE4933 /* Pods-AccessCheckoutDemo.debug.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
+				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -712,7 +712,7 @@
 			baseConfigurationReference = 6E7FDDA3E36720BDB3959BF7 /* Pods-AccessCheckoutDemo.release.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
+				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;

--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 			baseConfigurationReference = 8BA50193BD557BCBB2DE4933 /* Pods-AccessCheckoutDemo.debug.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
+				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -712,7 +712,7 @@
 			baseConfigurationReference = 6E7FDDA3E36720BDB3959BF7 /* Pods-AccessCheckoutDemo.release.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
+				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -210,16 +210,12 @@ class CardFlowViewController: UIViewController {
 
             cardBrandsLabel = label
         }
-
-        cardBrandsLabel?.font = .preferredFont(forTextStyle: .caption1)
-        if #available(iOS 13.0, *) {
-            cardBrandsLabel?.textColor = .label
-        } else {
-            cardBrandsLabel?.textColor = .black
-        }
+        
         cardBrandsLabel?.numberOfLines = 1
-        cardBrandsLabel?.textAlignment = .left
+        cardBrandsLabel?.font = .preferredFont(forTextStyle: .caption1)
         cardBrandsLabel?.text = ""
+        cardBrandsLabel?.textAlignment = .left
+        cardBrandsLabel?.textColor = .black
     }
 
     private func changePanValidIndicator(isValid: Bool) {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -6,6 +6,7 @@ class CardFlowViewController: UIViewController {
     @IBOutlet var expiryDateTextField: AccessCheckoutUITextField!
     @IBOutlet var cvcTextField: AccessCheckoutUITextField!
     @IBOutlet var imageView: UIImageView!
+    @IBOutlet var cardBrandsLabel: UILabel!
     @IBOutlet var submitButton: UIButton!
     @IBOutlet var spinner: UIActivityIndicatorView!
     @IBOutlet var paymentsCvcSessionToggle: UISwitch!
@@ -109,6 +110,9 @@ class CardFlowViewController: UIViewController {
             panTextField.clear()
             expiryDateTextField.clear()
             cvcTextField.clear()
+
+            cardBrandsLabel?.text = ""
+            imageView.image = unknownBrandImage
         }
 
         validationErrors?.forEach { error in
@@ -191,6 +195,31 @@ class CardFlowViewController: UIViewController {
 
         disableSubmitIfNotValid(valid: false)
         cardBrandsChanged(cardBrands: [])
+
+        if cardBrandsLabel == nil {
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(label)
+
+            NSLayoutConstraint.activate([
+                label.trailingAnchor.constraint(equalTo: panTextField.trailingAnchor),
+                label.topAnchor.constraint(equalTo: panTextField.bottomAnchor, constant: 8),
+                label.leadingAnchor.constraint(greaterThanOrEqualTo: panTextField.leadingAnchor),
+                label.heightAnchor.constraint(greaterThanOrEqualToConstant: 21),
+            ])
+
+            cardBrandsLabel = label
+        }
+
+        cardBrandsLabel?.font = .preferredFont(forTextStyle: .caption1)
+        if #available(iOS 13.0, *) {
+            cardBrandsLabel?.textColor = .label
+        } else {
+            cardBrandsLabel?.textColor = .black
+        }
+        cardBrandsLabel?.numberOfLines = 1
+        cardBrandsLabel?.textAlignment = .left
+        cardBrandsLabel?.text = ""
     }
 
     private func changePanValidIndicator(isValid: Bool) {
@@ -214,7 +243,12 @@ class CardFlowViewController: UIViewController {
 
 extension CardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandsChanged(cardBrands: [CardBrand]) {
-        UiUtils.updateCardBrandImage(self.imageView, with: cardBrands.first)
+        UiUtils.updateCardBrandImage(imageView, using: cardBrands)
+
+        let brandNames = cardBrands.map { $0.name }.joined(separator: ", ")
+        DispatchQueue.main.async {
+            self.cardBrandsLabel?.text = brandNames
+        }
     }
 
     func panValidChanged(isValid: Bool) {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/RestrictedCardFlowViewController.swift
@@ -62,7 +62,7 @@ class RestrictedCardFlowViewController: UIViewController {
 
 extension RestrictedCardFlowViewController: AccessCheckoutCardValidationDelegate {
     func cardBrandsChanged(cardBrands: [CardBrand]) {
-        UiUtils.updateCardBrandImage(self.imageView, with: cardBrands.first)
+        UiUtils.updateCardBrandImage(self.imageView, using: cardBrands)
     }
 
     func panValidChanged(isValid: Bool) {

--- a/AccessCheckoutDemo/AccessCheckoutDemo/UiUtils.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/UiUtils.swift
@@ -8,10 +8,11 @@ final class UiUtils {
 
     // This function and the one below are designed to assert the card brand displayed in the UI
     // and use a retry mechanism to cater for what appears to be the slowness of BitRise
-    public static func updateCardBrandImage(_ imageView: UIImageView, with cardBrand: CardBrand?) {
-        if let cardBrand = cardBrand,
-            let urlAsString = cardBrand.images.first(where: { $0.type == "image/png" })?.url,
-            let url = URL(string: urlAsString)
+    public static func updateCardBrandImage(_ imageView: UIImageView, using cardBrands: [CardBrand]) {
+        if !cardBrands.isEmpty,
+           let cardBrand = cardBrands.first,
+           let urlAsString = cardBrand.images.first(where: { $0.type == "image/png" })?.url,
+           let url = URL(string: urlAsString)
         {
             if let cachedImage = cardBrandsImagesCache[urlAsString] {
                 setImageSourceAndLabel(

--- a/AccessCheckoutDemo/AccessCheckoutDemo/UiUtils.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/UiUtils.swift
@@ -8,15 +8,16 @@ final class UiUtils {
 
     // This function and the one below are designed to assert the card brand displayed in the UI
     // and use a retry mechanism to cater for what appears to be the slowness of BitRise
-    public static func updateCardBrandImage(_ imageView: UIImageView, using cardBrands: [CardBrand]) {
+    public static func updateCardBrandImage(_ imageView: UIImageView, using cardBrands: [CardBrand])
+    {
         if !cardBrands.isEmpty,
-           let cardBrand = cardBrands.first,
-           let urlAsString = cardBrand.images.first(where: { $0.type == "image/png" })?.url,
-           let url = URL(string: urlAsString)
+            let cardBrand = cardBrands.first,
+            let urlAsString = cardBrand.images.first(where: { $0.type == "image/png" })?.url,
+            let url = URL(string: urlAsString)
         {
             if let cachedImage = cardBrandsImagesCache[urlAsString] {
                 setImageSourceAndLabel(
-                    imageView, source: cachedImage.uiImage, label: cachedImage.label
+                    imageView, uiImage: UIImage(data: cachedImage.data)!, label: cachedImage.label
                 )
             } else {
                 // User interactive QOS is chosen to make the task below a high priority task
@@ -25,12 +26,11 @@ final class UiUtils {
                     label: "worldpay.demo.uiutils", qos: .userInteractive)
                 serialQueue.async {
                     if let data = try? Data(contentsOf: url) {
-                        let cachedImage = CachedImage(
-                            uiImage: UIImage(data: data)!, label: cardBrand.name)
+                        let cachedImage = CachedImage(data: data, label: cardBrand.name)
                         cardBrandsImagesCache[urlAsString] = cachedImage
 
                         setImageSourceAndLabel(
-                            imageView, source: cachedImage.uiImage,
+                            imageView, uiImage: UIImage(data: cachedImage.data)!,
                             label: cachedImage.label
                         )
                     }
@@ -38,21 +38,21 @@ final class UiUtils {
             }
         } else {
             setImageSourceAndLabel(
-                imageView, source: unknownBrandImage, label: "unknown_card_brand")
+                imageView, uiImage: unknownBrandImage, label: "unknown_card_brand")
         }
     }
 
     private static func setImageSourceAndLabel(
-        _ imageView: UIImageView, source: UIImage, label: String
+        _ imageView: UIImageView, uiImage: UIImage, label: String
     ) {
         DispatchQueue.main.async {
-            imageView.image = source
+            imageView.image = uiImage
             imageView.accessibilityLabel = NSLocalizedString(label, comment: "")
         }
     }
 
     private struct CachedImage {
-        fileprivate let uiImage: UIImage
+        fileprivate let data: Data
         fileprivate let label: String
     }
 }

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/CardValidationStateHandler.swift
@@ -67,6 +67,14 @@ class CardValidationStateHandler {
 
         return cardBrands == latestCardBrands
     }
+
+    private func cardBrandsContainGlobalBrand(_ globalBrand: CardBrandModel?) -> Bool {
+        guard let globalBrand = globalBrand else {
+            return false
+        }
+
+        return globalBrand.name.lowercased() == cardBrands.first?.name.lowercased()
+    }
 }
 
 extension CardValidationStateHandler: PanValidationStateHandler {
@@ -81,9 +89,14 @@ extension CardValidationStateHandler: PanValidationStateHandler {
             }
         }
 
-        let cardBrandAsArray = globalBrand != nil ? [globalBrand!] : []
-        if !areCardBrandsEqual(self.cardBrands, cardBrandAsArray) {
-            updateCardBrands(cardBrands: cardBrandAsArray)
+        if let globalBrand = globalBrand {
+            if self.cardBrands.isEmpty || self.cardBrands.first?.name != globalBrand.name {
+                updateCardBrands(cardBrands: [globalBrand])
+            }
+        } else {
+            if !self.cardBrands.isEmpty {
+                updateCardBrands(cardBrands: [])
+            }
         }
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/validation/model/pan/PanValidationFlow.swift
@@ -41,6 +41,15 @@ class PanValidationFlow {
 
         guard sanitisedCardNumber.count >= 12 else {
             lastCheckedPanPrefix = ""
+
+            let globalBrand = panValidationStateHandler.getGlobalBrand()
+            if panValidationStateHandler.areCardBrandsDifferentFrom(
+                cardBrands: globalBrand != nil ? [globalBrand!] : []
+            ) {
+                panValidationStateHandler.updateCardBrands(
+                    cardBrands: globalBrand != nil ? [globalBrand!] : []
+                )
+            }
             return
         }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardValidationStateHandler.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/mock/MockCardValidationStateHandler.swift
@@ -1,0 +1,189 @@
+import Cuckoo
+
+@testable import AccessCheckoutSDK
+
+class MockCardValidationStateHandler: CardValidationStateHandler, Cuckoo.ClassMock {
+
+    typealias MocksType = CardValidationStateHandler
+
+    typealias Stubbing = __StubbingProxy_CardValidationStateHandler
+    typealias Verification = __VerificationProxy_CardValidationStateHandler
+
+    let cuckoo_manager =
+        Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: true)
+
+    private var __defaultImplStub: CardValidationStateHandler?
+
+    func enableDefaultImplementation(_ stub: CardValidationStateHandler) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+
+    override var merchantDelegate: AccessCheckoutCardValidationDelegate {
+        return cuckoo_manager.getter(
+            "merchantDelegate",
+            superclassCall:
+
+                super.merchantDelegate,
+            defaultCall: __defaultImplStub!.merchantDelegate)
+
+    }
+
+    override var panIsValid: Bool {
+        return cuckoo_manager.getter(
+            "panIsValid",
+            superclassCall:
+
+                super.panIsValid,
+            defaultCall: __defaultImplStub!.panIsValid)
+
+    }
+
+    override var expiryDateIsValid: Bool {
+        return cuckoo_manager.getter(
+            "expiryDateIsValid",
+            superclassCall:
+
+                super.expiryDateIsValid,
+            defaultCall: __defaultImplStub!.expiryDateIsValid)
+
+    }
+
+    override var cvcIsValid: Bool {
+        return cuckoo_manager.getter(
+            "cvcIsValid",
+            superclassCall:
+
+                super.cvcIsValid,
+            defaultCall: __defaultImplStub!.cvcIsValid)
+
+    }
+
+    override var cardBrands: [CardBrandModel] {
+        return cuckoo_manager.getter(
+            "cardBrands",
+            superclassCall:
+
+                super.cardBrands,
+            defaultCall: __defaultImplStub!.cardBrands)
+
+    }
+
+    struct __StubbingProxy_CardValidationStateHandler: Cuckoo.StubbingProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+
+        init(manager: Cuckoo.MockManager) {
+            self.cuckoo_manager = manager
+        }
+
+        var merchantDelegate:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<
+                MockCardValidationStateHandler, AccessCheckoutCardValidationDelegate
+            >
+        {
+            return .init(manager: cuckoo_manager, name: "merchantDelegate")
+        }
+
+        var panIsValid:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCardValidationStateHandler, Bool>
+        {
+            return .init(manager: cuckoo_manager, name: "panIsValid")
+        }
+
+        var expiryDateIsValid:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCardValidationStateHandler, Bool>
+        {
+            return .init(manager: cuckoo_manager, name: "expiryDateIsValid")
+        }
+
+        var cvcIsValid:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<MockCardValidationStateHandler, Bool>
+        {
+            return .init(manager: cuckoo_manager, name: "cvcIsValid")
+        }
+
+        var cardBrands:
+            Cuckoo.ClassToBeStubbedReadOnlyProperty<
+                MockCardValidationStateHandler, [CardBrandModel]
+            >
+        {
+            return .init(manager: cuckoo_manager, name: "cardBrands")
+        }
+
+    }
+
+    struct __VerificationProxy_CardValidationStateHandler: Cuckoo.VerificationProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+        private let callMatcher: Cuckoo.CallMatcher
+        private let sourceLocation: Cuckoo.SourceLocation
+
+        init(
+            manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher,
+            sourceLocation: Cuckoo.SourceLocation
+        ) {
+            self.cuckoo_manager = manager
+            self.callMatcher = callMatcher
+            self.sourceLocation = sourceLocation
+        }
+
+        var merchantDelegate: Cuckoo.VerifyReadOnlyProperty<AccessCheckoutCardValidationDelegate> {
+            return .init(
+                manager: cuckoo_manager, name: "merchantDelegate", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
+        }
+
+        var panIsValid: Cuckoo.VerifyReadOnlyProperty<Bool> {
+            return .init(
+                manager: cuckoo_manager, name: "panIsValid", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
+        }
+
+        var expiryDateIsValid: Cuckoo.VerifyReadOnlyProperty<Bool> {
+            return .init(
+                manager: cuckoo_manager, name: "expiryDateIsValid", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
+        }
+
+        var cvcIsValid: Cuckoo.VerifyReadOnlyProperty<Bool> {
+            return .init(
+                manager: cuckoo_manager, name: "cvcIsValid", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
+        }
+
+        var cardBrands: Cuckoo.VerifyReadOnlyProperty<[CardBrandModel]> {
+            return .init(
+                manager: cuckoo_manager, name: "cardBrands", callMatcher: callMatcher,
+                sourceLocation: sourceLocation)
+        }
+
+    }
+}
+
+class CardValidationStateHandlerStub: CardValidationStateHandler {
+
+    override var merchantDelegate: AccessCheckoutCardValidationDelegate {
+        return DefaultValueRegistry.defaultValue(for: (AccessCheckoutCardValidationDelegate).self)
+
+    }
+
+    override var panIsValid: Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
+
+    }
+
+    override var expiryDateIsValid: Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
+
+    }
+
+    override var cvcIsValid: Bool {
+        return DefaultValueRegistry.defaultValue(for: (Bool).self)
+
+    }
+
+    override var cardBrands: [CardBrandModel] {
+        return DefaultValueRegistry.defaultValue(for: ([CardBrandModel]).self)
+
+    }
+
+}

--- a/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
+++ b/AccessCheckoutSDK/pacts/access-checkout-ios-sdk-sessions.json
@@ -16,13 +16,13 @@
           "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "identity": "identity",
-          "cardExpiryDate": {
-            "year": 2099,
-            "month": 12
-          },
           "cvc": "123",
-          "cardNumber": "4111111111111110"
+          "identity": "identity",
+          "cardNumber": "4111111111111110",
+          "cardExpiryDate": {
+            "month": 12,
+            "year": 2099
+          }
         }
       },
       "response": {
@@ -31,21 +31,21 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "errorName": "bodyDoesNotMatchSchema",
-          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
+              "errorName": "panFailedLuhnCheck",
               "jsonPath": "$.cardNumber",
-              "message": "The identified field contains a PAN that has failed the Luhn check.",
-              "errorName": "panFailedLuhnCheck"
+              "message": "The identified field contains a PAN that has failed the Luhn check."
             }
-          ]
+          ],
+          "message": "The json body provided does not match the expected schema",
+          "errorName": "bodyDoesNotMatchSchema"
         },
         "matchingRules": {
-          "$.body.message": {
+          "$.body.validationErrors[0].message": {
             "match": "type"
           },
-          "$.body.validationErrors[0].message": {
+          "$.body.message": {
             "match": "type"
           }
         }
@@ -61,13 +61,13 @@
           "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "identity": "identity",
-          "cardNumber": "notACardNumber",
-          "cvc": "123",
           "cardExpiryDate": {
             "month": 1,
             "year": 2099
-          }
+          },
+          "cvc": "123",
+          "identity": "identity",
+          "cardNumber": "notACardNumber"
         }
       },
       "response": {
@@ -76,12 +76,12 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "message": "The json body provided does not match the expected schema",
           "errorName": "bodyDoesNotMatchSchema",
+          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "errorName": "fieldHasInvalidValue",
               "message": "Card number must be numeric",
+              "errorName": "fieldHasInvalidValue",
               "jsonPath": "$.cardNumber"
             }
           ]
@@ -102,17 +102,17 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
           "identity": "incorrectValue",
-          "cvc": "123",
           "cardNumber": "4111111111111111",
           "cardExpiryDate": {
             "year": 2099,
             "month": 12
-          }
+          },
+          "cvc": "123"
         }
       },
       "response": {
@@ -121,21 +121,21 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "errorName": "bodyDoesNotMatchSchema",
+          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
-              "jsonPath": "$.identity",
+              "message": "Identity is invalid",
               "errorName": "fieldHasInvalidValue",
-              "message": "Identity is invalid"
+              "jsonPath": "$.identity"
             }
           ],
-          "message": "The json body provided does not match the expected schema"
+          "errorName": "bodyDoesNotMatchSchema"
         },
         "matchingRules": {
-          "$.body.validationErrors[0].message": {
+          "$.body.message": {
             "match": "type"
           },
-          "$.body.message": {
+          "$.body.validationErrors[0].message": {
             "match": "type"
           }
         }
@@ -151,12 +151,12 @@
           "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
+          "cvc": "123",
           "cardExpiryDate": {
             "month": 13,
             "year": 2099
           },
           "cardNumber": "4111111111111111",
-          "cvc": "123",
           "identity": "identity"
         }
       },
@@ -170,8 +170,8 @@
           "validationErrors": [
             {
               "errorName": "integerIsTooLarge",
-              "jsonPath": "$.cardExpiryDate.month",
-              "message": "Card expiry month is too large - must be between 1 & 12"
+              "message": "Card expiry month is too large - must be between 1 & 12",
+              "jsonPath": "$.cardExpiryDate.month"
             }
           ],
           "errorName": "bodyDoesNotMatchSchema"
@@ -192,12 +192,12 @@
         "method": "post",
         "path": "/sessions/payments/cvc",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "cvc": "123",
-          "identity": "incorrectValue"
+          "identity": "incorrectValue",
+          "cvc": "123"
         }
       },
       "response": {
@@ -206,21 +206,21 @@
           "Content-Type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "errorName": "bodyDoesNotMatchSchema",
-          "message": "The json body provided does not match the expected schema",
           "validationErrors": [
             {
               "errorName": "fieldHasInvalidValue",
               "message": "Identity is invalid",
               "jsonPath": "$.identity"
             }
-          ]
+          ],
+          "errorName": "bodyDoesNotMatchSchema",
+          "message": "The json body provided does not match the expected schema"
         },
         "matchingRules": {
-          "$.body.message": {
+          "$.body.validationErrors[0].message": {
             "match": "type"
           },
-          "$.body.validationErrors[0].message": {
+          "$.body.message": {
             "match": "type"
           }
         }
@@ -232,8 +232,8 @@
         "method": "get",
         "path": "/sessions",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         }
       },
       "response": {
@@ -269,17 +269,17 @@
         "method": "post",
         "path": "/sessions/card",
         "headers": {
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
+          "cardNumber": "4111111111111111",
+          "cvc": "123",
+          "identity": "identity",
           "cardExpiryDate": {
             "month": 12,
             "year": 2099
-          },
-          "identity": "identity",
-          "cvc": "123",
-          "cardNumber": "4111111111111111"
+          }
         }
       },
       "response": {
@@ -308,12 +308,12 @@
         "method": "post",
         "path": "/sessions/payments/cvc",
         "headers": {
-          "content-type": "application/vnd.worldpay.sessions-v1.hal+json",
-          "Accept": "application/vnd.worldpay.sessions-v1.hal+json"
+          "Accept": "application/vnd.worldpay.sessions-v1.hal+json",
+          "content-type": "application/vnd.worldpay.sessions-v1.hal+json"
         },
         "body": {
-          "identity": "identity",
-          "cvc": "1234"
+          "cvc": "1234",
+          "identity": "identity"
         }
       },
       "response": {


### PR DESCRIPTION
What

- Adding card schemes to demo app
- Making sure all UI changes using main thread 
- Make sure stored cobranded card brands is pnly for pan field over 12 digits else use global brand

Why

- To test cobranded cards functionality
- If UI changes are not made on main thread it occasionly causes app crashing
- As less than 12 digits should not have card bin service response so use global brand

How

- Adding label containing card schemes to the cardFlowViewController
- Use DispatchQueue.main.async
- selects global brand from current brants and updates card brands to use only global brand when pan field goes from above 12 digits to less than 12 digits