### PR TITLE
US2128860: adding UI tests to test for cobranded functionality

### DIFF
--- a/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
+++ b/AccessCheckoutDemo/AccessCheckoutDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		51CBC4A325A46F5A000D0363 /* RestrictedCardFlowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CBC4A225A46F5A000D0363 /* RestrictedCardFlowViewController.swift */; };
 		51CBC4A725A480DC000D0363 /* RestrictedCardFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CBC4A625A480DC000D0363 /* RestrictedCardFlowUITests.swift */; };
 		51CBC4A925A480F0000D0363 /* RestrictedCardFlowValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CBC4A825A480F0000D0363 /* RestrictedCardFlowValidationTests.swift */; };
+		62AB4D8C2E818D1A00582220 /* CardFlowCardBrandsLabelCobrandedRealServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AB4D8B2E818D1A00582220 /* CardFlowCardBrandsLabelCobrandedRealServiceTests.swift */; };
 		B9E2AA0C48294C91BA6E878D /* Pods_AccessCheckoutDemo_AccessCheckoutDemoUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B46E6E24989CAB4DC75302 /* Pods_AccessCheckoutDemo_AccessCheckoutDemoUITests.framework */; };
 		C9AFE46F22B7C5A600943B3E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AFE46C22B7C5A600943B3E /* AppDelegate.swift */; };
 		C9AFE47022B7C5A600943B3E /* CardFlowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AFE46D22B7C5A600943B3E /* CardFlowViewController.swift */; };
@@ -85,6 +86,7 @@
 		51CBC4A625A480DC000D0363 /* RestrictedCardFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedCardFlowUITests.swift; sourceTree = "<group>"; };
 		51CBC4A825A480F0000D0363 /* RestrictedCardFlowValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictedCardFlowValidationTests.swift; sourceTree = "<group>"; };
 		5F532F45E152C8559DCC281F /* Pods-AccessCheckoutDemo-AccessCheckoutDemoUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutDemo-AccessCheckoutDemoUITests.debug.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutDemo-AccessCheckoutDemoUITests/Pods-AccessCheckoutDemo-AccessCheckoutDemoUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		62AB4D8B2E818D1A00582220 /* CardFlowCardBrandsLabelCobrandedRealServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFlowCardBrandsLabelCobrandedRealServiceTests.swift; sourceTree = "<group>"; };
 		63B46E6E24989CAB4DC75302 /* Pods_AccessCheckoutDemo_AccessCheckoutDemoUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AccessCheckoutDemo_AccessCheckoutDemoUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E7FDDA3E36720BDB3959BF7 /* Pods-AccessCheckoutDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutDemo.release.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutDemo/Pods-AccessCheckoutDemo.release.xcconfig"; sourceTree = "<group>"; };
 		8BA50193BD557BCBB2DE4933 /* Pods-AccessCheckoutDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AccessCheckoutDemo.debug.xcconfig"; path = "Target Support Files/Pods-AccessCheckoutDemo/Pods-AccessCheckoutDemo.debug.xcconfig"; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 				E7134D352437AE1100DD842F /* utils */,
 				E7B7F4DE2435EE7000E2DDA6 /* pageObjects */,
 				51B820772721A0B700CFAB53 /* CardFlowCardBrandTestsUsingRealServices.swift */,
+				62AB4D8B2E818D1A00582220 /* CardFlowCardBrandsLabelCobrandedRealServiceTests.swift */,
 				516E31E12694F1F40017E8EB /* CardFlowCardNumberSpacingTests.swift */,
 				C9AFE47A22B7C6DA00943B3E /* CardFlowRetrieveSessionsTests.swift */,
 				E74F7C3B24741490005D40FE /* CardFlowUITests.swift */,
@@ -512,6 +515,7 @@
 				E7134D372437AE3900DD842F /* AppLauncher.swift in Sources */,
 				C9AFE47E22B7C6DA00943B3E /* CardFlowRetrieveSessionsTests.swift in Sources */,
 				51B820782721A0B700CFAB53 /* CardFlowCardBrandTestsUsingRealServices.swift in Sources */,
+				62AB4D8C2E818D1A00582220 /* CardFlowCardBrandsLabelCobrandedRealServiceTests.swift in Sources */,
 				C9AFE47D22B7C6DA00943B3E /* CardFlowValidationTests.swift in Sources */,
 				E74F7C3E247416AE005D40FE /* SwitchViewPageObject.swift in Sources */,
 				E7B7F4DB24350F4B00E2DDA6 /* CvcFlowValidationTests.swift in Sources */,
