### PR TITLE
NOTICKET: Refactor typetext function calls to fix tests falling on iOS 18

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
@@ -183,7 +183,7 @@ class CardFlowCardBrandTestsUsingRealServices: XCTestCase {
     }
 
     func testDisplaysBrandImage_NOT_VISA_For493698() {
-//        view!.typeTextIntoPan("493698")
+//        view!.typeTextIntoPanCharByChar("493698")
         view!.typeTextIntoPanCharByChar("493698")
 
         XCTAssertEqual("4936 98", view!.panText)
@@ -208,7 +208,7 @@ class CardFlowCardBrandTestsUsingRealServices: XCTestCase {
             XCTAssertTrue(view!.imageIs("unknown_card_brand"))
         }
 
-        view!.typeTextIntoPan(pan)
+        view!.typeTextIntoPanCharByChar(pan)
 
         let panViewText = view!.panText?.replacingOccurrences(of: " ", with: "")
         XCTAssertEqual(pan, panViewText)

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
@@ -183,7 +183,8 @@ class CardFlowCardBrandTestsUsingRealServices: XCTestCase {
     }
 
     func testDisplaysBrandImage_NOT_VISA_For493698() {
-        view!.typeTextIntoPan("493698")
+//        view!.typeTextIntoPan("493698")
+        view!.typeTextIntoPanCharByChar("493698")
 
         XCTAssertEqual("4936 98", view!.panText)
         XCTAssertFalse(view!.imageIs("visa"))

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandTestsUsingRealServices.swift
@@ -183,7 +183,6 @@ class CardFlowCardBrandTestsUsingRealServices: XCTestCase {
     }
 
     func testDisplaysBrandImage_NOT_VISA_For493698() {
-//        view!.typeTextIntoPanCharByChar("493698")
         view!.typeTextIntoPanCharByChar("493698")
 
         XCTAssertEqual("4936 98", view!.panText)

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardNumberSpacingTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardNumberSpacingTests.swift
@@ -16,16 +16,17 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     // MARK: Card numbers spacing per brand
 
     func testFormatsAmexPan() {
-        view!.typeTextIntoPan("37178")
+//        view!.typeTextIntoPanCharByChar("37178")
+        view!.typeTextIntoPanCharByChar("37178")
         XCTAssertTrue(view!.imageIs("amex"))
 
         XCTAssertEqual(view!.panText!, "3717 8")
 
-        view!.typeTextIntoPan("1111")
+        view!.typeTextIntoPanCharByChar("1111")
 
         XCTAssertEqual(view!.panText!, "3717 81111")
 
-        view!.typeTextIntoPan("1111")
+        view!.typeTextIntoPanCharByChar("1111")
 
         XCTAssertEqual(view!.panText!, "3717 811111 111")
 
@@ -38,16 +39,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsVisaPan() {
-        view!.typeTextIntoPan("41111")
+        view!.typeTextIntoPanCharByChar("41111")
         XCTAssertTrue(view!.imageIs("visa"))
 
         XCTAssertEqual(view!.panText!, "4111 1")
 
-        view!.typeTextIntoPan("1111")
+        view!.typeTextIntoPanCharByChar("1111")
 
         XCTAssertEqual(view!.panText!, "4111 1111 1")
 
-        view!.typeTextIntoPan("3333")
+        view!.typeTextIntoPanCharByChar("3333")
 
         XCTAssertEqual(view!.panText!, "4111 1111 1333 3")
 
@@ -58,16 +59,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsMastercardPan() {
-        view!.typeTextIntoPan("54545")
+        view!.typeTextIntoPanCharByChar("54545")
         XCTAssertTrue(view!.imageIs("mastercard"))
 
         XCTAssertEqual(view!.panText!, "5454 5")
 
-        view!.typeTextIntoPan("4545")
+        view!.typeTextIntoPanCharByChar("4545")
 
         XCTAssertEqual(view!.panText!, "5454 5454 5")
 
-        view!.typeTextIntoPan("4545")
+        view!.typeTextIntoPanCharByChar("4545")
 
         XCTAssertEqual(view!.panText!, "5454 5454 5454 5")
 
@@ -78,16 +79,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsJcbPan() {
-        view!.typeTextIntoPan("35280")
+        view!.typeTextIntoPanCharByChar("35280")
         XCTAssertTrue(view!.imageIs("jcb"))
 
         XCTAssertEqual(view!.panText!, "3528 0")
 
-        view!.typeTextIntoPan("0070")
+        view!.typeTextIntoPanCharByChar("0070")
 
         XCTAssertEqual(view!.panText!, "3528 0007 0")
 
-        view!.typeTextIntoPan("0000")
+        view!.typeTextIntoPanCharByChar("0000")
 
         XCTAssertEqual(view!.panText!, "3528 0007 0000 0")
 
@@ -98,16 +99,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsDiscoverPan() {
-        view!.typeTextIntoPan("60110")
+        view!.typeTextIntoPanCharByChar("60110")
         XCTAssertTrue(view!.imageIs("discover"))
 
         XCTAssertEqual(view!.panText!, "6011 0")
 
-        view!.typeTextIntoPan("0040")
+        view!.typeTextIntoPanCharByChar("0040")
 
         XCTAssertEqual(view!.panText!, "6011 0004 0")
 
-        view!.typeTextIntoPan("0000")
+        view!.typeTextIntoPanCharByChar("0000")
 
         XCTAssertEqual(view!.panText!, "6011 0004 0000 0")
 
@@ -118,16 +119,17 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsDinersPan() {
-        view!.typeTextIntoPan("36700")
+//        view!.typeTextIntoPan("36700")
+        view!.typeTextIntoPanCharByChar("36700")
         XCTAssertTrue(view!.imageIs("diners"))
 
         XCTAssertEqual(view!.panText!, "3670 0")
 
-        view!.typeTextIntoPan("1020")
+        view!.typeTextIntoPanCharByChar("1020")
 
         XCTAssertEqual(view!.panText!, "3670 0102 0")
 
-        view!.typeTextIntoPan("0000")
+        view!.typeTextIntoPanCharByChar("0000")
 
         XCTAssertEqual(view!.panText!, "3670 0102 0000 0")
 
@@ -138,16 +140,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsMaestroPan() {
-        view!.typeTextIntoPan("67596")
+        view!.typeTextIntoPanCharByChar("67596")
         XCTAssertTrue(view!.imageIs("maestro"))
 
         XCTAssertEqual(view!.panText!, "6759 6")
 
-        view!.typeTextIntoPan("4982")
+        view!.typeTextIntoPanCharByChar("4982")
 
         XCTAssertEqual(view!.panText!, "6759 6498 2")
 
-        view!.typeTextIntoPan("6438")
+        view!.typeTextIntoPanCharByChar("6438")
 
         XCTAssertEqual(view!.panText!, "6759 6498 2643 8")
 
@@ -158,16 +160,16 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsUnknownBrandPan() {
-        view!.typeTextIntoPan("12200")
+        view!.typeTextIntoPanCharByChar("12200")
         XCTAssertTrue(view!.imageIs("unknown_card_brand"))
 
         XCTAssertEqual(view!.panText!, "1220 0")
 
-        view!.typeTextIntoPan("0000")
+        view!.typeTextIntoPanCharByChar("0000")
 
         XCTAssertEqual(view!.panText!, "1220 0000 0")
 
-        view!.typeTextIntoPan("0000")
+        view!.typeTextIntoPanCharByChar("0000")
 
         XCTAssertEqual(view!.panText!, "1220 0000 0000 0")
 

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardNumberSpacingTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardNumberSpacingTests.swift
@@ -16,7 +16,6 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     // MARK: Card numbers spacing per brand
 
     func testFormatsAmexPan() {
-//        view!.typeTextIntoPanCharByChar("37178")
         view!.typeTextIntoPanCharByChar("37178")
         XCTAssertTrue(view!.imageIs("amex"))
 
@@ -119,7 +118,6 @@ class CardFlowCardNumberSpacingTests: XCTestCase {
     }
 
     func testFormatsDinersPan() {
-//        view!.typeTextIntoPan("36700")
         view!.typeTextIntoPanCharByChar("36700")
         XCTAssertTrue(view!.imageIs("diners"))
 

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowRetrieveSessionsTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowRetrieveSessionsTests.swift
@@ -112,7 +112,7 @@ class CardPaymentFlowRetrieveSessionsTests: XCTestCase {
     }
 
     private func fillUpFormWithValidValues(using view: CardFlowViewPageObject) {
-        view.typeTextIntoPan("4111111111111111")
+        view.typeTextIntoPanCharByChar("4111111111111111")
         view.typeTextIntoExpiryDate("01/99")
         view.typeTextIntoCvc("123")
     }

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -42,7 +42,6 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testPAN_acceptsUpTo19Characters_plusSpaces() {
-//        view!.typeTextIntoPan("111122223333444455556666")
         view!.typeTextIntoPanCharByChar("111122223333444455556666")
 
         XCTAssertEqual(view!.panText!, "1111 2222 3333 4444 555")

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -21,7 +21,7 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testPAN_canDeleteDigits() {
-        view!.typeTextIntoPan("1000")
+        view!.typeTextIntoPanCharByChar("1000")
         XCTAssertEqual(view!.panText, "1000")
 
         view!.typeTextIntoPan(backspace)
@@ -32,7 +32,7 @@ class CardFlowCardValidationTests: XCTestCase {
 
     func testPAN_isInvalidAfterAllTextIsCleared() {
         let pan = "4444333322221111"
-        view!.typeTextIntoPan(pan)
+        view!.typeTextIntoPanCharByChar(pan)
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")
 
         view!.clearField(view!.panField)
@@ -50,7 +50,7 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testPartialPanIsInvalid() {
-        view!.typeTextIntoPan("4")
+        view!.typeTextIntoPanCharByChar("4")
         view!.expiryDateField.tap()  // we move the focus to another field so that the validation triggers
 
         XCTAssertTrue(view!.imageIs("visa"))
@@ -58,14 +58,14 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid() {
-        view!.typeTextIntoPan("4444333322221111")
+        view!.typeTextIntoPanCharByChar("4444333322221111")
 
         XCTAssertTrue(view!.imageIs("visa"))
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")
     }
 
     func test13DigitsVisaPanIsValid() {
-        view!.typeTextIntoPan("4911830000000")
+        view!.typeTextIntoPanCharByChar("4911830000000")
 
         XCTAssertTrue(view!.imageIs("visa"))
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")
@@ -152,7 +152,7 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testCvc_acceptsAsManyCharactersAsAllowedByCardBrand() {
-        view!.typeTextIntoPan("4")
+        view!.typeTextIntoPanCharByChar("4")
         view!.typeTextIntoCvc("1234")
 
         XCTAssertEqual(view!.cvcText!, "123")
@@ -180,7 +180,7 @@ class CardFlowCardValidationTests: XCTestCase {
         XCTAssertEqual(view!.cvcIsValidLabel.label, "valid")
 
         // changes to visa which only acceptes 3 digits long Cvcs
-        view!.typeTextIntoPan("4")
+        view!.typeTextIntoPanCharByChar("4")
         XCTAssertEqual(view!.cvcIsValidLabel.label, "invalid")
     }
 
@@ -189,7 +189,7 @@ class CardFlowCardValidationTests: XCTestCase {
     func testSubmit_isEnabledWhenCardDetailsAreValid() {
         XCTAssertFalse(view!.submitButton.isEnabled)
 
-        view!.typeTextIntoPan("4111111111111111")
+        view!.typeTextIntoPanCharByChar("4111111111111111")
         view!.typeTextIntoExpiryDate("01/34")
         view!.typeTextIntoCvc("123")
 

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowValidationTests.swift
@@ -42,7 +42,8 @@ class CardFlowCardValidationTests: XCTestCase {
     }
 
     func testPAN_acceptsUpTo19Characters_plusSpaces() {
-        view!.typeTextIntoPan("111122223333444455556666")
+//        view!.typeTextIntoPan("111122223333444455556666")
+        view!.typeTextIntoPanCharByChar("111122223333444455556666")
 
         XCTAssertEqual(view!.panText!, "1111 2222 3333 4444 555")
         XCTAssertEqual(view!.panText!.count, 23)

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowNoCardNumberSpacingTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowNoCardNumberSpacingTests.swift
@@ -14,19 +14,19 @@ class RestrictedCardFlowNoCardNumberSpacingTests: XCTestCase {
     // MARK: Testing disabled PAN formatting
 
     func testDoesNotFormatPan() {
-        view!.typeTextIntoPan("4111111111111111")
+        view!.typeTextIntoPanCharByChar("4111111111111111")
 
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
 
     func testCanEnterOnlyDigitsInPan() {
-        view!.typeTextIntoPan("4abc11111111   1111blahblah   111")
+        view!.typeTextIntoPanCharByChar("4abc11111111   1111blahblah   111")
 
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
 
     func testCanDeleteDigits() {
-        view!.typeTextIntoPan("4111")
+        view!.typeTextIntoPanCharByChar("4111")
         XCTAssertEqual(view!.panText, "4111")
 
         view!.typeTextIntoPan(backspace)

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
@@ -57,7 +57,8 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_visa() {
-        view!.typeTextIntoPan("4444333322221111")
+//        view!.typeTextIntoPan("4444333322221111")
+        view!.typeTextIntoPanCharByChar("4444333322221111")
 
         XCTAssertTrue(view!.imageIs("visa"))
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")
@@ -87,7 +88,8 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_amex() {
-        view!.typeTextIntoPan("343434343434343")
+//        view!.typeTextIntoPan("343434343434343")
+        view!.typeTextIntoPanCharByChar("343434343434343")
 
         XCTAssertTrue(view!.imageIs("amex"))
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
@@ -57,7 +57,6 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_visa() {
-//        view!.typeTextIntoPanCharByChar("4444333322221111")
         view!.typeTextIntoPanCharByChar("4444333322221111")
 
         XCTAssertTrue(view!.imageIs("visa"))
@@ -88,7 +87,6 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_amex() {
-//        view!.typeTextIntoPanCharByChar("343434343434343")
         view!.typeTextIntoPanCharByChar("343434343434343")
 
         XCTAssertTrue(view!.imageIs("amex"))

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/RestrictedCardFlowValidationTests.swift
@@ -17,31 +17,31 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     // MARK: Testing always displays card brand images independently of brand being accepted
 
     func testDisplaysAcceptedBrand_visa() {
-        view!.typeTextIntoPan("4")
+        view!.typeTextIntoPanCharByChar("4")
 
         XCTAssertTrue(view!.imageIs("visa"))
     }
 
     func testDisplaysAcceptedBrand_mastercard() {
-        view!.typeTextIntoPan("55")
+        view!.typeTextIntoPanCharByChar("55")
 
         XCTAssertTrue(view!.imageIs("mastercard"))
     }
 
     func testDisplaysAcceptedBrand_amex() {
-        view!.typeTextIntoPan("34")
+        view!.typeTextIntoPanCharByChar("34")
 
         XCTAssertTrue(view!.imageIs("amex"))
     }
 
     func testDisplaysNonAcceptedBrand_jcb() {
-        view!.typeTextIntoPan("352")
+        view!.typeTextIntoPanCharByChar("352")
 
         XCTAssertTrue(view!.imageIs("jcb"))
     }
 
     func testDisplaysUnknownBrand() {
-        view!.typeTextIntoPan("0")
+        view!.typeTextIntoPanCharByChar("0")
 
         XCTAssertTrue(view!.imageIs("unknown_card_brand"))
     }
@@ -49,7 +49,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     // MARK: Testing accepted cards
 
     func testPartialPanIsInvalid_visa() {
-        view!.typeTextIntoPan("4")
+        view!.typeTextIntoPanCharByChar("4")
         view!.dismissKeyboard()  // removes focus from Pan
 
         XCTAssertTrue(view!.imageIs("visa"))
@@ -57,7 +57,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_visa() {
-//        view!.typeTextIntoPan("4444333322221111")
+//        view!.typeTextIntoPanCharByChar("4444333322221111")
         view!.typeTextIntoPanCharByChar("4444333322221111")
 
         XCTAssertTrue(view!.imageIs("visa"))
@@ -65,7 +65,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testPartialPanIsInvalid_mastercard() {
-        view!.typeTextIntoPan("55")
+        view!.typeTextIntoPanCharByChar("55")
         view!.dismissKeyboard()  // removes focus from Pan
 
         XCTAssertTrue(view!.imageIs("mastercard"))
@@ -73,14 +73,14 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_mastercard() {
-        view!.typeTextIntoPan("5555555555554444")
+        view!.typeTextIntoPanCharByChar("5555555555554444")
 
         XCTAssertTrue(view!.imageIs("mastercard"))
         XCTAssertEqual(view!.panIsValidLabel.label, "valid")
     }
 
     func testPartialPanIsInvalid_amex() {
-        view!.typeTextIntoPan("34")
+        view!.typeTextIntoPanCharByChar("34")
         view!.dismissKeyboard()  // removes focus from Pan
 
         XCTAssertTrue(view!.imageIs("amex"))
@@ -88,7 +88,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanIsValid_amex() {
-//        view!.typeTextIntoPan("343434343434343")
+//        view!.typeTextIntoPanCharByChar("343434343434343")
         view!.typeTextIntoPanCharByChar("343434343434343")
 
         XCTAssertTrue(view!.imageIs("amex"))
@@ -98,7 +98,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     // MARK: Testing cards that are not accepted due to SDK initialised to accept only visa, mastercard, amex
 
     func testPartialPanForCardThatIsNotAcceptedIsInvalid() {
-        view!.typeTextIntoPan("352")
+        view!.typeTextIntoPanCharByChar("352")
         view!.dismissKeyboard()  // removes focus from Pan
 
         XCTAssertTrue(view!.imageIs("jcb"))
@@ -106,7 +106,7 @@ class RestrictedCardFlowValidationTests: XCTestCase {
     }
 
     func testCompletePanForCardThatIsNotAcceptedIsInvalid() {
-        view!.typeTextIntoPan("3528000700000000")
+        view!.typeTextIntoPanCharByChar("3528000700000000")
         view!.dismissKeyboard()  // removes focus from Pan
 
         XCTAssertTrue(view!.imageIs("jcb"))

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
@@ -78,6 +78,16 @@ class CardFlowViewPageObject {
         }
         panField.typeText(text)
     }
+    
+    func typeTextIntoPanCharByChar(_ text: String) {
+        if !panField.hasFocus {
+            panField.tap()
+        }
+        
+        for char in text {
+            panField.typeText(String(char))
+        }
+    }
 
     func typeTextIntoExpiryDate(_ text: String) {
         if !TestUtils.isFocused(expiryDateField) {

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/RestrictedCardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/RestrictedCardFlowViewPageObject.swift
@@ -37,6 +37,16 @@ class RestrictedCardFlowViewPageObject {
         }
         panField.typeText(text)
     }
+    
+    func typeTextIntoPanCharByChar(_ text: String) {
+        if !panField.hasFocus {
+            panField.tap()
+        }
+        
+        for char in text {
+            panField.typeText(String(char))
+        }
+    }
 
     func imageIs(_ brand: String) -> Bool {
         let brandAsLocalizedString = NSLocalizedString(


### PR DESCRIPTION
## What
Resolve issues where tests are intermittently failing on some newer iOS versions (notably iOS 18)
## How
Refactor calls to typeTextIntoPan(String) to typeTextIntoPanCharByChar()
## Why
We need to stabilise our tests results to avoid false negatives being reported on our CI