### PR TITLE
NOTICKET: refactor ui tests to enter text char by char to fix failing iOS 18 tests

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
+++ b/AccessCheckoutSDK/AccessCheckoutSDK.xcodeproj/project.pbxproj
@@ -1388,13 +1388,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKTests/Pods-AccessCheckoutSDKTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1431,13 +1427,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-AccessCheckoutSDKPactTests/Pods-AccessCheckoutSDKPactTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
@@ -27,10 +27,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
 
     func testCorrectlyFormatsWhenPastingAndTypingInMiddleOfPan() {
         view!.typeTextIntoPanCharByChar("4111")
-        view!.setPanCaretAtAndTypeIn(
-            position: 3, text: [backspace, backspace, "123", "5", backspace]
-        )
-
+        view!.setPanCaretAtAndTypeIn(position: 3, text: ["123", "5"])
         XCTAssertEqual(view!.panText!, "4111 2351")
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
@@ -19,28 +19,28 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     // MARK: Tests by inserting deleting text
 
     func testCorrectlyFormatsWhenTypingInMiddleOfPan() {
-        view!.typeTextIntoPan("4111")
+        view!.typeTextIntoPanCharByChar("4111")
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["4"])
 
         XCTAssertEqual(view!.panText!, "4114 1")
     }
 
     func testCorrectlyFormatsWhenPastingAndTypingInMiddleOfPan() {
-        view!.typeTextIntoPan("4111")
+        view!.typeTextIntoPanCharByChar("4111")
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["123", "5"])
 
         XCTAssertEqual(view!.panText!, "4111 2351")
     }
 
     func testCorrectlyFormatsWhenDeletingInMiddleOfPan() {
-        view!.typeTextIntoPan("4321 4321")
+        view!.typeTextIntoPanCharByChar("4321 4321")
         view!.setPanCaretAtAndTypeIn(position: 3, text: [backspace])
 
         XCTAssertEqual(view!.panText!, "4314 321")
     }
 
     func testCorrectlyFormatsWhenDeletingAndThenTypingInMiddleOfPan() {
-        view!.typeTextIntoPan("4321 4321")
+        view!.typeTextIntoPanCharByChar("4321 4321")
         view!.setPanCaretAtAndTypeIn(
             position: 3, text: [backspace, backspace, "3", "1234", backspace])
 
@@ -48,7 +48,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testCanDeleteSingleDigitAfterSpace() {
-        view!.typeTextIntoPan("43214")
+        view!.typeTextIntoPanCharByChar("43214")
         XCTAssertEqual(view!.panText!, "4321 4")
 
         view!.typeTextIntoPan(backspace)
@@ -57,7 +57,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testCanDeleteFirstDigit() {
-        view!.typeTextIntoPan("432145")
+        view!.typeTextIntoPanCharByChar("432145")
         XCTAssertEqual(view!.panText!, "4321 45")
 
         view!.setPanCaretAtAndTypeIn(position: 1, text: [backspace])
@@ -67,7 +67,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testReformatsCardWhenBrandChanges() {
-        view!.typeTextIntoPan("34567890123")
+        view!.typeTextIntoPanCharByChar("34567890123")
         XCTAssertEqual(view!.panText!, "3456 789012 3")
 
         view!.setPanCaretAtAndTypeIn(position: 0, text: ["4"])
@@ -80,7 +80,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     // MARK: Tests with text that contains digits and letters and spaces
 
     func testExtractsDigitsOnlyFromAlphanumericEntry() {
-        view!.typeTextIntoPan("123abc456defghi789zzzzzzzzzzz       zzzzzzzzz000")
+        view!.typeTextIntoPanCharByChar("123abc456defghi789zzzzzzzzzzz       zzzzzzzzz000")
 
         XCTAssertEqual(view!.panText!, "1234 5678 9000")
     }
@@ -88,7 +88,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     // MARK: Tests specific to spaces and caret position
 
     func testDeletesSpaceAndPreviousDigitWhenDeletingSpace() {
-        view!.typeTextIntoPan("123456")
+        view!.typeTextIntoPanCharByChar("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
 
         view!.setPanCaretAtAndTypeIn(position: 5, text: [backspace])
@@ -98,7 +98,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testDeletesSpaceAndPreviousDigitWhenDeletingSelectedSpace() {
-        view!.typeTextIntoPan("123456")
+        view!.typeTextIntoPanCharByChar("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
 
         view!.selectPanAndTypeIn(position: 4, selectionLength: 1, text: [backspace])
@@ -108,7 +108,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testMovesCaretAfterSpaceWhenInsertingDigitAtEndOfDigitsGroup() {
-        view!.typeTextIntoPan("12345")
+        view!.typeTextIntoPanCharByChar("12345")
         XCTAssertEqual(view!.panText!, "1234 5")
 
         view!.setPanCaretAtAndTypeIn(position: 3, text: ["6"])
@@ -118,7 +118,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testLeavesCaretAfterSpaceWhenDeletingDigitWhichIsJustAfterSpace() {
-        view!.typeTextIntoPan("123456")
+        view!.typeTextIntoPanCharByChar("123456")
         XCTAssertEqual(view!.panText!, "1234 56")
 
         view!.setPanCaretAtAndTypeIn(position: 6, text: [backspace])
@@ -128,7 +128,7 @@ class PanWithSpacingFormattingUITests: XCTestCase {
     }
 
     func testLeavesCaretAtSamePositionWhenSelectingTextThatStartsWithSpaceAndDeletingIt() {
-        view!.typeTextIntoPan("123456789012")
+        view!.typeTextIntoPanCharByChar("123456789012")
         XCTAssertEqual(view!.panText!, "1234 5678 9012")
 
         view!.selectPanAndTypeIn(position: 4, selectionLength: 3, text: [backspace])

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithSpacingFormattingUITests.swift
@@ -27,7 +27,9 @@ class PanWithSpacingFormattingUITests: XCTestCase {
 
     func testCorrectlyFormatsWhenPastingAndTypingInMiddleOfPan() {
         view!.typeTextIntoPanCharByChar("4111")
-        view!.setPanCaretAtAndTypeIn(position: 3, text: ["123", "5"])
+        view!.setPanCaretAtAndTypeIn(
+            position: 3, text: [backspace, backspace, "123", "5", backspace]
+        )
 
         XCTAssertEqual(view!.panText!, "4111 2351")
     }

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFormattingUITests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/PanWithoutSpacingFormattingUITests.swift
@@ -19,19 +19,19 @@ class PanWithoutSpacingFormattingUITests: XCTestCase {
     // MARK: Testing disabled PAN formatting
 
     func testDoesNotFormatPan() {
-        view!.typeTextIntoPan("4111111111111111")
+        view!.typeTextIntoPanCharByChar("4111111111111111")
 
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
 
     func testCanEnterOnlyDigitsInPan() {
-        view!.typeTextIntoPan("4abc11111111   1111blahblah   111")
+        view!.typeTextIntoPanCharByChar("4abc11111111   1111blahblah   111")
 
         XCTAssertEqual(view!.panText, "4111111111111111")
     }
 
     func testCanDeleteDigits() {
-        view!.typeTextIntoPan("4111")
+        view!.typeTextIntoPanCharByChar("4111")
         XCTAssertEqual(view!.panText, "4111")
 
         view!.typeTextIntoPan(backspace)

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
@@ -93,9 +93,11 @@ class PanBasePageObject {
 
         let button = setPanCaretPositionButton
         button.tap()
-
-        for character in text {
-            panField.typeText(character)
+     
+        for string in text {
+            for character in string {
+                panField.typeText(String(character))
+            }
         }
     }
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
@@ -48,6 +48,16 @@ class PanBasePageObject {
         }
         panField.typeText(text)
     }
+    
+    func typeTextIntoPanCharByChar(_ text: String) {
+        if !panField.hasFocus {
+            panField.tap()
+        }
+        
+        for char in text {
+            panField.typeText(String(char))
+        }
+    }
 
     func panCaretPosition() -> Int {
         let textField = panCaretPositionTextField

--- a/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTestAppUITests/pageObjects/PanBasePageObject.swift
@@ -81,8 +81,10 @@ class PanBasePageObject {
         let button = setPanCaretPositionButton
         button.tap()
 
-        for character in text {
-            panField.typeText(character)
+        for string in text {
+            for character in string {
+                panField.typeText(String(character))
+            }
         }
     }
 


### PR DESCRIPTION
# What
Resolve issues where tests are intermittently failing on some newer iOS versions (notably iOS 18)

# How
Refactor calls to typeTextIntoPan(String) to typeTextIntoPanCharByChar()

# Why
We need to stabilise our tests results to avoid false negatives being reported on our CI