@@ -684,7 +688,7 @@
 			baseConfigurationReference = 8BA50193BD557BCBB2DE4933 /* Pods-AccessCheckoutDemo.debug.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
+				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -712,7 +716,7 @@
 			baseConfigurationReference = 6E7FDDA3E36720BDB3959BF7 /* Pods-AccessCheckoutDemo.release.xcconfig */;
 			buildSettings = {
 				ACCESS_BASE_URL = "https://try.access.worldpay.com";
-				ACCESS_CHECKOUT_ID = "<replace-with-your-checkout-id>";
+				ACCESS_CHECKOUT_ID = "dd0ea6d1-6a59-4fc2-89b3-f50296d7aec5";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -211,7 +211,7 @@ class CardFlowViewController: UIViewController {
 
             cardBrandsLabel = label
         }
-        
+
         cardBrandsLabel?.accessibilityIdentifier = "cardBrandsLabel"
         cardBrandsLabel?.numberOfLines = 1
         cardBrandsLabel?.font = .preferredFont(forTextStyle: .caption1)

--- a/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemo/CardFlowViewController.swift
@@ -112,6 +112,7 @@ class CardFlowViewController: UIViewController {
             cvcTextField.clear()
 
             cardBrandsLabel?.text = ""
+            cardBrandsLabel?.accessibilityIdentifier = "cardBrandsLabel"
             imageView.image = unknownBrandImage
         }
 
@@ -211,6 +212,7 @@ class CardFlowViewController: UIViewController {
             cardBrandsLabel = label
         }
         
+        cardBrandsLabel?.accessibilityIdentifier = "cardBrandsLabel"
         cardBrandsLabel?.numberOfLines = 1
         cardBrandsLabel?.font = .preferredFont(forTextStyle: .caption1)
         cardBrandsLabel?.text = ""
@@ -244,6 +246,7 @@ extension CardFlowViewController: AccessCheckoutCardValidationDelegate {
         let brandNames = cardBrands.map { $0.name }.joined(separator: ", ")
         DispatchQueue.main.async {
             self.cardBrandsLabel?.text = brandNames
+            self.cardBrandsLabel?.accessibilityIdentifier = "cardBrandsLabel"
         }
     }
 

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
@@ -2,80 +2,92 @@ import XCTest
 
 class CardFlowCardBrandsLabelCobrandedRealServiceTests: XCTestCase {
     private let backspace = String(XCUIKeyboardKey.delete.rawValue)
-    
+
     var view: CardFlowViewPageObject?
-    
+
     override func setUp() {
         continueAfterFailure = false
-        
+
         let app = AppLauncher.launch()
         view = CardFlowViewPageObject(app)
     }
-    
+
     // MARK: Single and Multiple Digits Show Global Brand
-    
+
     func testDelegateNotification_singleDigitShowsGlobalBrand() {
         view!.typeTextIntoPan("4")
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
     }
-    
+
     func testDelegateNotification_multipleDigitsShowsGlobalBrand() {
         view!.typeTextIntoPan("41505809")
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
     }
-    
+
     // MARK: Twelve Digits Cobranded Card Two Notifications
-    
+
     func testDelegateNotification_12DigitsCobrandedCard_twoNotifications() {
         view!.typeTextIntoPan("41505809965")
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
-        
+
         view!.typeTextIntoPan("1")
         TestUtils.wait(seconds: 1.0)
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
     }
-    
+
     // MARK: Full Card Number Cobranded Two Notifications
-    
+
     func testDelegateNotification_fullCardNumberCobrandedCard_twoNotifications() {
         view!.typeTextIntoPan("41505809965")
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
-        
+
         view!.typeTextIntoPan("17927")
-        TestUtils.wait(seconds: 1.0)
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
     }
-    
+
+    // MARK: Pasted Card Number Returns Notifications
+
+    func testCardBrands_whenCardNumberPastedWith12Digits_showsCobrandedCards() {
+        view!.simulatePasteIntoPan("415058099651")
+
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+    }
+
+    func testCardBrands_whenCardNumberPastedWithMoreThan12Digits_showsCobrandedCards() {
+        view!.simulatePasteIntoPan("4150580996517927")
+
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+    }
+
     // MARK: Remove Digit from Twelve Two Notifications
-    
+
     func testDelegateNotification_remove1DigitFrom12_twoNotifications() {
         view!.typeTextIntoPan("415058099651")
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
         TestUtils.wait(seconds: 1.0)
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
-        
+
         view!.typeTextIntoPan(backspace)
-        
+
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
     }
-    
+
     // MARK: Clear Full Card Three Notifications
-    
+
     func testDelegateNotification_clearFullCard_threeNotifications() {
         view!.typeTextIntoPan("415058099651")
         view!.typeTextIntoPan("7927")
 
-        
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
         TestUtils.wait(seconds: 1.0)
 
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
-        
+
         view!.clearField(view!.panField)
         TestUtils.wait(seconds: 1.0)
 

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+class CardFlowCardBrandsLabelCobrandedRealServiceTests: XCTestCase {
+    private let backspace = String(XCUIKeyboardKey.delete.rawValue)
+    
+    var view: CardFlowViewPageObject?
+    
+    override func setUp() {
+        continueAfterFailure = false
+        
+        let app = AppLauncher.launch()
+        view = CardFlowViewPageObject(app)
+    }
+    
+    // MARK: Single and Multiple Digits Show Global Brand
+    
+    func testDelegateNotification_singleDigitShowsGlobalBrand() {
+        view!.typeTextIntoPan("4")
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+    }
+    
+    func testDelegateNotification_multipleDigitsShowsGlobalBrand() {
+        view!.typeTextIntoPan("41505809")
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+    }
+    
+    // MARK: Twelve Digits Cobranded Card Two Notifications
+    
+    func testDelegateNotification_12DigitsCobrandedCard_twoNotifications() {
+        view!.typeTextIntoPan("41505809965")
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+        
+        view!.typeTextIntoPan("1")
+        TestUtils.wait(seconds: 1.0)
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+    }
+    
+    // MARK: Full Card Number Cobranded Two Notifications
+    
+    func testDelegateNotification_fullCardNumberCobrandedCard_twoNotifications() {
+        view!.typeTextIntoPan("41505809965")
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+        
+        view!.typeTextIntoPan("17927")
+        TestUtils.wait(seconds: 1.0)
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+    }
+    
+    // MARK: Remove Digit from Twelve Two Notifications
+    
+    func testDelegateNotification_remove1DigitFrom12_twoNotifications() {
+        view!.typeTextIntoPan("415058099651")
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+        TestUtils.wait(seconds: 1.0)
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+        
+        view!.typeTextIntoPan(backspace)
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+    }
+    
+    // MARK: Clear Full Card Three Notifications
+    
+    func testDelegateNotification_clearFullCard_threeNotifications() {
+        view!.typeTextIntoPan("415058099651")
+        view!.typeTextIntoPan("7927")
+
+        
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
+        TestUtils.wait(seconds: 1.0)
+
+        TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
+        
+        view!.clearField(view!.panField)
+        TestUtils.wait(seconds: 1.0)
+
+        // asserting that the label does not exist (i.e. empty) as it is removed from UI if it is empty
+        XCTAssertFalse(view!.cardBrandsLabel.waitForExistence(timeout: 1))
+    }
+}

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/CardFlowCardBrandsLabelCobrandedRealServiceTests.swift
@@ -33,7 +33,6 @@ class CardFlowCardBrandsLabelCobrandedRealServiceTests: XCTestCase {
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
 
         view!.typeTextIntoPan("1")
-        TestUtils.wait(seconds: 1.0)
 
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
     }
@@ -68,7 +67,6 @@ class CardFlowCardBrandsLabelCobrandedRealServiceTests: XCTestCase {
     func testDelegateNotification_remove1DigitFrom12_twoNotifications() {
         view!.typeTextIntoPan("415058099651")
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
-        TestUtils.wait(seconds: 1.0)
 
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
 
@@ -84,12 +82,10 @@ class CardFlowCardBrandsLabelCobrandedRealServiceTests: XCTestCase {
         view!.typeTextIntoPan("7927")
 
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa")
-        TestUtils.wait(seconds: 1.0)
 
         TestUtils.assertLabelText(of: view!.cardBrandsLabel, equals: "visa, cartesBancaires")
 
         view!.clearField(view!.panField)
-        TestUtils.wait(seconds: 1.0)
 
         // asserting that the label does not exist (i.e. empty) as it is removed from UI if it is empty
         XCTAssertFalse(view!.cardBrandsLabel.waitForExistence(timeout: 1))

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
@@ -67,6 +67,10 @@ class CardFlowViewPageObject {
     var cvcIsValidLabel: XCUIElement {
         return app.staticTexts["cvcIsValidLabel"]
     }
+    
+    var cardBrandsLabel: XCUIElement {
+        return app.staticTexts["cardBrandsLabel"]
+    }
 
     init(_ app: XCUIApplication) {
         self.app = app

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/pageObjects/CardFlowViewPageObject.swift
@@ -67,7 +67,7 @@ class CardFlowViewPageObject {
     var cvcIsValidLabel: XCUIElement {
         return app.staticTexts["cvcIsValidLabel"]
     }
-    
+
     var cardBrandsLabel: XCUIElement {
         return app.staticTexts["cardBrandsLabel"]
     }
@@ -111,5 +111,9 @@ class CardFlowViewPageObject {
         _ = cutMenu.waitForExistence(timeout: waitForExistenceTimeoutInSeconds)
         cutMenu.tap()
         TestUtils.wait(seconds: 1)
+    }
+
+    func simulatePasteIntoPan(_ text: String) {
+        TestUtils.simulatePaste(text: text, into: panField)
     }
 }

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/utils/TestUtils.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/utils/TestUtils.swift
@@ -13,16 +13,31 @@ struct TestUtils {
     static func isFocused(_ element: XCUIElement) -> Bool {
         return (element.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
     }
-    
+
     static func assertLabelText(of element: XCUIElement, equals expectedText: String) {
         var currentAttempt = 1
         while element.label != expectedText && currentAttempt <= assertCardBrandMaxAttempts {
             currentAttempt += 1
-            TestUtils.wait(seconds: assertCardBrandSleeptBetweenAttemptsInMs)
+            TestUtils.wait(seconds: 0.1)
         }
-        
-        XCTAssertEqual(element.label, expectedText,
-                      "Expected label text '\(expectedText)' but found '\(element.label)'")
+
+        XCTAssertEqual(
+            element.label, expectedText,
+            "Expected label text '\(expectedText)' but found '\(element.label)'")
+    }
+
+    static func simulatePaste(text: String, into textField: XCUIElement) {
+        UIPasteboard.general.string = text
+
+        textField.tap()
+        textField.press(forDuration: 1.0)
+
+        let pasteMenuItem = XCUIApplication().menuItems["Paste"]
+        if pasteMenuItem.waitForExistence(timeout: 2.0) {
+            pasteMenuItem.tap()
+        }
+
+        wait(seconds: 0.2)
     }
 
     static func assertCardBrand(of cardBrandImage: XCUIElement, is brand: String) {
@@ -58,5 +73,4 @@ struct TestUtils {
 
         XCTAssertNotEqual(brandAsLocalizedString, cardBrandImage.label)
     }
-
 }

--- a/AccessCheckoutDemo/AccessCheckoutDemoUITests/utils/TestUtils.swift
+++ b/AccessCheckoutDemo/AccessCheckoutDemoUITests/utils/TestUtils.swift
@@ -13,6 +13,17 @@ struct TestUtils {
     static func isFocused(_ element: XCUIElement) -> Bool {
         return (element.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
     }
+    
+    static func assertLabelText(of element: XCUIElement, equals expectedText: String) {
+        var currentAttempt = 1
+        while element.label != expectedText && currentAttempt <= assertCardBrandMaxAttempts {
+            currentAttempt += 1
+            TestUtils.wait(seconds: assertCardBrandSleeptBetweenAttemptsInMs)
+        }
+        
+        XCTAssertEqual(element.label, expectedText,
+                      "Expected label text '\(expectedText)' but found '\(element.label)'")
+    }
 
     static func assertCardBrand(of cardBrandImage: XCUIElement, is brand: String) {
         let brandAsLocalizedString = NSLocalizedString(


### PR DESCRIPTION
What:
Adding UI tests to cover cobranded cards functionality using cardBrandLabel in demo app

Why:
To see that the cobranded responses are being displayed correctly in demo app

How:
Adds UI tests
Uses retry mechanism to assert label
