### PR TITLE
De659922

### DIFF
--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -152,15 +152,6 @@ public final class AccessCheckoutUITextField: UIView {
         NSLayoutConstraint.activate(self.uiTextFieldConstraints)
     }
 
-    override public var intrinsicContentSize: CGSize {
-        let width = self.uiTextField.intrinsicContentSize.height
-        let height =
-            self.uiTextField.intrinsicContentSize.height
-            + 2 * (self.borderWidth + AccessCheckoutUITextField.defaults.verticalPadding)
-
-        return CGSize(width: width, height: height)
-    }
-
     override public func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         self.setStyles()

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -24,6 +24,8 @@ public final class AccessCheckoutUITextField: UIView {
     private var uiTextFieldConstraints: [NSLayoutConstraint] = []
 
     private var _horizontalPadding: CGFloat = defaults.horizontalPadding
+    private var _verticalPadding: CGFloat = defaults.verticalPadding
+
     // Event Support
     internal var externalOnFocusChangedListener: ((AccessCheckoutUITextField, Bool) -> Void)?
 
@@ -100,7 +102,9 @@ public final class AccessCheckoutUITextField: UIView {
     internal init(_ uiTextField: UITextField) {
         super.init(frame: CGRect())
         self.uiTextField = uiTextField
+        self.addSubview(uiTextField)
         self.setStyles()
+        self.setLayout()
     }
 
     internal init() {
@@ -231,7 +235,7 @@ public final class AccessCheckoutUITextField: UIView {
     /* Padding properties */
 
     /**
-     A value that represents the padding between the border and the text
+     A value that represents the horizontal padding between the border and the text
      */
     @IBInspectable
     public var horizontalPadding: CGFloat {
@@ -241,6 +245,20 @@ public final class AccessCheckoutUITextField: UIView {
         }
         get {
             self._horizontalPadding
+        }
+    }
+
+    /**
+     A value that represents the vertical padding between the border and the text
+     */
+    @IBInspectable
+    public var verticalPadding: CGFloat {
+        set {
+            self._verticalPadding = newValue
+            self.setLayout()
+        }
+        get {
+            self._verticalPadding
         }
     }
 
@@ -259,7 +277,10 @@ public final class AccessCheckoutUITextField: UIView {
      */
     @IBInspectable
     public var borderWidth: CGFloat = defaults.borderWidth {
-        didSet { self.layer.borderWidth = self.borderWidth }
+        didSet {
+            self.layer.borderWidth = self.borderWidth
+            self.setLayout()
+        }
     }
 
     /**
@@ -293,7 +314,7 @@ public final class AccessCheckoutUITextField: UIView {
     }
 
     /**
-     The alignement of the text displayed in this component
+     The alignment of the text displayed in this component
      */
     @IBInspectable
     public var textAlignment: NSTextAlignment = defaults.textAlignment {

--- a/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDK/view/AccessCheckoutUITextField.swift
@@ -133,19 +133,19 @@ public final class AccessCheckoutUITextField: UIView {
         self.uiTextFieldConstraints = [
             self.uiTextField.topAnchor.constraint(
                 equalTo: topAnchor,
-                constant: AccessCheckoutUITextField.defaults.verticalPadding
+                constant: self.verticalPadding + self.borderWidth
             ),
             self.uiTextField.bottomAnchor.constraint(
                 equalTo: bottomAnchor,
-                constant: -AccessCheckoutUITextField.defaults.verticalPadding
+                constant: -self.verticalPadding - self.borderWidth
             ),
             self.uiTextField.leadingAnchor.constraint(
                 equalTo: leadingAnchor,
-                constant: self.horizontalPadding
+                constant: self.horizontalPadding + self.borderWidth
             ),
             self.uiTextField.trailingAnchor.constraint(
                 equalTo: trailingAnchor,
-                constant: -self.horizontalPadding
+                constant: -self.horizontalPadding - self.borderWidth
             ),
         ]
 

--- a/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
+++ b/AccessCheckoutSDK/AccessCheckoutSDKTests/view/AccessCheckoutUITextFieldTests.swift
@@ -50,10 +50,10 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         assertConstraints(
             textField,
-            top: AccessCheckoutUITextField.defaults.verticalPadding,
-            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+            top: AccessCheckoutUITextField.defaults.verticalPadding + AccessCheckoutUITextField.defaults.borderWidth,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding - AccessCheckoutUITextField.defaults.borderWidth,
+            leading: AccessCheckoutUITextField.defaults.horizontalPadding + AccessCheckoutUITextField.defaults.borderWidth,
+            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding - AccessCheckoutUITextField.defaults.borderWidth)
     }
 
     func testDefaultConstructorPositionsInternalTextFieldUsingConstraints() {
@@ -63,10 +63,10 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
 
         assertConstraints(
             textField,
-            top: AccessCheckoutUITextField.defaults.verticalPadding,
-            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+            top: AccessCheckoutUITextField.defaults.verticalPadding + AccessCheckoutUITextField.defaults.borderWidth,
+            bottom: -AccessCheckoutUITextField.defaults.verticalPadding - AccessCheckoutUITextField.defaults.borderWidth,
+            leading: AccessCheckoutUITextField.defaults.horizontalPadding + AccessCheckoutUITextField.defaults.borderWidth,
+            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding - AccessCheckoutUITextField.defaults.borderWidth)
     }
 
     // MARK: default styles values
@@ -204,25 +204,115 @@ class AccessCheckoutUITextFieldTests: XCTestCase {
     // MARK: Padding properties tests
 
     // horizontalPadding
-    func testHorizontalPaddingModifiesTheLayoutAccordingly() {
+    func testHorizontalPaddingModifiesLayoutAccordingly() {
+        let borderWidth = AccessCheckoutUITextField.defaults.borderWidth
+        var horizontalPadding = AccessCheckoutUITextField.defaults.horizontalPadding
+        let verticalPadding = AccessCheckoutUITextField.defaults.verticalPadding
+
         let textField = createTextField()
 
-        // Asserts padding is default padding to start with
+        // Asserts position corresponds to default padding + default border width
         assertConstraints(
             textField,
-            top: AccessCheckoutUITextField.defaults.verticalPadding,
-            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-            leading: AccessCheckoutUITextField.defaults.horizontalPadding,
-            trailing: -AccessCheckoutUITextField.defaults.horizontalPadding)
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
 
-        textField.horizontalPadding = 20
+        horizontalPadding = 20
+        textField.horizontalPadding = horizontalPadding
 
+        // Asserts position corresponds to custom padding + default border width
         assertConstraints(
             textField,
-            top: AccessCheckoutUITextField.defaults.verticalPadding,
-            bottom: -AccessCheckoutUITextField.defaults.verticalPadding,
-            leading: 20,
-            trailing: -20)
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+    }
+    
+    func testHorizontalPaddingModifiesLayoutAccordinglyWhenBorderWidthSet() {
+        let borderWidth = 4.0
+        var horizontalPadding = AccessCheckoutUITextField.defaults.horizontalPadding
+        let verticalPadding = AccessCheckoutUITextField.defaults.verticalPadding
+
+        let textField = createTextField()
+        textField.borderWidth = borderWidth
+        
+        // Asserts position corresponds to default padding + custom border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+
+        horizontalPadding = 20
+        textField.horizontalPadding = horizontalPadding
+
+        // Asserts position corresponds to custom padding + custom border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+    }
+
+    // verticalPadding
+    func testVerticalPaddingModifiesLayoutAccordingly() {
+        let borderWidth = AccessCheckoutUITextField.defaults.borderWidth
+        let horizontalPadding = AccessCheckoutUITextField.defaults.horizontalPadding
+        var verticalPadding = AccessCheckoutUITextField.defaults.verticalPadding
+
+        let textField = createTextField()
+
+        // Asserts position corresponds to default padding + default border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+
+        verticalPadding = 20
+        textField.verticalPadding = verticalPadding
+
+        // Asserts position corresponds to custom padding + default border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+    }
+    
+    func testVerticalPaddingModifiesLayoutAccordinglyWhenBorderWidthSet() {
+        let borderWidth = 4.0
+        let horizontalPadding = AccessCheckoutUITextField.defaults.horizontalPadding
+        var verticalPadding = AccessCheckoutUITextField.defaults.verticalPadding
+
+        let textField = createTextField()
+        textField.borderWidth = borderWidth
+
+        // Asserts position corresponds to default padding + custom border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
+
+        verticalPadding = 20
+        textField.verticalPadding = verticalPadding
+
+        // Asserts position corresponds to custom padding + custom border width
+        assertConstraints(
+            textField,
+            top: verticalPadding + borderWidth,
+            bottom: -verticalPadding - borderWidth,
+            leading: horizontalPadding + borderWidth,
+            trailing: -horizontalPadding - borderWidth)
     }
 
     // MARK: Border properties tests


### PR DESCRIPTION
### What
- add support for `verticalPadding` on `AccessCheckoutUITextField`
- remove override of `intrinsicContentSize` as it makes no difference when used
- fix issue in `AccessCheckoutUITextField` where positioning of internal UITextField is not taking border width into account (we now take the border width into account to calculate the UITextField constraints)